### PR TITLE
chore: bump toolchain to v4.30.0-rc2

### DIFF
--- a/benchmark-snapshot/lakefile.toml
+++ b/benchmark-snapshot/lakefile.toml
@@ -4,7 +4,7 @@ defaultTargets = ["BenchmarkProblems"]
 [[require]]
 name = "mathlib"
 git = "https://github.com/leanprover-community/mathlib4.git"
-rev = "50d5513e83c"
+rev = "4049cbf2b803"
 
 [[require]]
 name = "subverso"

--- a/benchmark-snapshot/lakefile.toml
+++ b/benchmark-snapshot/lakefile.toml
@@ -4,7 +4,7 @@ defaultTargets = ["BenchmarkProblems"]
 [[require]]
 name = "mathlib"
 git = "https://github.com/leanprover-community/mathlib4.git"
-rev = "4049cbf2b803"
+rev = "81d43c5e10be"
 
 [[require]]
 name = "subverso"

--- a/benchmark-snapshot/lean-toolchain
+++ b/benchmark-snapshot/lean-toolchain
@@ -1,2 +1,1 @@
-leanprover/lean4:v4.30.0-rc1
-
+leanprover/lean4:v4.30.0-rc2

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,8 +1,8 @@
 import Lake
 open Lake DSL
 
-require std from git "https://github.com/leanprover/std4" @ "v4.30.0-rc1"
-require verso from git "https://github.com/leanprover/verso" @ "v4.30.0-rc1"
+require std from git "https://github.com/leanprover/std4" @ "v4.30.0-rc2"
+require verso from git "https://github.com/leanprover/verso" @ "v4.30.0-rc2"
 
 package «lean-eval-leaderboard» where
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,2 +1,1 @@
-leanprover/lean4:v4.30.0-rc1
-
+leanprover/lean4:v4.30.0-rc2

--- a/templates/benchmark-snapshot/lakefile.toml
+++ b/templates/benchmark-snapshot/lakefile.toml
@@ -4,7 +4,7 @@ defaultTargets = ["BenchmarkProblems"]
 [[require]]
 name = "mathlib"
 git = "https://github.com/leanprover-community/mathlib4.git"
-rev = "v4.30.0-rc1"
+rev = "v4.30.0-rc2"
 
 [[require]]
 name = "subverso"


### PR DESCRIPTION
This PR bumps the leaderboard onto v4.30.0-rc2 to match the comparator upgrade in [kim-em/lean-eval#22](https://github.com/kim-em/lean-eval/pull/22). Updates lean-toolchain (top-level + benchmark-snapshot), the std/verso pins in lakefile.lean to v4.30.0-rc2, the benchmark-snapshot mathlib rev to 4049cbf2b803, and the benchmark-snapshot template's mathlib rev to v4.30.0-rc2.

🤖 Prepared with Claude Code