### PR TITLE
feat: add site favicon

### DIFF
--- a/SiteTheme.lean
+++ b/SiteTheme.lean
@@ -33,6 +33,7 @@ def theme (name : String) (siteName : String) : Theme := {
           <meta name="viewport" content="width=device-width, initial-scale=1"/>
           <title>{{ title }} s!" | {siteName}"</title>
           {{← builtinHeader }}
+          <link rel="icon" type="image/svg+xml" href="static/favicon.svg"/>
           <link rel="stylesheet" href="static/style.css"/>
           <script defer="true" src="static/background.js"></script>
         </head>

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#0b0f14"/>
+  <g stroke="#7fe3d9" stroke-width="6" stroke-linecap="round" fill="none">
+    <line x1="20" y1="14" x2="20" y2="50"/>
+    <line x1="20" y1="32" x2="48" y2="32"/>
+  </g>
+</svg>


### PR DESCRIPTION
This PR adds a site favicon: a teal turnstile (`⊢`) on a dark navy background, mirroring the wordmark in the topbar. The SVG lives at `static/favicon.svg` and is linked from the theme so every generated page picks it up.

🤖 Prepared with Claude Code