### PR TITLE
chore: retarget repo references to leanprover org

### DIFF
--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -222,7 +222,7 @@ private def introParagraphTerms : TermElabM (Array (TSyntax `term)) := do
     ← `(paragraph #[textInline "The benchmark catalog consists of carefully curated problems across mathematics, chosen so that their statements are mostly accessible using existing Mathlib definitions, but their solutions are difficult for current publicly available frontier models."]),
     ← `(paragraph #[
       textInline "The problem statements below are automatically extracted from the ",
-      linkInline "lean-eval" "https://github.com/kim-em/lean-eval",
+      linkInline "lean-eval" "https://github.com/leanprover/lean-eval",
       textInline " repository."
     ]),
     ← `(paragraph #[

--- a/LeaderboardSite/Pages/Submit.lean
+++ b/LeaderboardSite/Pages/Submit.lean
@@ -5,7 +5,7 @@ open Verso.Genre.Blog
 #doc (Page) "Submit" =>
 
 Submissions are made by opening a GitHub issue on the
-[lean-eval benchmark repository](https://github.com/kim-em/lean-eval).
+[lean-eval benchmark repository](https://github.com/leanprover/lean-eval).
 
 # 1. Put your proof somewhere the lean-eval CI can fetch it
 
@@ -21,7 +21,7 @@ Accepted submission sources are URLs of one of these shapes:
 Private GitHub repositories are supported. To use one, install the
 `lean-eval-bot` GitHub App on the repository first, so that the CI can clone
 it. The install link is in the
-[lean-eval README](https://github.com/kim-em/lean-eval).
+[lean-eval README](https://github.com/leanprover/lean-eval).
 
 Secret (unlisted) gists are not supported in v1. Make your gist public, or
 host the proof in a repository.
@@ -33,8 +33,8 @@ The CI walks whatever you submit and tries every directory containing a
 has a `Submission.lean` next to it. For example:
 
 * a clone of a single generated workspace from
-  [kim-em/lean-eval/generated/](https://github.com/kim-em/lean-eval/tree/main/generated)
-* a fork of kim-em/lean-eval itself with your proofs under the relevant
+  [leanprover/lean-eval/generated/](https://github.com/leanprover/lean-eval/tree/main/generated)
+* a fork of leanprover/lean-eval itself with your proofs under the relevant
   `generated/<problem_id>/` directories
 * a custom repository containing several benchmark workspaces side by side
 * a gist containing a two-file minimum: a `lakefile.toml` with
@@ -50,7 +50,7 @@ check the proof.
 # 3. Open a submission issue
 
 Click
-[Submit benchmark solution](https://github.com/kim-em/lean-eval/issues/new?template=submit.yml)
+[Submit benchmark solution](https://github.com/leanprover/lean-eval/issues/new?template=submit.yml)
 to open a pre-filled issue. The form asks for two things:
 
 * a submission URL in one of the shapes above

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lean-eval-leaderboard
 
 Results store and public website data source for the
-[lean-eval](https://github.com/kim-em/lean-eval) benchmark.
+[lean-eval](https://github.com/leanprover/lean-eval) benchmark.
 
 This repository holds machine-written artifacts produced by the lean-eval CI
 and by the leaderboard-site build pipeline.
@@ -82,12 +82,12 @@ documented in [docs/site-data-schema.md](docs/site-data-schema.md).
 | Field              | Type    | Description                                                                            |
 | ------------------ | ------- | -------------------------------------------------------------------------------------- |
 | `solved_at`        | string  | ISO 8601 UTC timestamp of when the record was first written.                           |
-| `benchmark_commit` | string  | 40-character SHA of the `kim-em/lean-eval` commit evaluated against.                   |
+| `benchmark_commit` | string  | 40-character SHA of the `leanprover/lean-eval` commit evaluated against.               |
 | `submission_repo`  | string  | Identifier of the submission source: `owner/repo` for a GitHub repository, or `user/gist-id` for a gist. |
 | `submission_ref`   | string  | 40-character SHA pinning the submission at evaluation time. For repositories this is a commit SHA; for gists this is the gist revision SHA. |
 | `submission_public`| boolean | `true` if the submission source was public at evaluation time, `false` otherwise. The leaderboard site uses this to decide whether to link to the solution. |
 | `model`            | string  | Free-form model identifier supplied by the submitter on the submission form.           |
-| `issue_number`     | integer | Issue number in `kim-em/lean-eval` that triggered the evaluation.                      |
+| `issue_number`     | integer | Issue number in `leanprover/lean-eval` that triggered the evaluation.                  |
 
 ## Write semantics
 

--- a/SiteTheme.lean
+++ b/SiteTheme.lean
@@ -57,8 +57,8 @@ def theme (name : String) (siteName : String) : Theme := {
             <footer class="footer">
               <div class="wrap footer-inner">
                 <span>"Public results for lean-eval."</span>
-                <a href="https://github.com/kim-em/lean-eval">"Benchmark repo"</a>
-                <a href="https://github.com/kim-em/lean-eval-leaderboard">"Results repo"</a>
+                <a href="https://github.com/leanprover/lean-eval">"Benchmark repo"</a>
+                <a href="https://github.com/leanprover/lean-eval-leaderboard">"Results repo"</a>
               </div>
             </footer>
           </div>

--- a/docs/site-data-schema.md
+++ b/docs/site-data-schema.md
@@ -33,7 +33,7 @@ This file is the benchmark catalog as consumed by the website.
   "schema_version": 2,
   "generated_at": "2026-04-11T12:00:00Z",
   "benchmark": {
-    "repo": "kim-em/lean-eval",
+    "repo": "leanprover/lean-eval",
     "commit": "8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f"
   },
   "problems": [
@@ -88,11 +88,11 @@ aggregated, ranked, and enriched with provenance and notability metadata.
   "schema_version": 1,
   "generated_at": "2026-04-11T12:00:00Z",
   "results_repo": {
-    "repo": "kim-em/lean-eval-leaderboard",
+    "repo": "leanprover/lean-eval-leaderboard",
     "commit": "0123456789abcdef0123456789abcdef01234567"
   },
   "benchmark": {
-    "repo": "kim-em/lean-eval",
+    "repo": "leanprover/lean-eval",
     "commit": "8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f"
   },
   "summary": {

--- a/docs/website-plan.md
+++ b/docs/website-plan.md
@@ -5,22 +5,22 @@ the public leaderboard site.
 
 ## Repo split
 
-- `kim-em/lean-eval`
+- `leanprover/lean-eval`
   - benchmark source of truth
   - theorem extraction
   - generated challenge workspaces
   - evaluation pipeline
-- `kim-em/lean-eval-leaderboard`
+- `leanprover/lean-eval-leaderboard`
   - public results store
   - derived website data under `site-data/`
   - Verso website
 
-The site should live in `kim-em/lean-eval-leaderboard`.
+The site should live in `leanprover/lean-eval-leaderboard`.
 
 ## Data flow
 
 1. Read raw `results/*.json` from this repo.
-2. Import benchmark metadata from `kim-em/lean-eval` at a pinned commit.
+2. Import benchmark metadata from `leanprover/lean-eval` at a pinned commit.
 3. Extract theorem statements and problem metadata into `site-data/problems.json`.
 4. Aggregate raw success records into `site-data/leaderboard.json`.
 5. Render the Verso site from `site-data/*.json`.

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -330,7 +330,7 @@ def build_problem_payload(benchmark_repo: pathlib.Path, problems: list[Problem])
         "schema_version": 2,
         "generated_at": utc_now(),
         "benchmark": {
-            "repo": "kim-em/lean-eval",
+            "repo": "leanprover/lean-eval",
             "commit": git_head(benchmark_repo),
         },
         "problems": [
@@ -482,11 +482,11 @@ def build_leaderboard_payload(
         "schema_version": 1,
         "generated_at": utc_now(),
         "results_repo": {
-            "repo": "kim-em/lean-eval-leaderboard",
+            "repo": "leanprover/lean-eval-leaderboard",
             "commit": git_head(results_repo),
         },
         "benchmark": {
-            "repo": "kim-em/lean-eval",
+            "repo": "leanprover/lean-eval",
             "commit": git_head(benchmark_repo),
         },
         "summary": {

--- a/site-data/leaderboard.json
+++ b/site-data/leaderboard.json
@@ -2,11 +2,11 @@
   "schema_version": 1,
   "generated_at": "2026-04-18T08:07:14Z",
   "results_repo": {
-    "repo": "kim-em/lean-eval-leaderboard",
+    "repo": "leanprover/lean-eval-leaderboard",
     "commit": "74c82d7d2eac199c6a7636822d18c7fbf85a663e"
   },
   "benchmark": {
-    "repo": "kim-em/lean-eval",
+    "repo": "leanprover/lean-eval",
     "commit": "97fbfe2dd049375534df6c4e018fb86bbcec183c"
   },
   "summary": {

--- a/site-data/problems.json
+++ b/site-data/problems.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "generated_at": "2026-04-18T08:07:14Z",
   "benchmark": {
-    "repo": "kim-em/lean-eval",
+    "repo": "leanprover/lean-eval",
     "commit": "97fbfe2dd049375534df6c4e018fb86bbcec183c"
   },
   "problems": [


### PR DESCRIPTION
This PR updates all hardcoded references to `kim-em/lean-eval` and `kim-em/lean-eval-leaderboard` so they point at the new `leanprover/...` locations in advance of the GitHub repo transfer to the `leanprover` organization.

Touches the site footer, Submit/Problems pages, README, design docs, the schema doc, the python generator's hardcoded `repo` strings, and the already-generated `site-data/*.json`. GitHub's automatic redirects keep the old URLs working, but we want the rendered site to point at the canonical locations once the transfer lands.

Companion PR on the benchmark repo: https://github.com/kim-em/lean-eval/pulls (TBD).

🤖 Prepared with Claude Code