### PR TITLE
doc: link leaderboard prominently from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # lean-eval-leaderboard
 
+**[View the leaderboard →](https://leanprover.github.io/lean-eval-leaderboard/)**
+
 Results store and public website data source for the
 [lean-eval](https://github.com/leanprover/lean-eval) benchmark.
 


### PR DESCRIPTION
This PR adds a prominent link to the public leaderboard at https://leanprover.github.io/lean-eval-leaderboard/ at the top of the README, so visitors landing on the repo can jump straight to the live site instead of reading past the project description.

🤖 Prepared with Claude Code