### PR TITLE
Add linkchecker config for CI

### DIFF
--- a/.linkchecker/linkcheckerrc
+++ b/.linkchecker/linkcheckerrc
@@ -1,0 +1,6 @@
+[filtering]
+ignorewarnings=url-content-too-large,url-too-long
+
+[checking]
+localonly=1
+maxrequestspersecond=30


### PR DESCRIPTION
## Summary
- Adds `.linkchecker/linkcheckerrc` config referenced by the deploy workflow's link-checking step (added in 694df42)
- Uses `localonly=1` to check internal links without hitting external URLs in CI

🤖 Prepared with Claude Code