### PR TITLE
chore: wrap pages in VersoDoc to drop Part.toPart deprecation

### DIFF
--- a/LeaderboardSite/Pages/Front.lean
+++ b/LeaderboardSite/Pages/Front.lean
@@ -62,9 +62,12 @@ private def introProse : Block Page :=
 
 /-- The home page: leaderboard widget (full-width) on top, intro prose
 (constrained-width) below. The page does its own wrapping; the theme
-does not impose a prose container on this page. -/
-def _root_.LeaderboardSite.Pages.Front : Part Page :=
-  pagePart "Lean AI formalization leaderboard"
-    (leaderboard% ++ #[introProse])
+does not impose a prose container on this page.
+
+Wrapped as a `VersoDoc` so the `site` DSL's lookup of `Front.toPart`
+resolves to `VersoDoc.toPart` rather than the deprecated `Part.toPart`. -/
+def _root_.LeaderboardSite.Pages.Front : VersoDoc Page :=
+  .mk (fun _ => pagePart "Lean AI formalization leaderboard"
+    (leaderboard% ++ #[introProse])) "{}"
 
 end LeaderboardSite.Pages

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -122,7 +122,10 @@ elab_rules : term
       let expectedType ← Lean.Elab.Term.elabTerm (← `(Part Page)) none
       Lean.Elab.Term.elabTerm pageTerm (some expectedType)
 
-def _root_.LeaderboardSite.Pages.Problems : Part Page :=
-  problems_page%
+/-- Wrapped as a `VersoDoc` so the `site` DSL's lookup of
+`Problems.toPart` resolves to `VersoDoc.toPart` rather than the
+deprecated `Part.toPart`. -/
+def _root_.LeaderboardSite.Pages.Problems : VersoDoc Page :=
+  .mk (fun _ => problems_page%) "{}"
 
 end LeaderboardSite.Pages


### PR DESCRIPTION
This PR wraps `LeaderboardSite.Pages.Front` and `LeaderboardSite.Pages.Problems` as `VersoDoc Page` values rather than `Part Page`, so that the `site` DSL's `%doc?` macro looks up `<page>.toPart` against `VersoDoc.toPart` instead of the deprecated `Lean.Doc.Part.toPart` shim. Removes the build warning and brings these two pages in line with `Submit`, which is already a `VersoDoc` (since it uses `#doc` syntax).

🤖 Prepared with Claude Code