### PR TITLE
feat: render production description in Verso leaderboard rows

### DIFF
--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -124,6 +124,7 @@ structure SolvedProblem where
   solvedAt : String
   rarityRank : Nat
   publicSolution : PublicSolution
+  productionDescription : Option String
 deriving Quote, Inhabited, Repr
 
 instance : FromJson SolvedProblem where
@@ -133,6 +134,7 @@ instance : FromJson SolvedProblem where
       solvedAt := ← json.getObjValAs? String "solved_at"
       rarityRank := ← json.getObjValAs? Nat "rarity_rank"
       publicSolution := ← json.getObjValAs? PublicSolution "public_solution"
+      productionDescription := (json.getObjValAs? String "production_description").toOption
     }
 
 structure LeaderboardEntry where

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -179,7 +179,8 @@ private def problemItem
     (anchorMap : Std.HashMap String (Block Page))
     (problemId : String) (title : String) (statement : String)
     (proofUrl? : Option String)
-    (rarityRank? : Option Nat) : Block Page :=
+    (rarityRank? : Option Nat)
+    (productionDescription? : Option String) : Block Page :=
   let problemHref := s!"problems/#{problemId}"
   let titleLink := htmlBlobBlock {{
     <a class="problem-title-link" href={{problemHref}}>{{textHtml title}}</a>
@@ -194,6 +195,19 @@ private def problemItem
         <span class="problem-meta">{{textHtml s!"#{r}"}}</span>
       }}
     | none => htmlBlobBlock {{ <span></span> }}
+  let productionNote := match productionDescription? with
+    | some description =>
+      let trimmed := description.trim
+      if trimmed.isEmpty then
+        htmlBlobBlock {{ <span></span> }}
+      else
+        htmlBlobBlock {{
+          <details class="production-note">
+            <summary>"How produced"</summary>
+            <p>{{textHtml trimmed}}</p>
+          </details>
+        }}
+    | none => htmlBlobBlock {{ <span></span> }}
   divBlock "problem-item" #[
     titleLink,
     divBlock "problem-meta-row" #[
@@ -205,7 +219,8 @@ private def problemItem
       ],
       rarityChip,
       proofLink
-    ]
+    ],
+    productionNote
   ]
 
 /-! ## Per-row (model) `<details>` block -/
@@ -248,6 +263,7 @@ private def entryBody
         let (title, statement) := problemTitleAndStatement problems item.problemId
         let proofUrl? := if item.publicSolution.available then item.publicSolution.url else none
         problemItem anchorMap item.problemId title statement proofUrl? (some item.rarityRank)
+          item.productionDescription
   let submitters : Html :=
     if entry.submitters.isEmpty then
       {{ <span class="empty-inline">"None"</span> }}
@@ -304,7 +320,7 @@ private def emptyShowcase
     (anchorMap : Std.HashMap String (Block Page))
     (preview : Array (String × String × String)) : Block Page :=
   let previewItems : Array (Block Page) := preview.map fun (id, title, statement) =>
-    problemItem anchorMap id title statement none none
+    problemItem anchorMap id title statement none none none
   divBlock "empty-showcase" #[
     divBlock "empty-copy" #[
       sectionLabel "No public solves yet",


### PR DESCRIPTION
This PR re-adds rendering of the optional \`production_description\` field that was lost when the leaderboard renderer was refactored from \`static/app.js\` to Verso/Lean.

\`SolvedProblem\` now carries a \`productionDescription : Option String\`, parsed from the JSON \`production_description\` key (absent in older records, present in records produced after leanprover/lean-eval#27). \`problemItem\` takes the new field and renders it as a collapsible \`<details class="production-note"><summary>How produced</summary>...\` block under the meta row when present (and non-empty after \`String.trim\`). Rows without a description render exactly as before. The matching \`.production-note\` CSS rules already exist in \`static/style.css\`.

The dogfood \`two_plus_two\` row (\`results/kim-em.json\`) is the first record with a populated description, so it'll be the first row the new UI shows once this lands and the site rebuilds.

🤖 Prepared with Claude Code