### PR TITLE
feat: link benchmark breakdown counts to problems page sections

### DIFF
--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -212,10 +212,10 @@ private def problemPartTerm (catalog : String) (problem : ProblemEntry) : TermEl
       $anchorBlock
     ] #[] (some $(quote problem.id)))
 
-private def sectionPartTerm (catalog : String) (title : String) (problems : Array ProblemEntry) : TermElabM (TSyntax `term) := do
+private def sectionPartTerm (catalog : String) (title : String) (htmlId : String) (problems : Array ProblemEntry) : TermElabM (TSyntax `term) := do
   let subParts ← problems.mapM (problemPartTerm catalog)
   let subParts : TSyntaxArray `term := subParts
-  `(pagePart $(quote title) #[] #[$subParts,*])
+  `(pagePart $(quote title) #[] #[$subParts,*] (some $(quote htmlId)))
 
 private def introParagraphTerms : TermElabM (Array (TSyntax `term)) := do
   pure #[
@@ -242,10 +242,10 @@ elab_rules : term
       let introBlocks ← introParagraphTerms
       let mainProblems := Array.filter (fun problem => !problem.test) problems
       let starterProblems := Array.filter (·.test) problems
-      let mainSection ← sectionPartTerm catalog "Main benchmark problems" mainProblems
+      let mainSection ← sectionPartTerm catalog "Main benchmark problems" "main-problems" mainProblems
       let mut subParts := #[mainSection]
       if !starterProblems.isEmpty then
-        subParts := subParts.push (← sectionPartTerm catalog "Starter problems" starterProblems)
+        subParts := subParts.push (← sectionPartTerm catalog "Starter problems" "starter-problems" starterProblems)
       let introBlocks' : TSyntaxArray `term := introBlocks
       let subParts' : TSyntaxArray `term := subParts
       let pageTerm ← `(pagePart "Problems" #[$introBlocks',*] #[$subParts',*])

--- a/static/app.js
+++ b/static/app.js
@@ -223,8 +223,8 @@ function renderHome(root, problems, leaderboard, renderedMap) {
         <aside class="hero-side">
           <div class="section-label">Benchmark breakdown</div>
           <div class="hero-side-metrics">
-            <div class="stat-pair"><span>Main problems</span><span>${summary.main_problems ?? 0}</span></div>
-            <div class="stat-pair"><span>Test problems</span><span>${summary.test_problems ?? 0}</span></div>
+            <a class="stat-pair stat-pair-link" href="${escapeHtml(problemsIndexHref())}#main-problems"><span>Main problems</span><span>${summary.main_problems ?? 0}</span></a>
+            <a class="stat-pair stat-pair-link" href="${escapeHtml(problemsIndexHref())}#starter-problems"><span>Test problems</span><span>${summary.test_problems ?? 0}</span></a>
           </div>
           <p class="hero-side-copy">
             Problem statements and leaderboard results are generated from public

--- a/static/style.css
+++ b/static/style.css
@@ -693,6 +693,23 @@ nav.top .home {
   border-bottom: 1px solid rgba(126, 227, 217, 0.06);
 }
 
+.stat-pair-link {
+  text-decoration: none;
+  color: inherit;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+
+.stat-pair-link:hover,
+.stat-pair-link:focus-visible {
+  color: #e7ecef;
+  border-bottom-color: rgba(126, 227, 217, 0.3);
+}
+
+.stat-pair-link:focus-visible {
+  outline: 2px solid rgba(126, 227, 217, 0.45);
+  outline-offset: 2px;
+}
+
 .submitter-list {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
This PR makes the *Main problems* and *Test problems* entries in the benchmark breakdown box on the front page clickable. They now link to anchored sections of the problems page (`#main-problems` and `#starter-problems`), giving readers a one-click path from the count to the actual catalog.

To support that, [LeaderboardSite/Pages/Problems.lean](LeaderboardSite/Pages/Problems.lean) now sets explicit `htmlId`s on the two section headings (`Main benchmark problems` and `Starter problems`). The hero stat pairs in [static/app.js](static/app.js) became `<a>` tags, and [static/style.css](static/style.css) gained a small `.stat-pair-link` rule for the hover/focus state.

🤖 Prepared with Claude Code