### PR TITLE
feat: surface optional production description per solved problem

### DIFF
--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -373,6 +373,12 @@ def build_leaderboard_payload(
             model_display.setdefault(model_id, model_name)
             per_model_submitters[model_id][user] += 1
             current = per_model_problem[model_id].get(problem_id)
+            production_description_raw = record.get("production_description")
+            production_description = (
+                str(production_description_raw).strip()
+                if isinstance(production_description_raw, str) and str(production_description_raw).strip()
+                else None
+            )
             candidate = {
                 "problem_id": problem_id,
                 "solved_at": str(record["solved_at"]),
@@ -394,6 +400,7 @@ def build_leaderboard_payload(
                         bool(record["submission_public"]),
                     ),
                 },
+                "production_description": production_description,
             }
             if current is None or timestamp_key(candidate["solved_at"]) < timestamp_key(current["solved_at"]):
                 per_model_problem[model_id][problem_id] = candidate
@@ -461,6 +468,7 @@ def build_leaderboard_payload(
                         "rarity_score": item["rarity_score"],
                         "public_solution": item["public_solution"],
                         "provenance": item["provenance"],
+                        "production_description": item.get("production_description"),
                     }
                     for item in notable
                 ],

--- a/static/app.js
+++ b/static/app.js
@@ -95,6 +95,17 @@ function renderProblemItem(problemMap, renderedMap, solved) {
   const title = problem?.title ?? solved.problem_id;
   const source = solved.public_solution?.available ? solved.public_solution.url : null;
   const problemHref = problemPageHref(solved.problem_id);
+  const description = typeof solved.production_description === "string"
+    ? solved.production_description.trim()
+    : "";
+  const productionMarkup = description
+    ? `
+      <details class="production-note">
+        <summary>How produced</summary>
+        <p>${escapeHtml(description)}</p>
+      </details>
+    `
+    : "";
   return `
     <div class="problem-item">
       <a class="problem-title-link" href="${escapeHtml(problemHref)}">${escapeHtml(title)}</a>
@@ -106,6 +117,7 @@ function renderProblemItem(problemMap, renderedMap, solved) {
         <span class="problem-meta">#${solved.rarity_rank}</span>
         ${source ? `<a class="problem-proof-link" href="${escapeHtml(source)}">proof</a>` : ""}
       </div>
+      ${productionMarkup}
     </div>
   `;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -539,6 +539,32 @@ nav.top .home {
   flex-wrap: wrap;
 }
 
+.production-note {
+  border-top: 1px solid rgba(126, 227, 217, 0.08);
+  padding-top: 8px;
+  font-size: 0.82rem;
+  color: #aab8bd;
+}
+
+.production-note > summary {
+  cursor: pointer;
+  color: #86ece0;
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.production-note > summary:hover {
+  color: #f2f6f8;
+}
+
+.production-note > p {
+  margin: 6px 0 0;
+  white-space: pre-wrap;
+  line-height: 1.45;
+}
+
 .problem-meta {
   color: #8fa0a6;
   font-family: "IBM Plex Mono", "SFMono-Regular", monospace;


### PR DESCRIPTION
This PR pipes the new optional \`production_description\` field from each per-user results JSON through \`build_leaderboard_payload\` and into each \`solved_problems\` entry of the generated \`site-data/leaderboard.json\`. The renderer adds a collapsible "How produced" \`<details>\` block on each leaderboard row's solved-problem item when the description is present; rows without one render exactly as before.

Pairs with leanprover/lean-eval#27, which is the change that causes new submissions to start carrying the field. Until that lands and the first new submission is recorded, every existing record will be missing \`production_description\` and the new UI will simply be invisible.

🤖 Prepared with Claude Code