### PR TITLE
feat: render every @[eval_problem] declaration per leaderboard row

### DIFF
--- a/LeaderboardSite/AnchorRegistry.lean
+++ b/LeaderboardSite/AnchorRegistry.lean
@@ -1,0 +1,46 @@
+import VersoBlog
+import LeaderboardSite.Data
+
+open Lean
+open Lean.Elab Term Command
+open Verso Doc Doc.Elab
+open Verso.Genre.Blog
+open Verso.Code.External
+open LeaderboardSite.Data
+
+set_option verso.exampleProject "benchmark-snapshot"
+set_option maxHeartbeats 1000000
+
+/-- Register one top-level constant per `@[eval_problem]`-tagged hole, each
+of type `Block Page` and holding the Verso anchor block for that hole.
+Pages downstream (catalog and home-page popovers) reference these
+constants by name, which keeps each downstream `def`'s body small enough
+for the Lean code generator — inlining 24+ Verso anchors into a single
+`def`'s expression tree overflows the codegen recursion budget.
+
+Lives in its own module (separate from `Data.lean`) so the `syntax`
+declaration is fully registered before the same module needs to parse
+the `register_problem_anchors` invocation; defining and using a custom
+command keyword in the same compilation unit doesn't reliably take
+effect on the very next command position. -/
+syntax "register_problem_anchors" : command
+
+elab_rules : command
+  | `(register_problem_anchors) => do
+      let (catalog, problems) ← Lean.Elab.Command.runTermElabM fun _ => do
+        let payload ← parseProblemsPayload
+        let catalog ← loadSnapshotCatalog
+        let problems ← validateProblems payload
+        pure (catalog, problems)
+      for problem in problems do
+        for hole in problem.holes do
+          let constName := anchorConstName problem.id hole
+          if (← Lean.getEnv).contains constName then
+            continue
+          let anchorTerm ← Lean.Elab.Command.runTermElabM fun _ =>
+            inlineAnchorTerm catalog problem hole
+          let constIdent := Lean.mkIdent constName
+          let cmd ← `(def $constIdent : Block Page := $anchorTerm)
+          Lean.Elab.Command.elabCommand cmd
+
+register_problem_anchors

--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -14,14 +14,38 @@ structure BenchmarkInfo where
   commit : String
 deriving FromJson
 
+/-- One `@[eval_problem]`-annotated declaration. Multiple holes may belong
+to the same `manifests/problems.toml` entry; they are rendered together as
+a stack on the problems page and in home-page popovers. -/
+structure Hole where
+  /-- Fully-qualified declaration name (e.g. `LeanEval.Foo.bar`). -/
+  name : String
+  /-- Short basename (e.g. `bar`); unique within one problem. -/
+  basename : String
+  /-- Kernel-level kind: `theorem` / `def` / `instance` / `opaque`. The
+  `body` text below already starts with the right Lean keyword, so the
+  renderer keys off the body's leading token rather than this field. -/
+  kind : String
+  /-- Trimmed source body, with `@[eval_problem]` already stripped. -/
+  body : String
+deriving Inhabited, Quote, Repr
+
+instance : FromJson Hole where
+  fromJson? json := do
+    return {
+      name := ← json.getObjValAs? String "name"
+      basename := ← json.getObjValAs? String "basename"
+      kind := ← json.getObjValAs? String "kind"
+      body := ← json.getObjValAs? String "body"
+    }
+
 structure ProblemEntry where
   id : String
   title : String
   test : Bool
   submitter : String
   moduleName : String
-  theoremName : String
-  statementText : String
+  holes : Array Hole
   notesText : Option String
   sourceText : Option String
   informalSolution : Option String
@@ -36,8 +60,7 @@ instance : FromJson ProblemEntry where
       test := ← json.getObjValAs? Bool "test"
       submitter := ← json.getObjValAs? String "submitter"
       moduleName := ← json.getObjValAs? String "module"
-      theoremName := ← json.getObjValAs? String "theorem"
-      statementText := ← json.getObjValAs? String "statement"
+      holes := ← json.getObjValAs? (Array Hole) "holes"
       notesText := (json.getObjValAs? String "notes").toOption
       sourceText := (json.getObjValAs? String "source").toOption
       informalSolution := (json.getObjValAs? String "informal_solution").toOption
@@ -213,44 +236,43 @@ def loadSnapshotCatalog : TermElabM String :=
   IO.FS.readFile snapshotCatalogPath
 
 def validateProblems (payload : ProblemsPayload) : TermElabM (Array ProblemEntry) := do
-  if payload.schemaVersion != 2 then
-    throwError "Unsupported problems schema version {payload.schemaVersion}; expected 2"
+  if payload.schemaVersion != 3 then
+    throwError "Unsupported problems schema version {payload.schemaVersion}; expected 3"
   let mut seen : Std.HashSet String := {}
   for problem in payload.problems do
     if problem.id.trimAscii.isEmpty then
       throwError "Encountered a problem with an empty id"
     if problem.title.trimAscii.isEmpty then
       throwError "Problem '{problem.id}' is missing a title"
-    if problem.statementText.trimAscii.isEmpty then
-      throwError "Problem '{problem.id}' is missing a statement"
+    if problem.holes.isEmpty then
+      throwError "Problem '{problem.id}' has no holes"
     if seen.contains problem.id then
       throwError "Duplicate problem id '{problem.id}' in {problemsJsonPath}"
     seen := seen.insert problem.id
   pure <| payload.problems.qsort (fun a b => a.sortIndex < b.sortIndex)
 
-private def shortTheoremName (problem : ProblemEntry) : String :=
-  match problem.theoremName.splitOn "." |>.reverse with
-  | name :: _ => name
-  | [] => problem.theoremName
+def holeAnchorId (problemId : String) (hole : Hole) : String :=
+  s!"{problemId}__{hole.basename}"
 
-def anchorSourceText (catalog : String) (problem : ProblemEntry) : TermElabM String := do
-  let startMarker := s!"-- ANCHOR: {problem.id}"
-  let endMarker := s!"-- ANCHOR_END: {problem.id}"
+/-- Look up one hole's anchor body in the snapshot catalog. The anchor name
+is `<problem-id>__<basename>`. Returns the trimmed body so callers can use
+it for plain-text fallbacks. -/
+def anchorSourceText (catalog : String) (problemId : String) (hole : Hole) : TermElabM String := do
+  let anchorId := holeAnchorId problemId hole
+  let startMarker := s!"-- ANCHOR: {anchorId}"
+  let endMarker := s!"-- ANCHOR_END: {anchorId}"
   let parts := catalog.splitOn startMarker
   let some rest := parts[1]?
-    | throwError "Anchor '{problem.id}' not found in {snapshotCatalogPath}"
+    | throwError "Anchor '{anchorId}' not found in {snapshotCatalogPath}"
   if parts.length != 2 then
-    throwError "Anchor '{problem.id}' appears multiple times in {snapshotCatalogPath}"
+    throwError "Anchor '{anchorId}' appears multiple times in {snapshotCatalogPath}"
   let rest := rest.dropWhile (· == '\n') |>.toString
   let bodyParts := rest.splitOn endMarker
   let some body := bodyParts[0]?
-    | throwError "Anchor '{problem.id}' is missing its body in {snapshotCatalogPath}"
+    | throwError "Anchor '{anchorId}' is missing its body in {snapshotCatalogPath}"
   if bodyParts.length < 2 then
-    throwError "Anchor '{problem.id}' is missing its closing marker in {snapshotCatalogPath}"
-  let body := body.trimAscii.toString
-  if !body.contains s!"theorem {shortTheoremName problem}" then
-    throwError "Anchor '{problem.id}' does not contain theorem {shortTheoremName problem}"
-  pure body
+    throwError "Anchor '{anchorId}' is missing its closing marker in {snapshotCatalogPath}"
+  pure body.trimAscii.toString
 
 def runPageDocElab (act : DocElabM α) : TermElabM α := do
   let ctx ← DocElabContext.fromGenreTerm (← `(Page))
@@ -259,17 +281,23 @@ def runPageDocElab (act : DocElabM α) : TermElabM α := do
   let (result, _) ← DocElabM.run ctx initDocState initPartState act
   pure result
 
-def anchorBlockTerm (catalog : String) (problem : ProblemEntry) : TermElabM (TSyntax `term) := do
-  let anchorName := Lean.mkIdent <| Lean.Name.mkSimple problem.id
+/-- One Verso anchor block per hole, in source order. Each anchor is
+spliced from `BenchmarkProblems.Catalog` and includes full syntax
+highlighting via Verso's `Code.External.anchor` machinery. -/
+def anchorBlockTerms (catalog : String) (problem : ProblemEntry) :
+    TermElabM (Array (TSyntax `term)) := do
   let moduleName := Lean.mkIdent `BenchmarkProblems.Catalog
-  let args : Array Verso.Doc.Arg := #[
-    .anon (.name anchorName),
-    .named .missing (Lean.mkIdent `module) (.name moduleName)
-  ]
-  let expected := Syntax.mkStrLit (← anchorSourceText catalog problem)
-  let terms ← runPageDocElab <| Verso.Code.External.anchor args expected
-  match terms[0]? with
-  | some term => pure term
-  | none => throwError "Anchor expander for '{problem.id}' returned no block"
+  problem.holes.mapM fun hole => do
+    let anchorId := holeAnchorId problem.id hole
+    let anchorName := Lean.mkIdent <| Lean.Name.mkSimple anchorId
+    let args : Array Verso.Doc.Arg := #[
+      .anon (.name anchorName),
+      .named .missing (Lean.mkIdent `module) (.name moduleName)
+    ]
+    let expected := Syntax.mkStrLit (← anchorSourceText catalog problem.id hole)
+    let terms ← runPageDocElab <| Verso.Code.External.anchor args expected
+    match terms[0]? with
+    | some term => pure term
+    | none => throwError "Anchor expander for '{anchorId}' returned no block"
 
 end LeaderboardSite.Data

--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -283,23 +283,77 @@ def runPageDocElab (act : DocElabM α) : TermElabM α := do
   let (result, _) ← DocElabM.run ctx initDocState initPartState act
   pure result
 
-/-- One Verso anchor block per hole, in source order. Each anchor is
-spliced from `BenchmarkProblems.Catalog` and includes full syntax
-highlighting via Verso's `Code.External.anchor` machinery. -/
-def anchorBlockTerms (catalog : String) (problem : ProblemEntry) :
-    TermElabM (Array (TSyntax `term)) := do
+/-- Build a `TSyntax \`term` for one hole's Verso anchor. When elaborated,
+this expands into a deeply-nested `Block Page` value carrying the
+highlighted source. Each call yields a fresh expression tree. -/
+def inlineAnchorTerm (catalog : String) (problem : ProblemEntry) (hole : Hole) :
+    TermElabM (TSyntax `term) := do
   let moduleName := Lean.mkIdent `BenchmarkProblems.Catalog
-  problem.holes.mapM fun hole => do
-    let anchorId := holeAnchorId problem.id hole
-    let anchorName := Lean.mkIdent <| Lean.Name.mkSimple anchorId
-    let args : Array Verso.Doc.Arg := #[
-      .anon (.name anchorName),
-      .named .missing (Lean.mkIdent `module) (.name moduleName)
-    ]
-    let expected := Syntax.mkStrLit (← anchorSourceText catalog problem.id hole)
-    let terms ← runPageDocElab <| Verso.Code.External.anchor args expected
-    match terms[0]? with
-    | some term => pure term
-    | none => throwError "Anchor expander for '{anchorId}' returned no block"
+  let anchorId := holeAnchorId problem.id hole
+  let anchorName := Lean.mkIdent <| Lean.Name.mkSimple anchorId
+  let args : Array Verso.Doc.Arg := #[
+    .anon (.name anchorName),
+    .named .missing (Lean.mkIdent `module) (.name moduleName)
+  ]
+  let expected := Syntax.mkStrLit (← anchorSourceText catalog problem.id hole)
+  let terms ← runPageDocElab <| Verso.Code.External.anchor args expected
+  match terms[0]? with
+  | some term => pure term
+  | none => throwError "Anchor expander for '{anchorId}' returned no block"
+
+/-- Stable top-level constant name carrying one hole's anchor block.
+Each anchor lives in its own `def` so the page that uses them stays
+tractable for the Lean code generator (otherwise inlining 24+ Verso
+anchor expressions into a single problem fragment overflows codegen
+recursion). -/
+def anchorConstName (problemId : String) (hole : Hole) : Lean.Name :=
+  let leaf := s!"_anc_{problemId}__{hole.basename}"
+  (((Lean.Name.mkSimple "LeaderboardSite").str "Pages").str "Anchors").str leaf
+
+/-- Identifier referring to the top-level constant declared by
+`register_problem_anchors%` for this hole. -/
+def anchorConstIdent (problemId : String) (hole : Hole) : Lean.Ident :=
+  Lean.mkIdent (anchorConstName problemId hole)
+
+/-- One identifier reference per hole, in source order. The identifier
+points at the constant declared by `register_problem_anchors%`. -/
+def anchorBlockTerms (problem : ProblemEntry) : Array (TSyntax `term) :=
+  problem.holes.map fun hole => ⟨anchorConstIdent problem.id hole⟩
 
 end LeaderboardSite.Data
+
+open LeaderboardSite.Data
+
+/-- Register one top-level constant per `@[eval_problem]`-tagged hole, each
+of type `Block Page` and holding the Verso anchor block for that hole.
+Pages downstream (catalog and home-page popovers) reference these
+constants by name, which keeps each downstream `def`'s body small enough
+for the Lean code generator — inlining 24+ Verso anchors into a single
+`def`'s expression tree overflows the default codegen recursion budget.
+
+Runs at root scope so the emitted `def`s pick up the absolute name
+`LeaderboardSite.Pages.Anchors._anc_<id>__<basename>` rather than being
+nested under whatever namespace the invocation site happens to be in. -/
+syntax "register_problem_anchors%" : command
+
+elab_rules : command
+  | `(register_problem_anchors%) => do
+      let (catalog, problems) ← Lean.Elab.Command.runTermElabM fun _ => do
+        let payload ← parseProblemsPayload
+        let catalog ← loadSnapshotCatalog
+        let problems ← validateProblems payload
+        pure (catalog, problems)
+      for problem in problems do
+        for hole in problem.holes do
+          let constName := anchorConstName problem.id hole
+          if (← Lean.getEnv).contains constName then
+            continue
+          let anchorTerm ← Lean.Elab.Command.runTermElabM fun _ =>
+            inlineAnchorTerm catalog problem hole
+          let constIdent := Lean.mkIdent constName
+          let cmd ← `(def $constIdent : Block Page := $anchorTerm)
+          Lean.Elab.Command.elabCommand cmd
+
+/-- Run the registration at module-elaboration time so all downstream
+pages can reference the constants by name. -/
+register_problem_anchors%

--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -311,12 +311,12 @@ def anchorConstName (problemId : String) (hole : Hole) : Lean.Name :=
   (((Lean.Name.mkSimple "LeaderboardSite").str "Pages").str "Anchors").str leaf
 
 /-- Identifier referring to the top-level constant declared by
-`register_problem_anchors%` for this hole. -/
+`register_problem_anchors` for this hole. -/
 def anchorConstIdent (problemId : String) (hole : Hole) : Lean.Ident :=
   Lean.mkIdent (anchorConstName problemId hole)
 
 /-- One identifier reference per hole, in source order. The identifier
-points at the constant declared by `register_problem_anchors%`. -/
+points at the constant declared by `register_problem_anchors`. -/
 def anchorBlockTerms (problem : ProblemEntry) : Array (TSyntax `term) :=
   problem.holes.map fun hole => ⟨anchorConstIdent problem.id hole⟩
 
@@ -334,10 +334,10 @@ for the Lean code generator — inlining 24+ Verso anchors into a single
 Runs at root scope so the emitted `def`s pick up the absolute name
 `LeaderboardSite.Pages.Anchors._anc_<id>__<basename>` rather than being
 nested under whatever namespace the invocation site happens to be in. -/
-syntax "register_problem_anchors%" : command
+syntax "register_problem_anchors" : command
 
 elab_rules : command
-  | `(register_problem_anchors%) => do
+  | `(register_problem_anchors) => do
       let (catalog, problems) ← Lean.Elab.Command.runTermElabM fun _ => do
         let payload ← parseProblemsPayload
         let catalog ← loadSnapshotCatalog
@@ -356,4 +356,4 @@ elab_rules : command
 
 /-- Run the registration at module-elaboration time so all downstream
 pages can reference the constants by name. -/
-register_problem_anchors%
+register_problem_anchors

--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -321,39 +321,3 @@ def anchorBlockTerms (problem : ProblemEntry) : Array (TSyntax `term) :=
   problem.holes.map fun hole => ⟨anchorConstIdent problem.id hole⟩
 
 end LeaderboardSite.Data
-
-open LeaderboardSite.Data
-
-/-- Register one top-level constant per `@[eval_problem]`-tagged hole, each
-of type `Block Page` and holding the Verso anchor block for that hole.
-Pages downstream (catalog and home-page popovers) reference these
-constants by name, which keeps each downstream `def`'s body small enough
-for the Lean code generator — inlining 24+ Verso anchors into a single
-`def`'s expression tree overflows the default codegen recursion budget.
-
-Runs at root scope so the emitted `def`s pick up the absolute name
-`LeaderboardSite.Pages.Anchors._anc_<id>__<basename>` rather than being
-nested under whatever namespace the invocation site happens to be in. -/
-syntax "register_problem_anchors" : command
-
-elab_rules : command
-  | `(register_problem_anchors) => do
-      let (catalog, problems) ← Lean.Elab.Command.runTermElabM fun _ => do
-        let payload ← parseProblemsPayload
-        let catalog ← loadSnapshotCatalog
-        let problems ← validateProblems payload
-        pure (catalog, problems)
-      for problem in problems do
-        for hole in problem.holes do
-          let constName := anchorConstName problem.id hole
-          if (← Lean.getEnv).contains constName then
-            continue
-          let anchorTerm ← Lean.Elab.Command.runTermElabM fun _ =>
-            inlineAnchorTerm catalog problem hole
-          let constIdent := Lean.mkIdent constName
-          let cmd ← `(def $constIdent : Block Page := $anchorTerm)
-          Lean.Elab.Command.elabCommand cmd
-
-/-- Run the registration at module-elaboration time so all downstream
-pages can reference the constants by name. -/
-register_problem_anchors

--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -259,8 +259,10 @@ is `<problem-id>__<basename>`. Returns the trimmed body so callers can use
 it for plain-text fallbacks. -/
 def anchorSourceText (catalog : String) (problemId : String) (hole : Hole) : TermElabM String := do
   let anchorId := holeAnchorId problemId hole
-  let startMarker := s!"-- ANCHOR: {anchorId}"
-  let endMarker := s!"-- ANCHOR_END: {anchorId}"
+  -- Trailing newline pins the match to the full anchor line; without it,
+  -- a basename like `genus` would prefix-match `genus_eq_zero_iff_homeo`.
+  let startMarker := s!"-- ANCHOR: {anchorId}\n"
+  let endMarker := s!"-- ANCHOR_END: {anchorId}\n"
   let parts := catalog.splitOn startMarker
   let some rest := parts[1]?
     | throwError "Anchor '{anchorId}' not found in {snapshotCatalogPath}"

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -151,19 +151,21 @@ private def heroBlock (summary : LeaderboardSummary) : Block Page :=
 
 /-! ## Problem rows inside an entry -/
 
-/-- Theorem-statement card shown as a CSS hover/focus popover. When an
-anchor-rendered Verso block is available for the given problem id we use
-it (with full syntax highlighting); otherwise we fall back to a plain
-`<pre>` static card. -/
+/-- Hover/focus popover showing every `@[eval_problem]` declaration tied
+to a problem id. When anchor-rendered Verso blocks are available for the
+given problem id we use them (with full syntax highlighting), one per
+hole, stacked; otherwise we fall back to a plain `<pre>` of the joined
+hole sources. -/
 private def theoremCard
-    (anchorMap : Std.HashMap String (Block Page))
+    (anchorMap : Std.HashMap String (Array (Block Page)))
     (problemId statement : String) : Block Page :=
   match anchorMap[problemId]? with
   | some rendered =>
-    divBlock "theorem-card theorem-card-rendered" #[
-      divBlock "theorem-card-label" #[paragraph #[textInline "Verso theorem preview"]],
-      rendered
-    ]
+    let holeBlocks : Array (Block Page) :=
+      rendered.map fun blk => divBlock "hole" #[blk]
+    divBlock "theorem-card theorem-card-rendered" <|
+      #[divBlock "theorem-card-label" #[paragraph #[textInline "Verso theorem preview"]]]
+      ++ holeBlocks
   | none =>
     divBlock "theorem-card theorem-card-static" #[
       divBlock "theorem-card-label" #[paragraph #[textInline "Lean theorem statement"]],
@@ -176,7 +178,7 @@ theorem text shown in the static-fallback popover. `proofUrl?`, when
 set, adds a public proof link next to the chip. The `anchorMap` carries
 pre-rendered Verso theorem blocks keyed by problem id. -/
 private def problemItem
-    (anchorMap : Std.HashMap String (Block Page))
+    (anchorMap : Std.HashMap String (Array (Block Page)))
     (problemId : String) (title : String) (statement : String)
     (proofUrl? : Option String)
     (rarityRank? : Option Nat)
@@ -249,7 +251,7 @@ private def entrySummary (entry : LeaderboardEntry) : Html :=
 /-- Render the body of a `<details>` row: notable problems + provenance. -/
 private def entryBody
     (problems : Std.HashMap String (String × String))
-    (anchorMap : Std.HashMap String (Block Page))
+    (anchorMap : Std.HashMap String (Array (Block Page)))
     (entry : LeaderboardEntry) : Array (Block Page) :=
   let notable := entry.notableProblemIds.filterMap fun pid =>
     entry.solvedProblems.find? (·.problemId == pid)
@@ -294,7 +296,7 @@ private def entryBody
 
 private def entryBlock
     (problems : Std.HashMap String (String × String))
-    (anchorMap : Std.HashMap String (Block Page))
+    (anchorMap : Std.HashMap String (Array (Block Page)))
     (entry : LeaderboardEntry) : Block Page :=
   detailsBlock "entry" (entrySummary entry) (entryBody problems anchorMap entry)
 
@@ -317,7 +319,7 @@ through Verso while the data-rich path is being built out. -/
 /-- Empty-state showcase: friendly message + a preview of the first
 four main benchmark problems with hover-popover theorem cards. -/
 private def emptyShowcase
-    (anchorMap : Std.HashMap String (Block Page))
+    (anchorMap : Std.HashMap String (Array (Block Page)))
     (preview : Array (String × String × String)) : Block Page :=
   let previewItems : Array (Block Page) := preview.map fun (id, title, statement) =>
     problemItem anchorMap id title statement none none none
@@ -337,7 +339,7 @@ private def emptyShowcase
 empty showcase with a 4-problem catalog preview. -/
 private def leaderboardPanel
     (problems : Std.HashMap String (String × String))
-    (anchorMap : Std.HashMap String (Block Page))
+    (anchorMap : Std.HashMap String (Array (Block Page)))
     (preview : Array (String × String × String))
     (entries : Array LeaderboardEntry) : Block Page :=
   let body : Array (Block Page) :=
@@ -369,7 +371,7 @@ def leaderboardBlocks
     (problemEntries : Array (String × String × String))
     (entries : Array LeaderboardEntry)
     (previewIds : Array String)
-    (anchorMap : Std.HashMap String (Block Page)) : Array (Block Page) :=
+    (anchorMap : Std.HashMap String (Array (Block Page))) : Array (Block Page) :=
   let problemMap : Std.HashMap String (String × String) :=
     problemEntries.foldl
       (fun m (id, title, statement) => m.insert id (title, statement))
@@ -390,15 +392,17 @@ sections. Used from `Front.lean` via the `leaderboard%` syntax. -/
 
 scoped syntax "leaderboard%" : term
 
-/-- Build a syntax tree for an `Std.HashMap String (Block Page)` whose
-keys are problem ids and whose values are the spliced anchor terms. -/
+/-- Build a syntax tree for an `Std.HashMap String (Array (Block Page))`
+whose keys are problem ids and whose values are the spliced per-hole
+anchor terms. -/
 private def anchorMapTerm
     (catalog : String) (problems : Array ProblemEntry)
     (neededIds : Array String) : TermElabM (TSyntax `term) := do
   let needed := problems.filter fun p => neededIds.contains p.id
-  needed.foldlM (init := ← `((∅ : Std.HashMap String (Block Page)))) fun acc p => do
-    let anchor ← anchorBlockTerm catalog p
-    `(($acc).insert $(quote p.id) $anchor)
+  needed.foldlM (init := ← `((∅ : Std.HashMap String (Array (Block Page))))) fun acc p => do
+    let anchors ← anchorBlockTerms catalog p
+    let anchorsArr : TSyntaxArray `term := anchors
+    `(($acc).insert $(quote p.id) #[$anchorsArr,*])
 
 elab_rules : term
   | `(leaderboard%) => do
@@ -408,8 +412,12 @@ elab_rules : term
       let problems ← validateProblems problemsPayload
       let summary := payload.summary
       let entries := payload.entries
+      -- Plain-text fallback for the popover when no rendered anchor is
+      -- available: concatenate every hole's body in source order.
       let problemTriples : Array (String × String × String) :=
-        problems.map fun p => (p.id, p.title, p.statementText)
+        problems.map fun p =>
+          let joined := String.intercalate "\n\n" (p.holes.map (·.body)).toList
+          (p.id, p.title, joined)
       -- The empty-state preview shows the first four main (non-test)
       -- problems, mirroring what the JS rendering used to emit.
       let mainProblems := problems.filter (!·.test)

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -396,19 +396,17 @@ scoped syntax "leaderboard%" : term
 whose keys are problem ids and whose values are the spliced per-hole
 anchor terms. -/
 private def anchorMapTerm
-    (catalog : String) (problems : Array ProblemEntry)
+    (problems : Array ProblemEntry)
     (neededIds : Array String) : TermElabM (TSyntax `term) := do
   let needed := problems.filter fun p => neededIds.contains p.id
   needed.foldlM (init := ← `((∅ : Std.HashMap String (Array (Block Page))))) fun acc p => do
-    let anchors ← anchorBlockTerms catalog p
-    let anchorsArr : TSyntaxArray `term := anchors
+    let anchorsArr : TSyntaxArray `term := anchorBlockTerms p
     `(($acc).insert $(quote p.id) #[$anchorsArr,*])
 
 elab_rules : term
   | `(leaderboard%) => do
       let payload ← parseLeaderboardPayload
       let problemsPayload ← parseProblemsPayload
-      let catalog ← loadSnapshotCatalog
       let problems ← validateProblems problemsPayload
       let summary := payload.summary
       let entries := payload.entries
@@ -430,7 +428,7 @@ elab_rules : term
         let base := previewIds ++ entries.flatMap (·.notableProblemIds)
         base.foldl (init := #[]) fun acc id =>
           if acc.contains id then acc else acc.push id
-      let anchorMap ← anchorMapTerm catalog problems neededIds
+      let anchorMap ← anchorMapTerm problems neededIds
       let term ← `(leaderboardBlocks
         $(quote summary)
         $(quote problemTriples)

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -1,6 +1,7 @@
 import Lean.Data.Json
 import VersoBlog
 import LeaderboardSite.Data
+import LeaderboardSite.AnchorRegistry
 
 open Lean
 open Lean.Elab Term

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -67,10 +67,8 @@ private def sourceParagraphTerm (problem : ProblemEntry) : TermElabM (TSyntax `t
   | none =>
       `(paragraph #[textInline $(quote s!"Source: {unavailableText}")])
 
-private def divBlockTerm (cls : String) (children : Array (TSyntax `term)) :
-    TermElabM (TSyntax `term) := do
-  let children' : TSyntaxArray `term := children
-  `(((Block.other (BlockExt.htmlDiv $(quote cls)) #[$children',*]) : Block Page))
+private def holeWrap (child : Block Page) : Block Page :=
+  .other (BlockExt.htmlDiv "hole") #[child]
 
 private def problemPartTerm (catalog : String) (problem : ProblemEntry) : TermElabM (TSyntax `term) := do
   let notesBlock ← optionalParagraphTerm "Notes" problem.notesText
@@ -79,7 +77,7 @@ private def problemPartTerm (catalog : String) (problem : ProblemEntry) : TermEl
   let anchors ← anchorBlockTerms catalog problem
   -- Wrap each hole's anchor block in a `<div class="hole">` so multiple
   -- holes stack with the spacing rule defined in `static/style.css`.
-  let holeBlocks ← anchors.mapM fun anchor => divBlockTerm "hole" #[anchor]
+  let holeBlocks ← anchors.mapM fun anchor => `(holeWrap $anchor)
   let holeBlocks : TSyntaxArray `term := holeBlocks
   `(pagePart $(quote problem.title) #[
       paragraph #[codeInline $(quote problem.id)],

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -67,18 +67,27 @@ private def sourceParagraphTerm (problem : ProblemEntry) : TermElabM (TSyntax `t
   | none =>
       `(paragraph #[textInline $(quote s!"Source: {unavailableText}")])
 
+private def divBlockTerm (cls : String) (children : Array (TSyntax `term)) :
+    TermElabM (TSyntax `term) := do
+  let children' : TSyntaxArray `term := children
+  `(((Block.other (BlockExt.htmlDiv $(quote cls)) #[$children',*]) : Block Page))
+
 private def problemPartTerm (catalog : String) (problem : ProblemEntry) : TermElabM (TSyntax `term) := do
   let notesBlock ← optionalParagraphTerm "Notes" problem.notesText
   let sourceBlock ← sourceParagraphTerm problem
   let solutionBlock ← optionalParagraphTerm "Informal solution" problem.informalSolution
-  let anchorBlock ← anchorBlockTerm catalog problem
+  let anchors ← anchorBlockTerms catalog problem
+  -- Wrap each hole's anchor block in a `<div class="hole">` so multiple
+  -- holes stack with the spacing rule defined in `static/style.css`.
+  let holeBlocks ← anchors.mapM fun anchor => divBlockTerm "hole" #[anchor]
+  let holeBlocks : TSyntaxArray `term := holeBlocks
   `(pagePart $(quote problem.title) #[
       paragraph #[codeInline $(quote problem.id)],
       paragraph #[textInline $(quote s!"Submitter: {problem.submitter}.")],
       $notesBlock,
       $sourceBlock,
       $solutionBlock,
-      $anchorBlock
+      $holeBlocks,*
     ] #[] (some $(quote problem.id)))
 
 private def sectionPartTerm (catalog : String) (title : String) (htmlId : String)

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -70,23 +70,38 @@ private def sourceParagraphTerm (problem : ProblemEntry) : TermElabM (TSyntax `t
 private def holeWrap (child : Block Page) : Block Page :=
   .other (BlockExt.htmlDiv "hole") #[child]
 
+/-- Assemble one problem's `Part Page` at runtime from the spliced anchor
+blocks. Routing per-problem assembly through this function keeps the
+elaborator-time syntax tree shallow (one runtime call per problem rather
+than a 5-plus-#holes literal), which avoids the code generator's
+maximum-recursion-depth limit on problems with many holes. -/
+private def assembleProblemPart
+    (title id submitterText : String)
+    (notes source solution : Block Page)
+    (anchors : Array (Block Page)) : Part Page :=
+  let prelude : Array (Block Page) := #[
+    paragraph #[codeInline id],
+    paragraph #[textInline submitterText],
+    notes,
+    source,
+    solution
+  ]
+  pagePart title (prelude ++ anchors.map holeWrap) #[] (some id)
+
 private def problemPartTerm (catalog : String) (problem : ProblemEntry) : TermElabM (TSyntax `term) := do
   let notesBlock ← optionalParagraphTerm "Notes" problem.notesText
   let sourceBlock ← sourceParagraphTerm problem
   let solutionBlock ← optionalParagraphTerm "Informal solution" problem.informalSolution
   let anchors ← anchorBlockTerms catalog problem
-  -- Wrap each hole's anchor block in a `<div class="hole">` so multiple
-  -- holes stack with the spacing rule defined in `static/style.css`.
-  let holeBlocks ← anchors.mapM fun anchor => `(holeWrap $anchor)
-  let holeBlocks : TSyntaxArray `term := holeBlocks
-  `(pagePart $(quote problem.title) #[
-      paragraph #[codeInline $(quote problem.id)],
-      paragraph #[textInline $(quote s!"Submitter: {problem.submitter}.")],
-      $notesBlock,
-      $sourceBlock,
-      $solutionBlock,
-      $holeBlocks,*
-    ] #[] (some $(quote problem.id)))
+  let anchorsArr : TSyntaxArray `term := anchors
+  `(assembleProblemPart
+      $(quote problem.title)
+      $(quote problem.id)
+      $(quote s!"Submitter: {problem.submitter}.")
+      $notesBlock
+      $sourceBlock
+      $solutionBlock
+      #[$anchorsArr,*])
 
 private def sectionPartTerm (catalog : String) (title : String) (htmlId : String)
     (problems : Array ProblemEntry) : TermElabM (TSyntax `term) := do

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -88,12 +88,11 @@ private def assembleProblemPart
   ]
   pagePart title (prelude ++ anchors.map holeWrap) #[] (some id)
 
-private def problemPartTerm (catalog : String) (problem : ProblemEntry) : TermElabM (TSyntax `term) := do
+private def problemPartTerm (problem : ProblemEntry) : TermElabM (TSyntax `term) := do
   let notesBlock ← optionalParagraphTerm "Notes" problem.notesText
   let sourceBlock ← sourceParagraphTerm problem
   let solutionBlock ← optionalParagraphTerm "Informal solution" problem.informalSolution
-  let anchors ← anchorBlockTerms catalog problem
-  let anchorsArr : TSyntaxArray `term := anchors
+  let anchorsArr : TSyntaxArray `term := anchorBlockTerms problem
   `(assembleProblemPart
       $(quote problem.title)
       $(quote problem.id)
@@ -103,9 +102,9 @@ private def problemPartTerm (catalog : String) (problem : ProblemEntry) : TermEl
       $solutionBlock
       #[$anchorsArr,*])
 
-private def sectionPartTerm (catalog : String) (title : String) (htmlId : String)
+private def sectionPartTerm (title : String) (htmlId : String)
     (problems : Array ProblemEntry) : TermElabM (TSyntax `term) := do
-  let subParts ← problems.mapM (problemPartTerm catalog)
+  let subParts ← problems.mapM problemPartTerm
   let subParts : TSyntaxArray `term := subParts
   `(pagePart $(quote title) #[] #[$subParts,*] (some $(quote htmlId)))
 
@@ -129,15 +128,14 @@ scoped syntax "problems_page%" : term
 elab_rules : term
   | `(problems_page%) => do
       let payload ← parseProblemsPayload
-      let catalog ← loadSnapshotCatalog
       let problems ← validateProblems payload
       let introBlocks ← introParagraphTerms
       let mainProblems := Array.filter (fun problem => !problem.test) problems
       let starterProblems := Array.filter (·.test) problems
-      let mainSection ← sectionPartTerm catalog "Main benchmark problems" "main-problems" mainProblems
+      let mainSection ← sectionPartTerm "Main benchmark problems" "main-problems" mainProblems
       let mut subParts := #[mainSection]
       if !starterProblems.isEmpty then
-        subParts := subParts.push (← sectionPartTerm catalog "Starter problems" "starter-problems" starterProblems)
+        subParts := subParts.push (← sectionPartTerm "Starter problems" "starter-problems" starterProblems)
       let introBlocks' : TSyntaxArray `term := introBlocks
       let subParts' : TSyntaxArray `term := subParts
       let pageTerm ← `(pagePart "Problems" #[$introBlocks',*] #[$subParts',*])

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -1,5 +1,6 @@
 import VersoBlog
 import LeaderboardSite.Data
+import LeaderboardSite.AnchorRegistry
 
 open Lean
 open Lean.Elab Term

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -9,13 +9,6 @@ open Verso.Code.External
 
 set_option verso.exampleProject "benchmark-snapshot"
 set_option maxHeartbeats 1000000
--- The catalog has ~69 highlighted anchor blocks across 36 problems
--- (jacobian_challenge_diffgeo alone contributes 24). Both the elaborator
--- and the code generator need a deeper recursion budget than default to
--- handle the resulting expression tree without "maximum recursion depth
--- reached" errors.
-set_option maxRecDepth 10000
-set_option compiler.maxRecDepth 10000
 
 namespace LeaderboardSite.Pages
 

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -9,6 +9,13 @@ open Verso.Code.External
 
 set_option verso.exampleProject "benchmark-snapshot"
 set_option maxHeartbeats 1000000
+-- The catalog has ~69 highlighted anchor blocks across 36 problems
+-- (jacobian_challenge_diffgeo alone contributes 24). Both the elaborator
+-- and the code generator need a deeper recursion budget than default to
+-- handle the resulting expression tree without "maximum recursion depth
+-- reached" errors.
+set_option maxRecDepth 10000
+set_option compiler.maxRecDepth 10000
 
 namespace LeaderboardSite.Pages
 

--- a/benchmark-snapshot/BenchmarkProblems/Catalog.lean
+++ b/benchmark-snapshot/BenchmarkProblems/Catalog.lean
@@ -2,29 +2,29 @@ import Mathlib
 
 namespace ProblemTwoPlusTwo
 
--- ANCHOR: two_plus_two
+-- ANCHOR: two_plus_two__two_plus_two_eq_four
 theorem two_plus_two_eq_four : (2 : Nat) + 2 = 4 := by
   sorry
--- ANCHOR_END: two_plus_two
+-- ANCHOR_END: two_plus_two__two_plus_two_eq_four
 
 end ProblemTwoPlusTwo
 
 namespace ProblemCiRegenerateMainCheck
 
--- ANCHOR: ci_regenerate_main_check
+-- ANCHOR: ci_regenerate_main_check__ci_regenerate_main_check
 theorem ci_regenerate_main_check : True := by
   sorry
--- ANCHOR_END: ci_regenerate_main_check
+-- ANCHOR_END: ci_regenerate_main_check__ci_regenerate_main_check
 
 end ProblemCiRegenerateMainCheck
 
 namespace ProblemListAppendSingletonLength
 
--- ANCHOR: list_append_singleton_length
+-- ANCHOR: list_append_singleton_length__list_append_singleton_length
 theorem list_append_singleton_length :
     (([1, 2] : List Nat).append [3]).length = 3 := by
   sorry
--- ANCHOR_END: list_append_singleton_length
+-- ANCHOR_END: list_append_singleton_length__list_append_singleton_length
 
 end ProblemListAppendSingletonLength
 
@@ -32,21 +32,21 @@ namespace ProblemChudnovskyFormulaForPiInv
 
 open scoped Real
 
--- ANCHOR: chudnovsky_formula_for_pi_inv
+-- ANCHOR: chudnovsky_formula_for_pi_inv__chudnovsky_formula_for_pi_inv
 theorem chudnovsky_formula_for_pi_inv :
     chudnovskySum = π⁻¹ := by
   sorry
--- ANCHOR_END: chudnovsky_formula_for_pi_inv
+-- ANCHOR_END: chudnovsky_formula_for_pi_inv__chudnovsky_formula_for_pi_inv
 
 end ProblemChudnovskyFormulaForPiInv
 
 namespace ProblemPi1CircleMulEquivInt
 
--- ANCHOR: pi1_circle_mulEquiv_int
+-- ANCHOR: pi1_circle_mulEquiv_int__pi1_circle_mulEquiv_int
 theorem pi1_circle_mulEquiv_int :
     Nonempty (HomotopyGroup.Pi 1 Circle (1 : Circle) ≃* Multiplicative ℤ) := by
   sorry
--- ANCHOR_END: pi1_circle_mulEquiv_int
+-- ANCHOR_END: pi1_circle_mulEquiv_int__pi1_circle_mulEquiv_int
 
 end ProblemPi1CircleMulEquivInt
 
@@ -54,11 +54,11 @@ namespace ProblemFiniteGraphRamseyTheorem
 
 open SimpleGraph
 
--- ANCHOR: finite_graph_ramsey_theorem
+-- ANCHOR: finite_graph_ramsey_theorem__finite_graph_ramsey_theorem
 theorem finite_graph_ramsey_theorem :
     ∀ r s : ℕ, 2 ≤ r → 2 ≤ s → ∃ n : ℕ, ∀ G : SimpleGraph (Fin n), ¬ G.CliqueFree r ∨ ¬ Gᶜ.CliqueFree s := by
   sorry
--- ANCHOR_END: finite_graph_ramsey_theorem
+-- ANCHOR_END: finite_graph_ramsey_theorem__finite_graph_ramsey_theorem
 
 end ProblemFiniteGraphRamseyTheorem
 
@@ -66,14 +66,14 @@ namespace ProblemSubstInvXSubXSqEqCatalan
 
 open PowerSeries
 
--- ANCHOR: substInv_X_sub_X_sq_eq_catalan
+-- ANCHOR: substInv_X_sub_X_sq_eq_catalan__substInv_X_sub_X_sq_eq_catalan
 theorem substInv_X_sub_X_sq_eq_catalan (n : ℕ) :
     haveI : Invertible (coeff 1 ((X : ℚ⟦X⟧) - X ^ 2)) := by
       simp [coeff_X, coeff_X_pow]; exact invertibleOne
     coeff (n + 1) (substInv ((X : ℚ⟦X⟧) - X ^ 2)) =
       (Nat.choose (2 * n) n : ℚ) / (↑n + 1) := by
   sorry
--- ANCHOR_END: substInv_X_sub_X_sq_eq_catalan
+-- ANCHOR_END: substInv_X_sub_X_sq_eq_catalan__substInv_X_sub_X_sq_eq_catalan
 
 end ProblemSubstInvXSubXSqEqCatalan
 
@@ -106,11 +106,11 @@ end LeanEval
 open LeanEval.NumberTheory
 open scoped ArithmeticFunction.sigma
 
--- ANCHOR: riemann_hypothesis_iff_lagarias_elementary_criterion
+-- ANCHOR: riemann_hypothesis_iff_lagarias_elementary_criterion__riemann_hypothesis_iff_lagarias_elementary_criterion
 theorem riemann_hypothesis_iff_lagarias_elementary_criterion :
     RiemannHypothesis ↔ LeanEval.NumberTheory.LagariasElementaryCriterion := by
   sorry
--- ANCHOR_END: riemann_hypothesis_iff_lagarias_elementary_criterion
+-- ANCHOR_END: riemann_hypothesis_iff_lagarias_elementary_criterion__riemann_hypothesis_iff_lagarias_elementary_criterion
 
 end ProblemRiemannHypothesisIffLagariasElementaryCriterion
 
@@ -176,66 +176,66 @@ end LeanEval
 open LeanEval.Combinatorics
 open scoped BigOperators
 
--- ANCHOR: dvd_card_connectedComponent_markoffGraph
+-- ANCHOR: dvd_card_connectedComponent_markoffGraph__dvd_card_connectedComponent_markoffGraph
 theorem dvd_card_connectedComponent_markoffGraph {p : ℕ} (hp : Nat.Prime p) (hgt : 3 < p) :
     ∀ c : (LeanEval.Combinatorics.markoffGraph p).ConnectedComponent, p ∣ Nat.card c := by
   sorry
--- ANCHOR_END: dvd_card_connectedComponent_markoffGraph
+-- ANCHOR_END: dvd_card_connectedComponent_markoffGraph__dvd_card_connectedComponent_markoffGraph
 
 end ProblemDvdCardConnectedComponentMarkoffGraph
 
 namespace ProblemMulCayleyConnectedIffClosureEqTop
 
--- ANCHOR: mulCayley_connected_iff_closure_eq_top
+-- ANCHOR: mulCayley_connected_iff_closure_eq_top__mulCayley_connected_iff_closure_eq_top
 theorem mulCayley_connected_iff_closure_eq_top {G : Type*} [Group G]
     (S : Set G) :
     (SimpleGraph.mulCayley S).Connected ↔ Subgroup.closure S = ⊤ := by
   sorry
--- ANCHOR_END: mulCayley_connected_iff_closure_eq_top
+-- ANCHOR_END: mulCayley_connected_iff_closure_eq_top__mulCayley_connected_iff_closure_eq_top
 
 end ProblemMulCayleyConnectedIffClosureEqTop
 
 namespace ProblemPi3SphereTwoMulEquivInt
 
--- ANCHOR: pi3_sphere_two_mulEquiv_int
+-- ANCHOR: pi3_sphere_two_mulEquiv_int__pi3_sphere_two_mulEquiv_int
 theorem pi3_sphere_two_mulEquiv_int (x : Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1) :
     Nonempty
       (HomotopyGroup.Pi 3 (Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1) x ≃*
         Multiplicative ℤ) := by
   sorry
--- ANCHOR_END: pi3_sphere_two_mulEquiv_int
+-- ANCHOR_END: pi3_sphere_two_mulEquiv_int__pi3_sphere_two_mulEquiv_int
 
 end ProblemPi3SphereTwoMulEquivInt
 
 namespace ProblemPinSphereNMulEquivInt
 
--- ANCHOR: pin_sphere_n_mulEquiv_int
+-- ANCHOR: pin_sphere_n_mulEquiv_int__pin_sphere_n_mulEquiv_int
 theorem pin_sphere_n_mulEquiv_int (n : ℕ)
     (x : Metric.sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1) :
     Nonempty
       (HomotopyGroup.Pi (n + 1) (Metric.sphere (0 : EuclideanSpace ℝ (Fin (n + 2))) 1) x ≃*
         Multiplicative ℤ) := by
   sorry
--- ANCHOR_END: pin_sphere_n_mulEquiv_int
+-- ANCHOR_END: pin_sphere_n_mulEquiv_int__pin_sphere_n_mulEquiv_int
 
 end ProblemPinSphereNMulEquivInt
 
 namespace ProblemPiSuccSphereNMulEquivZmodTwo
 
--- ANCHOR: pi_succ_sphere_n_mulEquiv_zmod_two
+-- ANCHOR: pi_succ_sphere_n_mulEquiv_zmod_two__pi_succ_sphere_n_mulEquiv_zmod_two
 theorem pi_succ_sphere_n_mulEquiv_zmod_two (n : ℕ) (hn : 3 ≤ n)
     (x : Metric.sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
     Nonempty
       (HomotopyGroup.Pi (n + 1) (Metric.sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) x ≃*
         Multiplicative (ZMod 2)) := by
   sorry
--- ANCHOR_END: pi_succ_sphere_n_mulEquiv_zmod_two
+-- ANCHOR_END: pi_succ_sphere_n_mulEquiv_zmod_two__pi_succ_sphere_n_mulEquiv_zmod_two
 
 end ProblemPiSuccSphereNMulEquivZmodTwo
 
 namespace ProblemFiniteGroupIsSolvableOfCardEqPrimePowMulPrimePow
 
--- ANCHOR: finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow
+-- ANCHOR: finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow__finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow
 theorem finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow {G : Type*} [Group G] [Fintype G]
     {p q a b : ℕ}
     (hp : Nat.Prime p)
@@ -244,7 +244,7 @@ theorem finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow {G : Type*} [
     (hcard : Fintype.card G = p ^ a * q ^ b) :
     IsSolvable G := by
   sorry
--- ANCHOR_END: finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow
+-- ANCHOR_END: finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow__finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow
 
 end ProblemFiniteGroupIsSolvableOfCardEqPrimePowMulPrimePow
 
@@ -252,7 +252,7 @@ namespace ProblemRoucheLogCountingZeroEq
 
 open ValueDistribution
 
--- ANCHOR: rouche_logCounting_zero_eq
+-- ANCHOR: rouche_logCounting_zero_eq__rouche_logCounting_zero_eq
 theorem rouche_logCounting_zero_eq {f g : ℂ → ℂ} {R : ℝ}
     (hR : 1 ≤ R)
     (hf : Meromorphic f)
@@ -260,7 +260,7 @@ theorem rouche_logCounting_zero_eq {f g : ℂ → ℂ} {R : ℝ}
     (hbound : ∀ z : ℂ, ‖z‖ = R → ‖g z‖ < ‖f z‖) :
     logCounting (f + g) 0 R = logCounting f 0 R := by
   sorry
--- ANCHOR_END: rouche_logCounting_zero_eq
+-- ANCHOR_END: rouche_logCounting_zero_eq__rouche_logCounting_zero_eq
 
 end ProblemRoucheLogCountingZeroEq
 
@@ -268,7 +268,7 @@ namespace ProblemMemConvexHullFinsetExtremePointsOfMemCompactConvex
 
 open Set
 
--- ANCHOR: mem_convexHull_finset_extremePoints_of_mem_compact_convex
+-- ANCHOR: mem_convexHull_finset_extremePoints_of_mem_compact_convex__mem_convexHull_finset_extremePoints_of_mem_compact_convex
 theorem mem_convexHull_finset_extremePoints_of_mem_compact_convex {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
     {s : Set E} {x : E}
     (hscomp : IsCompact s)
@@ -279,7 +279,7 @@ theorem mem_convexHull_finset_extremePoints_of_mem_compact_convex {E : Type*} [N
       t.card ≤ Module.finrank ℝ E + 1 ∧
       x ∈ convexHull ℝ (↑t : Set E) := by
   sorry
--- ANCHOR_END: mem_convexHull_finset_extremePoints_of_mem_compact_convex
+-- ANCHOR_END: mem_convexHull_finset_extremePoints_of_mem_compact_convex__mem_convexHull_finset_extremePoints_of_mem_compact_convex
 
 end ProblemMemConvexHullFinsetExtremePointsOfMemCompactConvex
 
@@ -287,7 +287,7 @@ namespace ProblemIrreducibleNonnegativeMatrixHasPositiveEigenvectorAtSpectralRad
 
 open scoped NNReal
 
--- ANCHOR: irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius
+-- ANCHOR: irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius__irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius
 theorem irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius {n : Type*} [Fintype n] [DecidableEq n]
     (A : Matrix n n ℝ)
     (hA : A.IsIrreducible) :
@@ -295,7 +295,7 @@ theorem irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadiu
       Module.End.HasEigenvector (Matrix.toLin' A) (spectralRadius ℝ A).toReal v ∧
       (∀ i, 0 < v i) := by
   sorry
--- ANCHOR_END: irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius
+-- ANCHOR_END: irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius__irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius
 
 end ProblemIrreducibleNonnegativeMatrixHasPositiveEigenvectorAtSpectralRadius
 
@@ -303,26 +303,26 @@ namespace ProblemExistsComplementaryPolynomialOnUnitCircle
 
 open Polynomial
 
--- ANCHOR: exists_complementary_polynomial_on_unit_circle
+-- ANCHOR: exists_complementary_polynomial_on_unit_circle__exists_complementary_polynomial_on_unit_circle
 theorem exists_complementary_polynomial_on_unit_circle (P : ℂ[X])
     (hP : ∀ z : Circle, ‖P.eval (z : ℂ)‖ ≤ 1) :
     ∃ Q : ℂ[X],
       Q.natDegree = P.natDegree ∧
         ∀ z : Circle, ‖P.eval (z : ℂ)‖ ^ 2 + ‖Q.eval (z : ℂ)‖ ^ 2 = 1 := by
   sorry
--- ANCHOR_END: exists_complementary_polynomial_on_unit_circle
+-- ANCHOR_END: exists_complementary_polynomial_on_unit_circle__exists_complementary_polynomial_on_unit_circle
 
 end ProblemExistsComplementaryPolynomialOnUnitCircle
 
 namespace ProblemIsStarNormalMulOfCommute
 
--- ANCHOR: isStarNormal_mul_of_commute
+-- ANCHOR: isStarNormal_mul_of_commute__isStarNormal_mul_of_commute
 theorem isStarNormal_mul_of_commute {A : Type*} [NonUnitalCStarAlgebra A]
     {a b : A} (ha : IsStarNormal a) (hb : IsStarNormal b)
     (hab : Commute a b) :
     IsStarNormal (a * b) := by
   sorry
--- ANCHOR_END: isStarNormal_mul_of_commute
+-- ANCHOR_END: isStarNormal_mul_of_commute__isStarNormal_mul_of_commute
 
 end ProblemIsStarNormalMulOfCommute
 
@@ -330,12 +330,12 @@ namespace ProblemPosSemidefMapExp
 
 open scoped MatrixOrder Matrix
 
--- ANCHOR: posSemidef_map_exp
+-- ANCHOR: posSemidef_map_exp__posSemidef_map_exp
 theorem posSemidef_map_exp {n : Type*} [Fintype n] [DecidableEq n]
     {A : Matrix n n ℝ} (hA : A.PosSemidef) :
     (A.map Real.exp).PosSemidef := by
   sorry
--- ANCHOR_END: posSemidef_map_exp
+-- ANCHOR_END: posSemidef_map_exp__posSemidef_map_exp
 
 end ProblemPosSemidefMapExp
 
@@ -343,18 +343,18 @@ namespace ProblemOppenheimInequality
 
 open scoped MatrixOrder Matrix
 
--- ANCHOR: oppenheim_inequality
+-- ANCHOR: oppenheim_inequality__oppenheim_inequality
 theorem oppenheim_inequality {n : Type*} [Fintype n] [DecidableEq n]
     {A B : Matrix n n ℝ} (hA : A.PosSemidef) (hB : B.PosSemidef) :
     A.det * ∏ i, B i i ≤ (A ⊙ B).det := by
   sorry
--- ANCHOR_END: oppenheim_inequality
+-- ANCHOR_END: oppenheim_inequality__oppenheim_inequality
 
 end ProblemOppenheimInequality
 
 namespace ProblemVonNeumannDoubleCommutantTfae
 
--- ANCHOR: vonNeumann_doubleCommutant_tfae
+-- ANCHOR: vonNeumann_doubleCommutant_tfae__vonNeumann_doubleCommutant_tfae
 theorem vonNeumann_doubleCommutant_tfae {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] [CompleteSpace H]
     (S : StarSubalgebra ℂ (H →L[ℂ] H)) :
     List.TFAE
@@ -365,7 +365,7 @@ theorem vonNeumann_doubleCommutant_tfae {H : Type*} [NormedAddCommGroup H] [Inne
           (ContinuousLinearMap.toPointwiseConvergenceCLM ℂ (RingHom.id ℂ) H H ''
             (S : Set (H →L[ℂ] H))) ] := by
   sorry
--- ANCHOR_END: vonNeumann_doubleCommutant_tfae
+-- ANCHOR_END: vonNeumann_doubleCommutant_tfae__vonNeumann_doubleCommutant_tfae
 
 end ProblemVonNeumannDoubleCommutantTfae
 
@@ -420,14 +420,14 @@ end LeanEval
 open LeanEval.RepresentationTheory
 open scoped TensorProduct
 
--- ANCHOR: symAction_range_eq_centralizer_glAction
+-- ANCHOR: symAction_range_eq_centralizer_glAction__symAction_range_eq_centralizer_glAction
 theorem symAction_range_eq_centralizer_glAction {R : Type*} [Field R]
     {M : Type*} [AddCommGroup M] [Module R M] [FiniteDimensional R M]
     {k : ℕ} [Invertible (k.factorial : R)] :
     Algebra.adjoin R (Set.range (LeanEval.RepresentationTheory.symAction R M k)) =
       Subalgebra.centralizer R (Set.range (LeanEval.RepresentationTheory.glAction R M k)) := by
   sorry
--- ANCHOR_END: symAction_range_eq_centralizer_glAction
+-- ANCHOR_END: symAction_range_eq_centralizer_glAction__symAction_range_eq_centralizer_glAction
 
 end ProblemSymActionRangeEqCentralizerGlAction
 
@@ -482,14 +482,14 @@ end LeanEval
 open LeanEval.RepresentationTheory
 open scoped TensorProduct
 
--- ANCHOR: glAction_range_eq_centralizer_symAction
+-- ANCHOR: glAction_range_eq_centralizer_symAction__glAction_range_eq_centralizer_symAction
 theorem glAction_range_eq_centralizer_symAction {R : Type*} [Field R]
     {M : Type*} [AddCommGroup M] [Module R M] [FiniteDimensional R M]
     {k : ℕ} [Invertible (k.factorial : R)] :
     Algebra.adjoin R (Set.range (LeanEval.RepresentationTheory.glAction R M k)) =
       Subalgebra.centralizer R (Set.range (LeanEval.RepresentationTheory.symAction R M k)) := by
   sorry
--- ANCHOR_END: glAction_range_eq_centralizer_symAction
+-- ANCHOR_END: glAction_range_eq_centralizer_symAction__glAction_range_eq_centralizer_symAction
 
 end ProblemGlActionRangeEqCentralizerSymAction
 
@@ -544,7 +544,7 @@ end LeanEval
 open LeanEval.RepresentationTheory
 open scoped TensorProduct
 
--- ANCHOR: g2_irrep_tensor_square_decomp
+-- ANCHOR: g2_irrep_tensor_square_decomp__g2_irrep_tensor_square_decomp
 theorem g2_irrep_tensor_square_decomp :
     ∃ (V : Type) (_ : AddCommGroup V) (_ : Module ℂ V)
       (_ : LieRingModule (LieAlgebra.g₂ ℂ) V) (_ : LieModule ℂ (LieAlgebra.g₂ ℂ) V),
@@ -553,7 +553,7 @@ theorem g2_irrep_tensor_square_decomp :
       (isotypicComponents (UniversalEnvelopingAlgebra ℂ (LieAlgebra.g₂ ℂ))
         (V ⊗[ℂ] V)).ncard = 14 := by
   sorry
--- ANCHOR_END: g2_irrep_tensor_square_decomp
+-- ANCHOR_END: g2_irrep_tensor_square_decomp__g2_irrep_tensor_square_decomp
 
 end ProblemG2IrrepTensorSquareDecomp
 
@@ -608,7 +608,7 @@ end LeanEval
 open LeanEval.RepresentationTheory
 open scoped TensorProduct
 
--- ANCHOR: e8_irrep_tensor_square_decomp
+-- ANCHOR: e8_irrep_tensor_square_decomp__e8_irrep_tensor_square_decomp
 theorem e8_irrep_tensor_square_decomp :
     ∃ (V : Type) (_ : AddCommGroup V) (_ : Module ℂ V)
       (_ : LieRingModule (LieAlgebra.e₈ ℂ) V) (_ : LieModule ℂ (LieAlgebra.e₈ ℂ) V),
@@ -617,7 +617,7 @@ theorem e8_irrep_tensor_square_decomp :
       (isotypicComponents (UniversalEnvelopingAlgebra ℂ (LieAlgebra.e₈ ℂ))
         (V ⊗[ℂ] V)).ncard = 40 := by
   sorry
--- ANCHOR_END: e8_irrep_tensor_square_decomp
+-- ANCHOR_END: e8_irrep_tensor_square_decomp__e8_irrep_tensor_square_decomp
 
 end ProblemE8IrrepTensorSquareDecomp
 
@@ -626,7 +626,7 @@ namespace ProblemCerfGammaFour
 open scoped Manifold ContDiff
 open Metric (sphere)
 
--- ANCHOR: cerf_gamma_four
+-- ANCHOR: cerf_gamma_four__cerf_gamma_four
 theorem cerf_gamma_four (f : sphere (0 : EuclideanSpace ℝ (Fin 4)) 1 ≃ₘ⟮𝓡 3, 𝓡 3⟯
          sphere (0 : EuclideanSpace ℝ (Fin 4)) 1) :
     ∃ (A : Matrix.orthogonalGroup (Fin 4) ℝ)
@@ -641,7 +641,7 @@ theorem cerf_gamma_four (f : sphere (0 : EuclideanSpace ℝ (Fin 4)) 1 ≃ₘ⟮
             Matrix.UnitaryGroup.toLinearEquiv A
               (p : EuclideanSpace ℝ (Fin 4))) := by
   sorry
--- ANCHOR_END: cerf_gamma_four
+-- ANCHOR_END: cerf_gamma_four__cerf_gamma_four
 
 end ProblemCerfGammaFour
 
@@ -650,7 +650,7 @@ namespace ProblemSmaleConjecture
 open scoped Manifold ContDiff
 open Metric (sphere)
 
--- ANCHOR: smale_conjecture
+-- ANCHOR: smale_conjecture__smale_conjecture
 theorem smale_conjecture {n : ℕ} [NeZero n]
     (X : Type) [TopologicalSpace X] [T2Space X] [SecondCountableTopology X]
     [ChartedSpace (EuclideanHalfSpace n) X] [IsManifold (𝓡∂ n) ∞ X]
@@ -687,7 +687,7 @@ theorem smale_conjecture {n : ℕ} [NeZero n]
          (p : sphere (0 : EuclideanSpace ℝ (Fin 4)) 1),
               H ((b : X), t, p) = F ((b : X), p)) := by
   sorry
--- ANCHOR_END: smale_conjecture
+-- ANCHOR_END: smale_conjecture__smale_conjecture
 
 end ProblemSmaleConjecture
 
@@ -695,7 +695,7 @@ namespace ProblemCyclotomicIntegerHouseLeTwo
 
 open NumberField
 
--- ANCHOR: cyclotomic_integer_house_le_two
+-- ANCHOR: cyclotomic_integer_house_le_two__cyclotomic_integer_house_le_two
 theorem cyclotomic_integer_house_le_two {K : Type*} [Field K] [NumberField K] [Algebra ℚ K]
     (n : ℕ) [NeZero n] [IsCyclotomicExtension {n} ℚ K] {β : K}
     (hβ_int : IsIntegral ℤ β)
@@ -703,7 +703,7 @@ theorem cyclotomic_integer_house_le_two {K : Type*} [Field K] [NumberField K] [A
     house β ≤ 2 →
       house β = 2 ∨ ∃ m : ℕ, 0 < m ∧ house β = 2 * Real.cos (Real.pi / m) := by
   sorry
--- ANCHOR_END: cyclotomic_integer_house_le_two
+-- ANCHOR_END: cyclotomic_integer_house_le_two__cyclotomic_integer_house_le_two
 
 end ProblemCyclotomicIntegerHouseLeTwo
 
@@ -711,7 +711,7 @@ namespace ProblemCyclotomicIntegerHouseBetweenTwoAnd7633
 
 open NumberField
 
--- ANCHOR: cyclotomic_integer_house_between_two_and_76_33
+-- ANCHOR: cyclotomic_integer_house_between_two_and_76_33__cyclotomic_integer_house_between_two_and_76_33
 theorem cyclotomic_integer_house_between_two_and_76_33 {K : Type*} [Field K] [NumberField K] [Algebra ℚ K]
     (n : ℕ) [NeZero n] [IsCyclotomicExtension {n} ℚ K] {β : K}
     (hβ_int : IsIntegral ℤ β)
@@ -723,7 +723,7 @@ theorem cyclotomic_integer_house_between_two_and_76_33 {K : Type*} [Field K] [Nu
       house β = (1 + Real.sqrt 5) / Real.sqrt 2 ∨
       house β = (1 + Real.sqrt 13) / 2 := by
   sorry
--- ANCHOR_END: cyclotomic_integer_house_between_two_and_76_33
+-- ANCHOR_END: cyclotomic_integer_house_between_two_and_76_33__cyclotomic_integer_house_between_two_and_76_33
 
 end ProblemCyclotomicIntegerHouseBetweenTwoAnd7633
 
@@ -783,7 +783,7 @@ end LeanEval
 
 open LeanEval.Analysis
 
--- ANCHOR: gleason_theorem_finite
+-- ANCHOR: gleason_theorem_finite__gleason_theorem_finite
 theorem gleason_theorem_finite {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
       [CompleteSpace H] [FiniteDimensional ℂ H]
     (hdim : 3 ≤ Module.finrank ℂ H)
@@ -793,7 +793,7 @@ theorem gleason_theorem_finite {H : Type*} [NormedAddCommGroup H] [InnerProductS
       reTr ρ = 1 ∧
       ∀ P : H →L[ℂ] H, LeanEval.Analysis.IsOrthProj P → f.μ P = reTr (ρ * P) := by
   sorry
--- ANCHOR_END: gleason_theorem_finite
+-- ANCHOR_END: gleason_theorem_finite__gleason_theorem_finite
 
 end ProblemGleasonTheoremFinite
 
@@ -845,7 +845,7 @@ end LeanEval
 
 open LeanEval.Analysis
 
--- ANCHOR: gleason_theorem_separable
+-- ANCHOR: gleason_theorem_separable__gleason_theorem_separable
 theorem gleason_theorem_separable {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H]
       [CompleteSpace H] [TopologicalSpace.SeparableSpace H]
     (hdim : 3 ≤ Module.rank ℂ H)
@@ -855,6 +855,380 @@ theorem gleason_theorem_separable {H : Type*} [NormedAddCommGroup H] [InnerProdu
       ∀ x : Metric.sphere (0 : H) 1,
         f.f x = (inner ℂ (x : H) (ρ (x : H))).re := by
   sorry
--- ANCHOR_END: gleason_theorem_separable
+-- ANCHOR_END: gleason_theorem_separable__gleason_theorem_separable
 
 end ProblemGleasonTheoremSeparable
+
+namespace ProblemJacobianChallengeDiffgeo
+
+/-!
+# Jacobians of compact Riemann surfaces
+
+Kevin Buzzard's "Jacobian Challenge" v0.3, posted to leanprover Zulip
+(`#Autoformalization > Jacobian challenge`):
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge>.
+The original source uses anonymous instances; here every `instance` is
+named explicitly so the eval-problem pipeline can address it.
+
+## Main missing definitions
+
+* `genus` -- genus of a compact Riemann surface
+* `Jacobian` -- the Jacobian of a compact Riemann surface
+* `Jacobian.ofCurve` -- the Abel-Jacobi map from a compact Riemann surface to its Jacobian
+* `ContMDiff.degree` -- the degree of a holomorphic map between compact Riemann surfaces.
+    Equal to 0 if the map is constant, otherwise equal to the usual degree.
+* `Jacobian.pushforward` -- the pushforward map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+* `Jacobian.pullback` -- the pullback map on Jacobians induced by a holomorphic map between
+  compact Riemann surfaces.
+
+## Main missing theorems
+
+* `genus_eq_zero_iff_homeo` -- a compact Riemann surface has genus 0 iff it is homeomorphic to the sphere
+* `ofCurve_inj` -- the Abel-Jacobi map is injective iff the genus is positive
+* `Jacobian.ofCurve_contMDiff` -- the Abel-Jacobi map is holomorphic
+* `Jacobian.pushforward_contMDiff` -- the pushforward map is holomorphic
+* `Jacobian.pullback_contMDiff` -- the pullback map is holomorphic
+* `pushforward_pullback` -- pullback then pushforward is multiplication by degree
+-/
+
+open scoped ContDiff -- for ω notation
+
+namespace JacobianChallenge
+
+universe u v w
+
+-- let X be a compact Riemann surface
+variable {X : Type u} [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+  [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X]
+
+-- data
+-- ANCHOR: jacobian_challenge_diffgeo__genus
+def genus (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : ℕ := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__genus
+
+-- this proof avoids the hack answer `∀ X, genus X = 0`
+-- Prop
+-- ANCHOR: jacobian_challenge_diffgeo__genus_eq_zero_iff_homeo
+theorem genus_eq_zero_iff_homeo :
+    genus X = 0 ↔ Nonempty (X ≃ₜ (Metric.sphere (0 : EuclideanSpace ℝ (Fin 3)) 1)) :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__genus_eq_zero_iff_homeo
+
+-- data
+-- ANCHOR: jacobian_challenge_diffgeo__Jacobian
+def Jacobian (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]
+    [Nonempty X] [ChartedSpace ℂ X] [IsManifold (modelWithCornersSelf ℂ ℂ) ω X] : Type u := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__Jacobian
+
+namespace Jacobian
+
+-- data
+-- ANCHOR: jacobian_challenge_diffgeo__instAddCommGroup
+instance instAddCommGroup : AddCommGroup (Jacobian X) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__instAddCommGroup
+
+-- data
+-- ANCHOR: jacobian_challenge_diffgeo__instTopologicalSpace
+instance instTopologicalSpace : TopologicalSpace (Jacobian X) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__instTopologicalSpace
+
+-- Prop
+-- ANCHOR: jacobian_challenge_diffgeo__instT2Space
+instance instT2Space : T2Space (Jacobian X) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__instT2Space
+
+-- Prop
+-- ANCHOR: jacobian_challenge_diffgeo__instCompactSpace
+instance instCompactSpace : CompactSpace (Jacobian X) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__instCompactSpace
+-- ANCHOR: jacobian_challenge_diffgeo__instChartedSpace
+instance instChartedSpace : ChartedSpace (Fin (genus X) → ℂ) (Jacobian X) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__instChartedSpace
+
+-- Prop
+-- ANCHOR: jacobian_challenge_diffgeo__instIsManifold
+instance instIsManifold :
+    IsManifold (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__instIsManifold
+
+-- Prop
+-- ANCHOR: jacobian_challenge_diffgeo__instLieAddGroup
+instance instLieAddGroup :
+    LieAddGroup (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (Jacobian X) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__instLieAddGroup
+-- ANCHOR: jacobian_challenge_diffgeo__ofCurve
+def ofCurve (P : X) : X → Jacobian X := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__ofCurve
+-- ANCHOR: jacobian_challenge_diffgeo__ofCurve_contMDiff
+theorem ofCurve_contMDiff (P : X) :
+    ContMDiff (modelWithCornersSelf ℂ ℂ)
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (ofCurve P) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__ofCurve_contMDiff
+-- ANCHOR: jacobian_challenge_diffgeo__ofCurve_self
+theorem ofCurve_self (P : X) : ofCurve P P = 0 := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__ofCurve_self
+
+-- this is the lemma which stops the hack answer "J(X)=0 for all X"
+-- ANCHOR: jacobian_challenge_diffgeo__ofCurve_inj
+theorem ofCurve_inj (P : X) (h : 0 < genus X) : Function.Injective (ofCurve P) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__ofCurve_inj
+
+variable {Y : Type v} [TopologicalSpace Y] [T2Space Y] [CompactSpace Y] [ConnectedSpace Y]
+  [Nonempty Y] [ChartedSpace ℂ Y] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Y]
+
+variable (f : X → Y) (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+-- ANCHOR: jacobian_challenge_diffgeo__pushforward
+def pushforward (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian X →ₜ+ Jacobian Y := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pushforward
+-- ANCHOR: jacobian_challenge_diffgeo__pushforward_contMDiff
+theorem pushforward_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus X) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ)) ω (pushforward f hf) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pushforward_contMDiff
+
+-- functoriality
+-- ANCHOR: jacobian_challenge_diffgeo__pushforward_id_apply
+theorem pushforward_id_apply (P : Jacobian X) :
+    pushforward id contMDiff_id P = P := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pushforward_id_apply
+
+variable {Z : Type w} [TopologicalSpace Z] [T2Space Z] [CompactSpace Z] [ConnectedSpace Z]
+  [Nonempty Z] [ChartedSpace ℂ Z] [IsManifold (modelWithCornersSelf ℂ ℂ) ω Z]
+
+variable (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+-- ANCHOR: jacobian_challenge_diffgeo__pushforward_comp_apply
+theorem pushforward_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian X) :
+    pushforward (g ∘ f) (hg.comp hf) P = pushforward g hg (pushforward f hf P) :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pushforward_comp_apply
+
+-- if f is constant then the pullback should be the zero map, otherwise it's
+-- the usual pullback
+-- ANCHOR: jacobian_challenge_diffgeo__pullback
+def pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    Jacobian Y →ₜ+ Jacobian X := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pullback
+-- ANCHOR: jacobian_challenge_diffgeo__pullback_contMDiff
+theorem pullback_contMDiff (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) :
+    ContMDiff (modelWithCornersSelf ℂ (Fin (genus Y) → ℂ))
+      (modelWithCornersSelf ℂ (Fin (genus X) → ℂ)) ω (pullback f hf) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pullback_contMDiff
+-- ANCHOR: jacobian_challenge_diffgeo__pullback_id_apply
+theorem pullback_id_apply (P : Jacobian X) :
+    pullback id contMDiff_id P = P := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pullback_id_apply
+-- ANCHOR: jacobian_challenge_diffgeo__pullback_comp_apply
+theorem pullback_comp_apply (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (g : Y → Z) (hg : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω g)
+    (P : Jacobian Z) :
+    pullback (g.comp f) (hg.comp hf) P = pullback f hf (pullback g hg P) := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pullback_comp_apply
+-- ANCHOR: jacobian_challenge_diffgeo__degree
+def degree (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) : ℕ :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__degree -- 0 for constant case
+-- ANCHOR: jacobian_challenge_diffgeo__pushforward_pullback
+theorem pushforward_pullback (f : X → Y)
+    (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)
+    (P : Jacobian Y) :
+    pushforward f hf (pullback f hf P) = (degree f hf) • P := sorry
+-- ANCHOR_END: jacobian_challenge_diffgeo__pushforward_pullback
+
+end Jacobian
+
+end JacobianChallenge
+
+end ProblemJacobianChallengeDiffgeo
+
+namespace ProblemJacobianChallengeAlggeo
+
+/-
+Copyright (c) 2026 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+/-!
+# Jacobians in algebraic geometry
+
+Christian Merten's algebraic-geometry analogue of Kevin Buzzard's Jacobian
+challenge, posted to leanprover Zulip:
+<https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge/near/587802685>.
+
+In the following, by a smooth curve we mean a geometrically irreducible, smooth scheme of relative
+dimension one over a field.
+
+## Main missing definitions
+
+* `AlgebraicGeometry.JacobianChallenge.genus` -- genus of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian` -- the Jacobian of a proper, smooth curve
+* `AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve` -- the Abel-Jacobi map from a proper smooth
+  curve to its Jacobian
+
+## Main missing theorems
+
+* `Jacobian.smoothOfRelativeDimension_genus` -- The Jacobian of a proper, smooth curve `C` is smooth
+  of relative dimension `g`, where `g` is the genus of `C`.
+* `Jacobian.exists_unique_ofCurve_comp` -- the universal property of the Jacobian of a proper,
+  smooth curve.
+-/
+
+set_option autoImplicit false
+
+universe u
+
+open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory MonObj
+
+namespace AlgebraicGeometry
+
+namespace JacobianChallenge
+
+-- We make `C` implicit at the variable level so that instance and `def` holes
+-- whose statement references the outer `C` (e.g. `instance instGrpObj :
+-- GrpObj (Jacobian C) := sorry`) elaborate to a Π-type with `{C}` implicit;
+-- otherwise the eval-pipeline's `Solution.lean` would have to thread a `C`
+-- argument through every delegation. Decls that genuinely need `C` explicit
+-- (e.g. `genus`, `Jacobian`, `comp_ofCurve`) supply their own `(C : ...)`
+-- binder.
+variable {k : Type u} [Field k] {C : Over (Spec (.of k))}
+  -- smooth curve
+  [SmoothOfRelativeDimension 1 C.hom]
+  -- proper
+  [IsProper C.hom]
+  -- geometrically irreducible
+  [GeometricallyIrreducible C.hom]
+
+-- data
+-- ANCHOR: jacobian_challenge_alggeo__genus
+/-- The genus of a smooth proper curve. -/
+def genus (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : ℕ :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__genus
+
+-- data
+-- ANCHOR: jacobian_challenge_alggeo__Jacobian
+/-- The Jacobian of a smooth, proper curve over a field `k`. -/
+def Jacobian (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]
+    [GeometricallyIrreducible C.hom] : Over (Spec (.of k)) :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__Jacobian
+
+namespace Jacobian
+
+/-! ## The Jacobian of `C` is an abelian variety. -/
+
+-- data
+-- ANCHOR: jacobian_challenge_alggeo__instGrpObj
+/-- The group scheme structure on the Jacobian of the curve `C`. -/
+instance instGrpObj : GrpObj (Jacobian C) :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__instGrpObj
+
+-- ANCHOR: jacobian_challenge_alggeo__smoothOfRelativeDimension_genus
+/-- The Jacobian of `C` is smooth of relative dimension `g` over `k`, where `g` is the
+genus of `C`. -/
+instance smoothOfRelativeDimension_genus :
+    SmoothOfRelativeDimension (genus C) (Jacobian C).hom :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__smoothOfRelativeDimension_genus
+
+-- ANCHOR: jacobian_challenge_alggeo__instIsProper
+/-- The Jacobian of `C` is proper over `k`. -/
+instance instIsProper : IsProper (Jacobian C).hom :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__instIsProper
+
+-- ANCHOR: jacobian_challenge_alggeo__instGeometricallyIrreducible
+/-- The Jacobian of `C` is geometrically irreducible over `k`. -/
+instance instGeometricallyIrreducible : GeometricallyIrreducible (Jacobian C).hom :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__instGeometricallyIrreducible
+
+-- data
+-- ANCHOR: jacobian_challenge_alggeo__ofCurve
+/-- The Abel-Jacobi map from a smooth, proper curve to its Jacobian associated
+to a `k`-rational point of `C`. -/
+def ofCurve (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) : C ⟶ Jacobian C :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__ofCurve
+
+-- ANCHOR: jacobian_challenge_alggeo__comp_ofCurve
+/-- The Abel-Jacobi map sends the `k`-rational point `P` to `0`, where `0` (denoted by `η` below) is
+the neutral element of the group scheme `Jacobian C`. -/
+theorem comp_ofCurve (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C) :
+    P ≫ ofCurve P = η[Jacobian C] :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__comp_ofCurve
+
+-- ANCHOR: jacobian_challenge_alggeo__exists_unique_ofCurve_comp
+/--
+The universal property of the Jacobian variety: For any abelian variety `A`,
+any morphism `f : C ⟶ A` such that `f(P) = 0` factors uniquely through the
+Jacobian of `C`.
+In other words, `Jacobian C` is the Albanese variety of `C`.
+-/
+theorem exists_unique_ofCurve_comp (C : Over (Spec (.of k))) [IsProper C.hom]
+    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]
+    (P : 𝟙_ (Over (Spec (.of k))) ⟶ C)
+    {A : Over (Spec (.of k))} [Smooth A.hom] [IsProper A.hom] [GrpObj A]
+    [GeometricallyIrreducible A.hom] (f : C ⟶ A) (hf : P ≫ f = η[A]) :
+    ∃! (g : Jacobian C ⟶ A), f = ofCurve P ≫ g :=
+  sorry
+-- ANCHOR_END: jacobian_challenge_alggeo__exists_unique_ofCurve_comp
+
+end Jacobian
+
+end JacobianChallenge
+
+end AlgebraicGeometry
+
+end ProblemJacobianChallengeAlggeo
+
+namespace ProblemDefHoleExample
+
+/-!
+Minimal example exercising the def-hole / multi-hole eval-problem pipeline.
+
+A `def` and a `theorem` referring to it, both `sorry`. A submission
+defines `Submission.foo := 37` and proves `Submission.foo_def`; comparator
+should accept it.
+-/
+-- ANCHOR: def_hole_example__foo
+def foo : Nat := sorry
+-- ANCHOR_END: def_hole_example__foo
+-- ANCHOR: def_hole_example__foo_def
+theorem foo_def : foo = 37 := sorry
+-- ANCHOR_END: def_hole_example__foo_def
+
+end ProblemDefHoleExample
+
+namespace ProblemInstanceHoleExample
+
+/-!
+Minimal example exercising `instance` holes in the multi-hole
+eval-problem pipeline. The carrier type is itself a hole so the source
+has no non-hole declarations and the generator does not need a
+`ChallengeDeps` split.
+-/
+-- ANCHOR: instance_hole_example__WidgetCarrier
+def WidgetCarrier : Type := sorry
+-- ANCHOR_END: instance_hole_example__WidgetCarrier
+-- ANCHOR: instance_hole_example__instInhabitedWidget
+instance instInhabitedWidget : Inhabited WidgetCarrier := sorry
+-- ANCHOR_END: instance_hole_example__instInhabitedWidget
+
+end ProblemInstanceHoleExample

--- a/benchmark-snapshot/BenchmarkProblems/Catalog.lean
+++ b/benchmark-snapshot/BenchmarkProblems/Catalog.lean
@@ -859,8 +859,6 @@ theorem gleason_theorem_separable {H : Type*} [NormedAddCommGroup H] [InnerProdu
 
 end ProblemGleasonTheoremSeparable
 
-namespace ProblemJacobianChallengeDiffgeo
-
 /-!
 # Jacobians of compact Riemann surfaces
 
@@ -1050,10 +1048,6 @@ end Jacobian
 
 end JacobianChallenge
 
-end ProblemJacobianChallengeDiffgeo
-
-namespace ProblemJacobianChallengeAlggeo
-
 /-
 Copyright (c) 2026 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
@@ -1196,10 +1190,6 @@ end JacobianChallenge
 
 end AlgebraicGeometry
 
-end ProblemJacobianChallengeAlggeo
-
-namespace ProblemDefHoleExample
-
 /-!
 Minimal example exercising the def-hole / multi-hole eval-problem pipeline.
 
@@ -1214,10 +1204,6 @@ def foo : Nat := sorry
 theorem foo_def : foo = 37 := sorry
 -- ANCHOR_END: def_hole_example__foo_def
 
-end ProblemDefHoleExample
-
-namespace ProblemInstanceHoleExample
-
 /-!
 Minimal example exercising `instance` holes in the multi-hole
 eval-problem pipeline. The carrier type is itself a hole so the source
@@ -1230,5 +1216,3 @@ def WidgetCarrier : Type := sorry
 -- ANCHOR: instance_hole_example__instInhabitedWidget
 instance instInhabitedWidget : Inhabited WidgetCarrier := sorry
 -- ANCHOR_END: instance_hole_example__instInhabitedWidget
-
-end ProblemInstanceHoleExample

--- a/benchmark-snapshot/BenchmarkProblems/Catalog.lean
+++ b/benchmark-snapshot/BenchmarkProblems/Catalog.lean
@@ -1035,8 +1035,8 @@ theorem pullback_comp_apply (f : X → Y)
 -- ANCHOR: jacobian_challenge_diffgeo__degree
 def degree (f : X → Y)
     (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f) : ℕ :=
-  sorry
--- ANCHOR_END: jacobian_challenge_diffgeo__degree -- 0 for constant case
+  sorry -- 0 for constant case
+-- ANCHOR_END: jacobian_challenge_diffgeo__degree
 -- ANCHOR: jacobian_challenge_diffgeo__pushforward_pullback
 theorem pushforward_pullback (f : X → Y)
     (hf : ContMDiff (modelWithCornersSelf ℂ ℂ) (modelWithCornersSelf ℂ ℂ) ω f)

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -365,15 +365,30 @@ def write_benchmark_snapshot(benchmark_repo: pathlib.Path, problems: list[Proble
         for line in imports:
             if line not in module_imports:
                 module_imports.append(line)
-        namespace = snapshot_namespace(problem)
-        module_lines.append(f"namespace {namespace}")
-        module_lines.append("")
-        for fragment in fragments:
-            if fragment:
-                module_lines.append(fragment)
-                module_lines.append("")
-        module_lines.append(f"end {namespace}")
-        module_lines.append("")
+        # Legacy single-theorem problems get a per-problem `namespace
+        # Problem<CamelId>` wrap so their `ChallengeDeps`-derived helpers
+        # (often in shared namespaces like `Foo.bar`) don't collide
+        # across problems. Multi-hole problems instead reproduce the
+        # source module's full namespace structure verbatim, which both
+        # gives the bodies the original namespace context they need to
+        # type-check (e.g. references to `Spec` inside `namespace
+        # AlgebraicGeometry`) and isolates each problem under its
+        # original module's logical namespace path.
+        if is_legacy_single_theorem(problem):
+            namespace = snapshot_namespace(problem)
+            module_lines.append(f"namespace {namespace}")
+            module_lines.append("")
+            for fragment in fragments:
+                if fragment:
+                    module_lines.append(fragment)
+                    module_lines.append("")
+            module_lines.append(f"end {namespace}")
+            module_lines.append("")
+        else:
+            for fragment in fragments:
+                if fragment:
+                    module_lines.append(fragment)
+                    module_lines.append("")
 
     catalog_path = BENCHMARK_SNAPSHOT_ROOT / "BenchmarkProblems" / "Catalog.lean"
     write_text(catalog_path, "\n".join(module_imports + [""] + module_lines).rstrip() + "\n")

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -281,7 +281,11 @@ def inject_multi_hole_anchor(problem: Problem, hole: Hole, source_text: str) -> 
 
     For multi-hole problems the per-hole `body` string is a verbatim
     substring of the generated `Challenge.lean`, so plain string search
-    suffices and we don't need to keyword-match across kinds."""
+    suffices and we don't need to keyword-match across kinds. Extend the
+    captured span to end-of-line so any trailing same-line `-- ...`
+    inline comments end up inside the anchor wrap rather than on the
+    closing marker line (which subverso parses as part of the anchor
+    name)."""
     aid = anchor_id(problem.id, hole)
     idx = source_text.find(hole.body)
     if idx < 0:
@@ -289,12 +293,16 @@ def inject_multi_hole_anchor(problem: Problem, hole: Hole, source_text: str) -> 
             f"Could not locate hole body for {problem.id}::{hole.basename} "
             f"in Challenge.lean — `body` field in holes.json must be a substring of the generated Challenge.lean."
         )
+    end_idx = idx + len(hole.body)
+    nl = source_text.find("\n", end_idx)
+    if nl != -1:
+        end_idx = nl
     return (
         source_text[:idx]
         + f"-- ANCHOR: {aid}\n"
-        + hole.body
+        + source_text[idx:end_idx]
         + f"\n-- ANCHOR_END: {aid}"
-        + source_text[idx + len(hole.body):]
+        + source_text[end_idx:]
     )
 
 

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -22,7 +22,14 @@ BENCHMARK_SNAPSHOT_ROOT = REPO_ROOT / "benchmark-snapshot"
 DEFAULT_BENCHMARK_REPO = pathlib.Path(
     os.environ.get("LEAN_EVAL_BENCHMARK_REPO", str(REPO_ROOT.parent / "lean-evals"))
 )
-THEOREM_PATTERN = r"(?:^|\s)theorem\s+{name}\b(?P<body>.*?)(?:\s*:=\s*by\b)"
+
+
+@dataclass(frozen=True)
+class Hole:
+    name: str
+    basename: str
+    kind: str
+    body: str
 
 
 @dataclass(frozen=True)
@@ -32,11 +39,10 @@ class Problem:
     test: bool
     submitter: str
     module: str
-    theorem: str
     notes: str | None
     source: str | None
     informal_solution: str | None
-    statement: str
+    holes: tuple[Hole, ...]
     challenge_path: str
     sort_index: int
 
@@ -69,40 +75,49 @@ def load_json(path: pathlib.Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def load_holes(benchmark_repo: pathlib.Path, problem_id: str) -> tuple[Hole, ...]:
+    """Read `generated/<id>/holes.json` and return the per-hole metadata."""
+    path = benchmark_repo / "generated" / problem_id / "holes.json"
+    if not path.is_file():
+        raise SystemExit(
+            f"holes.json not found for problem '{problem_id}': {path}. "
+            f"Re-run `python scripts/generate_projects.py` in the benchmark repo "
+            f"to publish per-hole metadata."
+        )
+    payload = load_json(path)
+    holes = []
+    for raw in payload["holes"]:
+        holes.append(Hole(
+            name=str(raw["name"]),
+            basename=str(raw["basename"]),
+            kind=str(raw["kind"]),
+            body=str(raw["body"]),
+        ))
+    return tuple(holes)
+
+
 def load_manifest(manifest_path: pathlib.Path, benchmark_repo: pathlib.Path) -> list[Problem]:
     data = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
     problems: list[Problem] = []
     for index, raw in enumerate(data["problem"]):
-        statement = extract_statement(
-            benchmark_repo / pathlib.Path(*str(raw["module"]).split(".")).with_suffix(".lean"),
-            str(raw["theorem"]).rsplit(".", maxsplit=1)[-1],
-        )
+        problem_id = str(raw["id"])
+        holes = load_holes(benchmark_repo, problem_id)
         problems.append(
             Problem(
-                id=str(raw["id"]),
+                id=problem_id,
                 title=str(raw["title"]),
                 test=bool(raw.get("test", False)),
                 submitter=str(raw["submitter"]),
                 module=str(raw["module"]),
-                theorem=str(raw["theorem"]),
                 notes=str(raw["notes"]).strip() if raw.get("notes") else None,
                 source=str(raw["source"]).strip() if raw.get("source") else None,
                 informal_solution=str(raw["informal_solution"]).strip() if raw.get("informal_solution") else None,
-                statement=statement,
-                challenge_path=f"generated/{raw['id']}",
+                holes=holes,
+                challenge_path=f"generated/{problem_id}",
                 sort_index=index,
             )
         )
     return problems
-
-
-def extract_statement(source_path: pathlib.Path, theorem_name: str) -> str:
-    text = source_path.read_text(encoding="utf-8")
-    pattern = re.compile(THEOREM_PATTERN.format(name=re.escape(theorem_name)), re.DOTALL)
-    match = pattern.search(text)
-    if not match:
-        return ""
-    return match.group("body").strip()
 
 
 def write_json(path: pathlib.Path, payload: Any) -> None:
@@ -171,15 +186,20 @@ def generated_problem_root(benchmark_repo: pathlib.Path, problem: Problem) -> pa
 
 
 def strip_imports(text: str) -> tuple[list[str], list[str]]:
+    """Pull every `import ...` line out of `text`, regardless of position.
+
+    The multi-hole `Challenge.lean` may contain `import` lines interleaved
+    with the source module's copyright comment block, so we cannot rely on
+    a contiguous header run. Lean only accepts imports at the top of a
+    file anyway, so removing them globally and re-emitting them at the
+    catalog's top is safe."""
     imports: list[str] = []
     body: list[str] = []
-    in_imports = True
     for line in text.splitlines():
-        if in_imports and line.startswith("import "):
+        if line.startswith("import "):
             imports.append(line)
-            continue
-        in_imports = False
-        body.append(line)
+        else:
+            body.append(line)
     return imports, body
 
 
@@ -216,11 +236,16 @@ def collect_local_declarations(lines: list[str]) -> dict[str, str]:
     return declarations
 
 
-def qualify_theorem_text(problem: Problem, theorem_text: str, local_declarations: dict[str, str]) -> str:
-    theorem_name = problem.theorem.rsplit(".", maxsplit=1)[-1]
+def qualify_theorem_text(theorem_text: str, theorem_basename: str, local_declarations: dict[str, str]) -> str:
+    """Rewrite short references in a theorem body to fully-qualified forms.
+
+    Used only on the legacy single-theorem path, where the theorem body
+    references same-module helpers via short names but the helpers will
+    live inside our per-problem `Problem<CamelId>` namespace at the
+    catalog level."""
     qualified = theorem_text
     for short_name, full_name in sorted(local_declarations.items(), key=lambda item: len(item[0]), reverse=True):
-        if short_name == theorem_name:
+        if short_name == theorem_basename:
             continue
         qualified = re.sub(
             rf"(?<![A-Za-z0-9_.']){re.escape(short_name)}\b",
@@ -230,25 +255,60 @@ def qualify_theorem_text(problem: Problem, theorem_text: str, local_declarations
     return qualified
 
 
-def inject_anchor(problem: Problem, theorem_text: str) -> tuple[str, str]:
-    theorem_name = problem.theorem.rsplit(".", maxsplit=1)[-1]
+def anchor_id(problem_id: str, hole: Hole) -> str:
+    return f"{problem_id}__{hole.basename}"
+
+
+def inject_legacy_theorem_anchor(problem: Problem, hole: Hole, theorem_text: str) -> str:
     pattern = re.compile(
-        rf"(?ms)^theorem\s+{re.escape(theorem_name)}\b.*?^\s*sorry\s*$"
+        rf"(?ms)^theorem\s+{re.escape(hole.basename)}\b.*?^\s*sorry\s*$"
     )
     match = pattern.search(theorem_text)
     if not match:
-        raise SystemExit(f"Could not find theorem block for {problem.id}")
-    anchored = (
+        raise SystemExit(f"Could not find theorem block for {problem.id}::{hole.basename}")
+    aid = anchor_id(problem.id, hole)
+    return (
         theorem_text[:match.start()]
-        + f"-- ANCHOR: {problem.id}\n"
+        + f"-- ANCHOR: {aid}\n"
         + match.group(0)
-        + f"\n-- ANCHOR_END: {problem.id}"
+        + f"\n-- ANCHOR_END: {aid}"
         + theorem_text[match.end():]
     )
-    return anchored, match.group(0).rstrip()
 
 
-def build_problem_fragment(problem: Problem, benchmark_repo: pathlib.Path) -> tuple[list[str], list[str], str]:
+def inject_multi_hole_anchor(problem: Problem, hole: Hole, source_text: str) -> str:
+    """Wrap a hole's body inline with `-- ANCHOR: <id>__<basename>` markers.
+
+    For multi-hole problems the per-hole `body` string is a verbatim
+    substring of the generated `Challenge.lean`, so plain string search
+    suffices and we don't need to keyword-match across kinds."""
+    aid = anchor_id(problem.id, hole)
+    idx = source_text.find(hole.body)
+    if idx < 0:
+        raise SystemExit(
+            f"Could not locate hole body for {problem.id}::{hole.basename} "
+            f"in Challenge.lean — `body` field in holes.json must be a substring of the generated Challenge.lean."
+        )
+    return (
+        source_text[:idx]
+        + f"-- ANCHOR: {aid}\n"
+        + hole.body
+        + f"\n-- ANCHOR_END: {aid}"
+        + source_text[idx + len(hole.body):]
+    )
+
+
+def is_legacy_single_theorem(problem: Problem) -> bool:
+    return len(problem.holes) == 1 and problem.holes[0].kind == "theorem"
+
+
+def build_problem_fragment(problem: Problem, benchmark_repo: pathlib.Path) -> tuple[list[str], list[str]]:
+    """Build a per-problem catalog fragment.
+
+    Returns `(imports, body_parts)` where `body_parts` are concatenated
+    inside the problem's `namespace Problem<CamelId>` block. The fragment
+    contains one `-- ANCHOR: <id>__<basename>` block per hole, in source
+    order."""
     root = generated_problem_root(benchmark_repo, problem)
     challenge_path = root / "Challenge.lean"
     deps_path = root / "ChallengeDeps.lean"
@@ -257,30 +317,35 @@ def build_problem_fragment(problem: Problem, benchmark_repo: pathlib.Path) -> tu
     imports = [line for line in challenge_imports if line.strip() != "import ChallengeDeps"]
     body_parts: list[str] = []
 
-    if deps_path.is_file():
-        deps_imports, deps_body = strip_imports(deps_path.read_text(encoding="utf-8"))
-        for line in deps_imports:
-            if line not in imports:
-                imports.append(line)
-        body_parts.append("\n".join(deps_body).strip())
-        local_declarations = collect_local_declarations(deps_body)
+    if is_legacy_single_theorem(problem):
+        # Legacy single-theorem path. Preserve the existing
+        # ChallengeDeps + qualify-theorem-references machinery so byte
+        # equivalence is maintained for problems that previously rendered
+        # cleanly.
+        local_declarations: dict[str, str] = {}
+        if deps_path.is_file():
+            deps_imports, deps_body = strip_imports(deps_path.read_text(encoding="utf-8"))
+            for line in deps_imports:
+                if line not in imports:
+                    imports.append(line)
+            body_parts.append("\n".join(deps_body).strip())
+            local_declarations = collect_local_declarations(deps_body)
+        hole = problem.holes[0]
+        theorem_text = qualify_theorem_text("\n".join(challenge_body).strip(), hole.basename, local_declarations)
+        body_parts.append(inject_legacy_theorem_anchor(problem, hole, theorem_text).strip())
     else:
-        deps_body = []
-        local_declarations = {}
-
-    theorem_text = qualify_theorem_text(problem, "\n".join(challenge_body).strip(), local_declarations)
-    anchored_theorem, anchor_block = inject_anchor(problem, theorem_text)
-    body_parts.append(anchored_theorem.strip())
-    return imports, body_parts, anchor_block
+        # Multi-hole path: the entire source module is reproduced verbatim
+        # in Challenge.lean (with `@[eval_problem]` already stripped).
+        # Inject one anchor block per hole around its `body` substring.
+        text = "\n".join(challenge_body).strip()
+        for hole in problem.holes:
+            text = inject_multi_hole_anchor(problem, hole, text)
+        body_parts.append(text.strip())
+    return imports, body_parts
 
 
 def snapshot_namespace(problem: Problem) -> str:
     return f"Problem{camel_case(problem.id)}"
-
-
-def snapshot_module_name(problem: Problem) -> str:
-    _ = problem
-    return "BenchmarkProblems.Catalog"
 
 
 def write_benchmark_snapshot(benchmark_repo: pathlib.Path, problems: list[Problem]) -> None:
@@ -296,7 +361,7 @@ def write_benchmark_snapshot(benchmark_repo: pathlib.Path, problems: list[Proble
     module_imports: list[str] = []
     module_lines: list[str] = []
     for problem in sorted(problems, key=lambda p: p.sort_index):
-        imports, fragments, _ = build_problem_fragment(problem, benchmark_repo)
+        imports, fragments = build_problem_fragment(problem, benchmark_repo)
         for line in imports:
             if line not in module_imports:
                 module_imports.append(line)
@@ -327,7 +392,7 @@ def timestamp_key(value: str) -> float:
 
 def build_problem_payload(benchmark_repo: pathlib.Path, problems: list[Problem]) -> dict[str, Any]:
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "generated_at": utc_now(),
         "benchmark": {
             "repo": "leanprover/lean-eval",
@@ -340,8 +405,15 @@ def build_problem_payload(benchmark_repo: pathlib.Path, problems: list[Problem])
                 "test": problem.test,
                 "submitter": problem.submitter,
                 "module": problem.module,
-                "theorem": problem.theorem,
-                "statement": problem.statement,
+                "holes": [
+                    {
+                        "name": hole.name,
+                        "basename": hole.basename,
+                        "kind": hole.kind,
+                        "body": hole.body,
+                    }
+                    for hole in problem.holes
+                ],
                 "notes": problem.notes,
                 "source": problem.source,
                 "informal_solution": problem.informal_solution,

--- a/site-data/leaderboard.json
+++ b/site-data/leaderboard.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-04-30T13:27:53Z",
+  "generated_at": "2026-04-30T14:40:39Z",
   "results_repo": {
     "repo": "leanprover/lean-eval-leaderboard",
-    "commit": "b746b432c57ca32f9ba4289d1f0c6c9e1c050a28"
+    "commit": "6112c0710b59b75043b6994cf3beb036d83a578d"
   },
   "benchmark": {
     "repo": "leanprover/lean-eval",

--- a/site-data/leaderboard.json
+++ b/site-data/leaderboard.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-04-30T13:12:58Z",
+  "generated_at": "2026-04-30T13:21:36Z",
   "results_repo": {
     "repo": "leanprover/lean-eval-leaderboard",
-    "commit": "1a3d7c28b925503e9da35e9cd8480baac2095d60"
+    "commit": "ee94b5e46d82e55b502dc6168332224db6d77a19"
   },
   "benchmark": {
     "repo": "leanprover/lean-eval",

--- a/site-data/leaderboard.json
+++ b/site-data/leaderboard.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-04-30T13:21:36Z",
+  "generated_at": "2026-04-30T13:27:53Z",
   "results_repo": {
     "repo": "leanprover/lean-eval-leaderboard",
-    "commit": "ee94b5e46d82e55b502dc6168332224db6d77a19"
+    "commit": "b746b432c57ca32f9ba4289d1f0c6c9e1c050a28"
   },
   "benchmark": {
     "repo": "leanprover/lean-eval",

--- a/site-data/leaderboard.json
+++ b/site-data/leaderboard.json
@@ -1,20 +1,20 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-04-30T12:24:28Z",
+  "generated_at": "2026-04-30T13:12:58Z",
   "results_repo": {
     "repo": "leanprover/lean-eval-leaderboard",
-    "commit": "176e9443e6c6622c67513861362e6fa77efffa57"
+    "commit": "1a3d7c28b925503e9da35e9cd8480baac2095d60"
   },
   "benchmark": {
     "repo": "leanprover/lean-eval",
-    "commit": "01f98c0d77b70f0750499b9ec96bf8bd353972d1"
+    "commit": "a6091941f833b240fdfa4a37855fe2da0fca1dbd"
   },
   "summary": {
     "models": 2,
     "submitters": 2,
-    "problems": 32,
-    "main_problems": 29,
-    "test_problems": 3
+    "problems": 36,
+    "main_problems": 31,
+    "test_problems": 5
   },
   "entries": [
     {

--- a/site-data/problems.json
+++ b/site-data/problems.json
@@ -1,9 +1,9 @@
 {
-  "schema_version": 2,
-  "generated_at": "2026-04-30T12:24:28Z",
+  "schema_version": 3,
+  "generated_at": "2026-04-30T13:12:58Z",
   "benchmark": {
     "repo": "leanprover/lean-eval",
-    "commit": "01f98c0d77b70f0750499b9ec96bf8bd353972d1"
+    "commit": "a6091941f833b240fdfa4a37855fe2da0fca1dbd"
   },
   "problems": [
     {
@@ -12,8 +12,14 @@
       "test": true,
       "submitter": "Kim Morrison",
       "module": "LeanEval.EasyProblems",
-      "theorem": "two_plus_two_eq_four",
-      "statement": ": (2 : Nat) + 2 = 4",
+      "holes": [
+        {
+          "name": "LeanEval.two_plus_two_eq_four",
+          "basename": "two_plus_two_eq_four",
+          "kind": "theorem",
+          "body": "theorem two_plus_two_eq_four : (2 : Nat) + 2 = 4 := by\n  sorry"
+        }
+      ],
       "notes": "An easy problem to get you on the leaderboard.",
       "source": "Internal starter problem.",
       "informal_solution": "By computation.",
@@ -26,8 +32,14 @@
       "test": true,
       "submitter": "Kim Morrison",
       "module": "LeanEval.EasyProblems",
-      "theorem": "ci_regenerate_main_check",
-      "statement": ": True",
+      "holes": [
+        {
+          "name": "LeanEval.ci_regenerate_main_check",
+          "basename": "ci_regenerate_main_check",
+          "kind": "theorem",
+          "body": "theorem ci_regenerate_main_check : True := by trivial"
+        }
+      ],
       "notes": "Internal trivial problem used to exercise the regenerate-main workflow end-to-end.",
       "source": "Internal CI check.",
       "informal_solution": "True is true.",
@@ -40,8 +52,14 @@
       "test": true,
       "submitter": "Kim Morrison",
       "module": "LeanEval.EasyProblems",
-      "theorem": "list_append_singleton_length",
-      "statement": ":\n    (([1, 2] : List Nat).append [3]).length = 3",
+      "holes": [
+        {
+          "name": "LeanEval.list_append_singleton_length",
+          "basename": "list_append_singleton_length",
+          "kind": "theorem",
+          "body": "theorem list_append_singleton_length :\n    (([1, 2] : List Nat).append [3]).length = 3 := by\n  sorry"
+        }
+      ],
       "notes": "A simple list problem that exercises notation in generated files.",
       "source": "Internal starter problem.",
       "informal_solution": "Compute the length after append.",
@@ -54,8 +72,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Analysis.Chudnovsky",
-      "theorem": "chudnovsky_formula_for_pi_inv",
-      "statement": ":\n    chudnovskySum = \u03c0\u207b\u00b9",
+      "holes": [
+        {
+          "name": "LeanEval.Analysis.chudnovsky_formula_for_pi_inv",
+          "basename": "chudnovsky_formula_for_pi_inv",
+          "kind": "theorem",
+          "body": "theorem chudnovsky_formula_for_pi_inv :\n    chudnovskySum = \u03c0\u207b\u00b9 := by\n  sorry"
+        }
+      ],
       "notes": "Uses the existing Mathlib definition of the Chudnovsky series and asks for the missing identity with pi inverse.",
       "source": "https://link.springer.com/article/10.1007/s40316-018-0102-6",
       "informal_solution": "Evaluate the Chudnovsky series and prove that it sums to 1 / pi.",
@@ -68,8 +92,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Topology.HomotopyGroups",
-      "theorem": "pi1_circle_mulEquiv_int",
-      "statement": ":\n    Nonempty (HomotopyGroup.Pi 1 Circle (1 : Circle) \u2243* Multiplicative \u2124)",
+      "holes": [
+        {
+          "name": "LeanEval.Topology.pi1_circle_mulEquiv_int",
+          "basename": "pi1_circle_mulEquiv_int",
+          "kind": "theorem",
+          "body": "/-- The fundamental group of the complex unit circle is infinite cyclic. -/\ntheorem pi1_circle_mulEquiv_int :\n    Nonempty (HomotopyGroup.Pi 1 Circle (1 : Circle) \u2243* Multiplicative \u2124) := by\n  sorry"
+        }
+      ],
       "notes": "Computes the fundamental group of the complex unit circle.",
       "source": "Classical theorem in algebraic topology.",
       "informal_solution": "Use winding number to identify loops in the circle up to homotopy with the integers.",
@@ -82,8 +112,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Combinatorics.Ramsey",
-      "theorem": "finite_graph_ramsey_theorem",
-      "statement": ":\n    \u2200 r s : \u2115, 2 \u2264 r \u2192 2 \u2264 s \u2192 \u2203 n : \u2115, \u2200 G : SimpleGraph (Fin n), \u00ac G.CliqueFree r \u2228 \u00ac G\u1d9c.CliqueFree s",
+      "holes": [
+        {
+          "name": "LeanEval.Combinatorics.finite_graph_ramsey_theorem",
+          "basename": "finite_graph_ramsey_theorem",
+          "kind": "theorem",
+          "body": "theorem finite_graph_ramsey_theorem :\n    \u2200 r s : \u2115, 2 \u2264 r \u2192 2 \u2264 s \u2192 \u2203 n : \u2115, \u2200 G : SimpleGraph (Fin n), \u00ac G.CliqueFree r \u2228 \u00ac G\u1d9c.CliqueFree s := by\n  sorry"
+        }
+      ],
       "notes": "States finite Ramsey existence for red/blue edge colourings of complete graphs, encoded by a graph and its complement.",
       "source": "Classical theorem in Ramsey theory.",
       "informal_solution": "Show that for every r and s there is an n such that every graph on n vertices contains either a clique of size r or an independent set of size s.",
@@ -96,8 +132,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Combinatorics.CatalanSubstInv",
-      "theorem": "substInv_X_sub_X_sq_eq_catalan",
-      "statement": "(n : \u2115) :\n    haveI : Invertible (coeff 1 ((X : \u211a\u27e6X\u27e7) - X ^ 2))",
+      "holes": [
+        {
+          "name": "LeanEval.Combinatorics.substInv_X_sub_X_sq_eq_catalan",
+          "basename": "substInv_X_sub_X_sq_eq_catalan",
+          "kind": "theorem",
+          "body": "theorem substInv_X_sub_X_sq_eq_catalan (n : \u2115) :\n    haveI : Invertible (coeff 1 ((X : \u211a\u27e6X\u27e7) - X ^ 2)) := by\n      simp [coeff_X, coeff_X_pow]; exact invertibleOne\n    coeff (n + 1) (substInv ((X : \u211a\u27e6X\u27e7) - X ^ 2)) =\n      (Nat.choose (2 * n) n : \u211a) / (\u2191n + 1) := by\n  sorry"
+        }
+      ],
       "notes": "The compositional inverse of X - X\u00b2 is the generating function for Catalan numbers. This is a classical application of Lagrange inversion in enumerative combinatorics, connecting formal power series inversion to Dyck paths, binary trees, and triangulations.",
       "source": "E. Catalan, Note sur une \u00e9quation aux diff\u00e9rences finies, 1838; J.-L. Lagrange, Nouvelle m\u00e9thode pour r\u00e9soudre les \u00e9quations litt\u00e9rales, 1770.",
       "informal_solution": "The compositional inverse C(x) satisfies C - C\u00b2 = x, giving C = (1 - \u221a(1-4x))/2. By the binomial series, its coefficients are the Catalan numbers C_n = (2n choose n)/(n+1).",
@@ -110,8 +152,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.NumberTheory.Lagarias",
-      "theorem": "riemann_hypothesis_iff_lagarias_elementary_criterion",
-      "statement": ":\n    RiemannHypothesis \u2194 LagariasElementaryCriterion",
+      "holes": [
+        {
+          "name": "LeanEval.NumberTheory.riemann_hypothesis_iff_lagarias_elementary_criterion",
+          "basename": "riemann_hypothesis_iff_lagarias_elementary_criterion",
+          "kind": "theorem",
+          "body": "theorem riemann_hypothesis_iff_lagarias_elementary_criterion :\n    RiemannHypothesis \u2194 LagariasElementaryCriterion := by\n  sorry"
+        }
+      ],
       "notes": "Lagarias' elementary divisor-sum criterion stated using Mathlib's RiemannHypothesis, harmonic numbers, and sigma notation.",
       "source": "https://arxiv.org/abs/math/0008177",
       "informal_solution": "Prove that the Riemann hypothesis is equivalent to the inequality \u03c3(n) \u2264 H_n + exp(H_n) log(H_n) for all positive integers n.",
@@ -124,8 +172,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Combinatorics.MarkoffGraph",
-      "theorem": "dvd_card_connectedComponent_markoffGraph",
-      "statement": "{p : \u2115} (hp : Nat.Prime p) (hgt : 3 < p) :\n    \u2200 c : (markoffGraph p).ConnectedComponent, p \u2223 Nat.card c",
+      "holes": [
+        {
+          "name": "LeanEval.Combinatorics.dvd_card_connectedComponent_markoffGraph",
+          "basename": "dvd_card_connectedComponent_markoffGraph",
+          "kind": "theorem",
+          "body": "/-- For prime `p > 3`, every connected component of the nonzero Markoff graph over `ZMod p`\nhas cardinality divisible by `p`. -/\ntheorem dvd_card_connectedComponent_markoffGraph\n    {p : \u2115} (hp : Nat.Prime p) (hgt : 3 < p) :\n    \u2200 c : (markoffGraph p).ConnectedComponent, p \u2223 Nat.card c := by\n  sorry"
+        }
+      ],
       "notes": "For prime p > 3, every connected component of the nonzero Markoff graph over ZMod p has cardinality divisible by p.",
       "source": "https://link.springer.com/article/10.1007/s00222-025-01346-9",
       "informal_solution": "Exploit the Vieta involution symmetries of the Markoff graph over F_p and show each connected component has size divisible by p.",
@@ -138,8 +192,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Combinatorics.CayleyConnected",
-      "theorem": "mulCayley_connected_iff_closure_eq_top",
-      "statement": "{G : Type*} [Group G]\n    (S : Set G) :\n    (SimpleGraph.mulCayley S).Connected \u2194 Subgroup.closure S = \u22a4",
+      "holes": [
+        {
+          "name": "LeanEval.Combinatorics.mulCayley_connected_iff_closure_eq_top",
+          "basename": "mulCayley_connected_iff_closure_eq_top",
+          "kind": "theorem",
+          "body": "theorem mulCayley_connected_iff_closure_eq_top\n    {G : Type*} [Group G]\n    (S : Set G) :\n    (SimpleGraph.mulCayley S).Connected \u2194 Subgroup.closure S = \u22a4 := by\n  sorry"
+        }
+      ],
       "notes": "A foundational result in geometric group theory using the newly defined Cayley graph. Connectivity of the Cayley graph is equivalent to the generating set S generating G as a group.",
       "source": "A. Cayley, On the theory of groups, as depending on the symbolic equation \u03b8^n = 1, 1878.",
       "informal_solution": "Forward: if connected, any g \u2208 G is reached from 1 by a path, which corresponds to a product of generators. Reverse: if S generates, any g is a product of generators, giving a path from 1 to g.",
@@ -152,8 +212,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Topology.HomotopyGroups",
-      "theorem": "pi3_sphere_two_mulEquiv_int",
-      "statement": "(x : Metric.sphere (0 : EuclideanSpace \u211d (Fin 3)) 1) :\n    Nonempty\n      (HomotopyGroup.Pi 3 (Metric.sphere (0 : EuclideanSpace \u211d (Fin 3)) 1) x \u2243*\n        Multiplicative \u2124)",
+      "holes": [
+        {
+          "name": "LeanEval.Topology.pi3_sphere_two_mulEquiv_int",
+          "basename": "pi3_sphere_two_mulEquiv_int",
+          "kind": "theorem",
+          "body": "/-- The third homotopy group of the 2-sphere is infinite cyclic. -/\ntheorem pi3_sphere_two_mulEquiv_int\n    (x : Metric.sphere (0 : EuclideanSpace \u211d (Fin 3)) 1) :\n    Nonempty\n      (HomotopyGroup.Pi 3 (Metric.sphere (0 : EuclideanSpace \u211d (Fin 3)) 1) x \u2243*\n        Multiplicative \u2124) := by\n  sorry"
+        }
+      ],
       "notes": "The classical computation pi_3(S^2) = Z, with an explicit basepoint.",
       "source": "Classical theorem in algebraic topology.",
       "informal_solution": "Use the Hopf fibration to identify the third homotopy group of the 2-sphere with the integers.",
@@ -166,8 +232,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Topology.HomotopyGroups",
-      "theorem": "pin_sphere_n_mulEquiv_int",
-      "statement": "(n : \u2115)\n    (x : Metric.sphere (0 : EuclideanSpace \u211d (Fin (n + 2))) 1) :\n    Nonempty\n      (HomotopyGroup.Pi (n + 1) (Metric.sphere (0 : EuclideanSpace \u211d (Fin (n + 2))) 1) x \u2243*\n        Multiplicative \u2124)",
+      "holes": [
+        {
+          "name": "LeanEval.Topology.pin_sphere_n_mulEquiv_int",
+          "basename": "pin_sphere_n_mulEquiv_int",
+          "kind": "theorem",
+          "body": "/-- For every `n \u2265 1`, the `n`th homotopy group of the `n`-sphere is infinite cyclic. -/\ntheorem pin_sphere_n_mulEquiv_int\n    (n : \u2115)\n    (x : Metric.sphere (0 : EuclideanSpace \u211d (Fin (n + 2))) 1) :\n    Nonempty\n      (HomotopyGroup.Pi (n + 1) (Metric.sphere (0 : EuclideanSpace \u211d (Fin (n + 2))) 1) x \u2243*\n        Multiplicative \u2124) := by\n  sorry"
+        }
+      ],
       "notes": "The diagonal sphere homotopy-group computation pi_n(S^n) = Z for n at least 1.",
       "source": "Classical theorem in algebraic topology.",
       "informal_solution": "Identify homotopy classes of self-maps of S^n with their degree.",
@@ -180,8 +252,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Topology.HomotopyGroups",
-      "theorem": "pi_succ_sphere_n_mulEquiv_zmod_two",
-      "statement": "(n : \u2115) (hn : 3 \u2264 n)\n    (x : Metric.sphere (0 : EuclideanSpace \u211d (Fin (n + 1))) 1) :\n    Nonempty\n      (HomotopyGroup.Pi (n + 1) (Metric.sphere (0 : EuclideanSpace \u211d (Fin (n + 1))) 1) x \u2243*\n        Multiplicative (ZMod 2))",
+      "holes": [
+        {
+          "name": "LeanEval.Topology.pi_succ_sphere_n_mulEquiv_zmod_two",
+          "basename": "pi_succ_sphere_n_mulEquiv_zmod_two",
+          "kind": "theorem",
+          "body": "/-- A concrete stable-family statement: for `n \u2265 3`, `\u03c0_(n+1)(S^n) \u2243 \u2124/2`. -/\ntheorem pi_succ_sphere_n_mulEquiv_zmod_two\n    (n : \u2115) (hn : 3 \u2264 n)\n    (x : Metric.sphere (0 : EuclideanSpace \u211d (Fin (n + 1))) 1) :\n    Nonempty\n      (HomotopyGroup.Pi (n + 1) (Metric.sphere (0 : EuclideanSpace \u211d (Fin (n + 1))) 1) x \u2243*\n        Multiplicative (ZMod 2)) := by\n  sorry"
+        }
+      ],
       "notes": "A concrete stable-family homotopy-group computation.",
       "source": "Classical theorem in unstable homotopy theory.",
       "informal_solution": "Use suspension and the stable range to show the first stable stem is Z/2.",
@@ -194,8 +272,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.GroupTheory.Burnside",
-      "theorem": "finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow",
-      "statement": "{G : Type*} [Group G] [Fintype G]\n    {p q a b : \u2115}\n    (hp : Nat.Prime p)\n    (hq : Nat.Prime q)\n    (hpq : p \u2260 q)\n    (hcard : Fintype.card G = p ^ a * q ^ b) :\n    IsSolvable G",
+      "holes": [
+        {
+          "name": "LeanEval.GroupTheory.finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow",
+          "basename": "finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow",
+          "kind": "theorem",
+          "body": "theorem finite_group_isSolvable_of_card_eq_prime_pow_mul_prime_pow\n    {G : Type*} [Group G] [Fintype G]\n    {p q a b : \u2115}\n    (hp : Nat.Prime p)\n    (hq : Nat.Prime q)\n    (hpq : p \u2260 q)\n    (hcard : Fintype.card G = p ^ a * q ^ b) :\n    IsSolvable G := by\n  sorry"
+        }
+      ],
       "notes": "Burnside's theorem that a finite group of order p^a q^b is solvable.",
       "source": "Classical theorem in finite group theory.",
       "informal_solution": "Use character theory and induction on the group order to prove solvability.",
@@ -208,8 +292,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.ComplexAnalysis.Rouche",
-      "theorem": "rouche_logCounting_zero_eq",
-      "statement": "{f g : \u2102 \u2192 \u2102} {R : \u211d}\n    (hR : 1 \u2264 R)\n    (hf : Meromorphic f)\n    (hg : AnalyticOn \u2102 g Set.univ)\n    (hbound : \u2200 z : \u2102, \u2016z\u2016 = R \u2192 \u2016g z\u2016 < \u2016f z\u2016) :\n    logCounting (f + g) 0 R = logCounting f 0 R",
+      "holes": [
+        {
+          "name": "LeanEval.ComplexAnalysis.rouche_logCounting_zero_eq",
+          "basename": "rouche_logCounting_zero_eq",
+          "kind": "theorem",
+          "body": "theorem rouche_logCounting_zero_eq\n    {f g : \u2102 \u2192 \u2102} {R : \u211d}\n    (hR : 1 \u2264 R)\n    (hf : Meromorphic f)\n    (hg : AnalyticOn \u2102 g Set.univ)\n    (hbound : \u2200 z : \u2102, \u2016z\u2016 = R \u2192 \u2016g z\u2016 < \u2016f z\u2016) :\n    logCounting (f + g) 0 R = logCounting f 0 R := by\n  sorry"
+        }
+      ],
       "notes": "Phrases Rouch\u00e9's theorem as equality of zero-counting functions for f and f + g.",
       "source": "Classical theorem in complex analysis.",
       "informal_solution": "If |g| < |f| on the boundary circle, then f and f + g have the same number of zeros inside, counted with multiplicity.",
@@ -222,8 +312,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.ConvexGeometry.MinkowskiCaratheodory",
-      "theorem": "mem_convexHull_finset_extremePoints_of_mem_compact_convex",
-      "statement": "{E : Type*} [NormedAddCommGroup E] [NormedSpace \u211d E] [FiniteDimensional \u211d E]\n    {s : Set E} {x : E}\n    (hscomp : IsCompact s)\n    (hsconv : Convex \u211d s)\n    (hx : x \u2208 s) :\n    \u2203 t : Finset E,\n      (\u2191t : Set E) \u2286 s.extremePoints \u211d \u2227\n      t.card \u2264 Module.finrank \u211d E + 1 \u2227\n      x \u2208 convexHull \u211d (\u2191t : Set E)",
+      "holes": [
+        {
+          "name": "LeanEval.ConvexGeometry.mem_convexHull_finset_extremePoints_of_mem_compact_convex",
+          "basename": "mem_convexHull_finset_extremePoints_of_mem_compact_convex",
+          "kind": "theorem",
+          "body": "theorem mem_convexHull_finset_extremePoints_of_mem_compact_convex\n    {E : Type*} [NormedAddCommGroup E] [NormedSpace \u211d E] [FiniteDimensional \u211d E]\n    {s : Set E} {x : E}\n    (hscomp : IsCompact s)\n    (hsconv : Convex \u211d s)\n    (hx : x \u2208 s) :\n    \u2203 t : Finset E,\n      (\u2191t : Set E) \u2286 s.extremePoints \u211d \u2227\n      t.card \u2264 Module.finrank \u211d E + 1 \u2227\n      x \u2208 convexHull \u211d (\u2191t : Set E) := by\n  sorry"
+        }
+      ],
       "notes": "Finite-dimensional compact convex sets are generated by their extreme points, with a finrank + 1 bound.",
       "source": "Classical theorem in convex geometry.",
       "informal_solution": "Combine Krein-Milman with Caratheodory to represent each point as a convex combination of at most finrank + 1 extreme points.",
@@ -236,8 +332,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.LinearAlgebra.PerronFrobenius",
-      "theorem": "irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius",
-      "statement": "{n : Type*} [Fintype n] [DecidableEq n]\n    (A : Matrix n n \u211d)\n    (hA : A.IsIrreducible) :\n    \u2203 v : n \u2192 \u211d,\n      Module.End.HasEigenvector (Matrix.toLin' A) (spectralRadius \u211d A).toReal v \u2227\n      (\u2200 i, 0 < v i)",
+      "holes": [
+        {
+          "name": "LeanEval.LinearAlgebra.irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius",
+          "basename": "irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius",
+          "kind": "theorem",
+          "body": "theorem irreducible_nonnegative_matrix_has_positive_eigenvector_at_spectralRadius\n    {n : Type*} [Fintype n] [DecidableEq n]\n    (A : Matrix n n \u211d)\n    (hA : A.IsIrreducible) :\n    \u2203 v : n \u2192 \u211d,\n      Module.End.HasEigenvector (Matrix.toLin' A) (spectralRadius \u211d A).toReal v \u2227\n      (\u2200 i, 0 < v i) := by\n  sorry"
+        }
+      ],
       "notes": "A Perron-Frobenius style eigenvector existence statement at the spectral radius.",
       "source": "Classical theorem in linear algebra.",
       "informal_solution": "Show that an irreducible nonnegative matrix has a strictly positive eigenvector with eigenvalue equal to its spectral radius.",
@@ -250,8 +352,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.ComplexAnalysis.ComplementaryPolynomials",
-      "theorem": "exists_complementary_polynomial_on_unit_circle",
-      "statement": "(P : \u2102[X])\n    (hP : \u2200 z : Circle, \u2016P.eval (z : \u2102)\u2016 \u2264 1) :\n    \u2203 Q : \u2102[X],\n      Q.natDegree = P.natDegree \u2227\n        \u2200 z : Circle, \u2016P.eval (z : \u2102)\u2016 ^ 2 + \u2016Q.eval (z : \u2102)\u2016 ^ 2 = 1",
+      "holes": [
+        {
+          "name": "LeanEval.ComplexAnalysis.exists_complementary_polynomial_on_unit_circle",
+          "basename": "exists_complementary_polynomial_on_unit_circle",
+          "kind": "theorem",
+          "body": "/-- If `P` is bounded by `1` on the unit circle, then there is a polynomial `Q` of the same degree\nwhose squared moduli complement `P` to `1` on the unit circle. -/\ntheorem exists_complementary_polynomial_on_unit_circle\n    (P : \u2102[X])\n    (hP : \u2200 z : Circle, \u2016P.eval (z : \u2102)\u2016 \u2264 1) :\n    \u2203 Q : \u2102[X],\n      Q.natDegree = P.natDegree \u2227\n        \u2200 z : Circle, \u2016P.eval (z : \u2102)\u2016 ^ 2 + \u2016Q.eval (z : \u2102)\u2016 ^ 2 = 1 := by\n  sorry"
+        }
+      ],
       "notes": "If a complex polynomial has modulus at most 1 on the unit circle, then there is a same-degree complementary polynomial whose squared moduli add to 1 on the circle.",
       "source": "https://link.springer.com/article/10.1007/s00220-025-05302-9",
       "informal_solution": "Construct a polynomial Q so that |P(z)|^2 + |Q(z)|^2 = 1 for all z on the unit circle.",
@@ -264,8 +372,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Algebra.NormalProduct",
-      "theorem": "isStarNormal_mul_of_commute",
-      "statement": "{A : Type*} [NonUnitalCStarAlgebra A]\n    {a b : A} (ha : IsStarNormal a) (hb : IsStarNormal b)\n    (hab : Commute a b) :\n    IsStarNormal (a * b)",
+      "holes": [
+        {
+          "name": "LeanEval.Algebra.isStarNormal_mul_of_commute",
+          "basename": "isStarNormal_mul_of_commute",
+          "kind": "theorem",
+          "body": "theorem isStarNormal_mul_of_commute\n    {A : Type*} [NonUnitalCStarAlgebra A]\n    {a b : A} (ha : IsStarNormal a) (hb : IsStarNormal b)\n    (hab : Commute a b) :\n    IsStarNormal (a * b) := by\n  sorry"
+        }
+      ],
       "notes": "Uses the Fuglede-Putnam-Rosenblum theorem to show all four of a, star a, b, star b pairwise commute, then verifies the normality condition by direct computation.",
       "source": "B. Fuglede, A commutativity theorem for normal operators, 1950.",
       "informal_solution": "From Commute a b and normality, apply Fuglede-Putnam twice to get Commute (star a) b and Commute (star a) (star b). Then star(ab)\u00b7(ab) = b*\u00b7a*\u00b7a\u00b7b = b*\u00b7a\u00b7a*\u00b7b (a normal) = a\u00b7b*\u00b7b\u00b7a* (all commute) = a\u00b7b\u00b7b*\u00b7a* (b normal) = (ab)\u00b7star(ab).",
@@ -278,8 +392,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.LinearAlgebra.EntrywiseExpPSD",
-      "theorem": "posSemidef_map_exp",
-      "statement": "{n : Type*} [Fintype n] [DecidableEq n]\n    {A : Matrix n n \u211d} (hA : A.PosSemidef) :\n    (A.map Real.exp).PosSemidef",
+      "holes": [
+        {
+          "name": "LeanEval.LinearAlgebra.posSemidef_map_exp",
+          "basename": "posSemidef_map_exp",
+          "kind": "theorem",
+          "body": "theorem posSemidef_map_exp\n    {n : Type*} [Fintype n] [DecidableEq n]\n    {A : Matrix n n \u211d} (hA : A.PosSemidef) :\n    (A.map Real.exp).PosSemidef := by\n  sorry"
+        }
+      ],
       "notes": "Part of the Schur-Polya-Loewner theory of entrywise functions preserving PSD. The proof uses the Schur product theorem iteratively: exp_\u2299(A) = \u2211 A^{\u2299k}/k!, each Hadamard power is PSD, and the convergent series of PSD matrices is PSD.",
       "source": "I.J. Schoenberg, Positive definite functions on spheres, 1942.",
       "informal_solution": "Write exp(a_{ij}) as the convergent series \u2211 (a_{ij})^k / k!. The matrix with entries (a_{ij})^k is the k-fold Hadamard product A^{\u2299k}, which is PSD by iterated Schur product. The partial sums are nonneg combinations of PSD matrices, hence PSD. PSD is a closed condition, so the limit is PSD.",
@@ -292,8 +412,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.LinearAlgebra.Oppenheim",
-      "theorem": "oppenheim_inequality",
-      "statement": "{n : Type*} [Fintype n] [DecidableEq n]\n    {A B : Matrix n n \u211d} (hA : A.PosSemidef) (hB : B.PosSemidef) :\n    A.det * \u220f i, B i i \u2264 (A \u2299 B).det",
+      "holes": [
+        {
+          "name": "LeanEval.LinearAlgebra.oppenheim_inequality",
+          "basename": "oppenheim_inequality",
+          "kind": "theorem",
+          "body": "theorem oppenheim_inequality\n    {n : Type*} [Fintype n] [DecidableEq n]\n    {A B : Matrix n n \u211d} (hA : A.PosSemidef) (hB : B.PosSemidef) :\n    A.det * \u220f i, B i i \u2264 (A \u2299 B).det := by\n  sorry"
+        }
+      ],
       "notes": "Oppenheim's 1930 inequality: for PSD matrices A, B, det(A \u2299 B) \u2265 det(A) \u00b7 \u220f\u1d62 B\u1d62\u1d62. Uses the Schur product theorem (newly formalized) as a key ingredient.",
       "source": "I. Schur, Bemerkungen zur Theorie der beschr\u00e4nkten Bilinearformen, 1911; A. Oppenheim, Inequalities connected with definite Hermitian forms, 1930.",
       "informal_solution": "Use induction on the matrix size, extracting a Schur complement at each step and applying the Schur product theorem to bound the determinant.",
@@ -306,8 +432,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Analysis.VonNeumannDoubleCommutant",
-      "theorem": "vonNeumann_doubleCommutant_tfae",
-      "statement": "{H : Type*} [NormedAddCommGroup H] [InnerProductSpace \u2102 H] [CompleteSpace H]\n    (S : StarSubalgebra \u2102 (H \u2192L[\u2102] H)) :\n    List.TFAE\n      [ Set.centralizer (Set.centralizer (S : Set (H \u2192L[\u2102] H))) = S\n      , IsClosed\n          (ContinuousLinearMap.toWOT (RingHom.id \u2102) H H '' (S : Set (H \u2192L[\u2102] H)))\n      , IsClosed\n          (ContinuousLinearMap.toPointwiseConvergenceCLM \u2102 (RingHom.id \u2102) H H ''\n            (S : Set (H \u2192L[\u2102] H))) ]",
+      "holes": [
+        {
+          "name": "LeanEval.Analysis.vonNeumann_doubleCommutant_tfae",
+          "basename": "vonNeumann_doubleCommutant_tfae",
+          "kind": "theorem",
+          "body": "theorem vonNeumann_doubleCommutant_tfae\n    {H : Type*} [NormedAddCommGroup H] [InnerProductSpace \u2102 H] [CompleteSpace H]\n    (S : StarSubalgebra \u2102 (H \u2192L[\u2102] H)) :\n    List.TFAE\n      [ Set.centralizer (Set.centralizer (S : Set (H \u2192L[\u2102] H))) = S\n      , IsClosed\n          (ContinuousLinearMap.toWOT (RingHom.id \u2102) H H '' (S : Set (H \u2192L[\u2102] H)))\n      , IsClosed\n          (ContinuousLinearMap.toPointwiseConvergenceCLM \u2102 (RingHom.id \u2102) H H ''\n            (S : Set (H \u2192L[\u2102] H))) ] := by\n  sorry"
+        }
+      ],
       "notes": "The classical double commutant theorem: for a unital *-subalgebra of bounded operators on a complex Hilbert space, equality with the double commutant is equivalent to closedness in the weak operator topology and to closedness in the strong operator topology. WOT and SOT live on Mathlib's irreducible type copies of H \u2192L[\u2102] H (`ContinuousLinearMapWOT` and `PointwiseConvergenceCLM`), so each closure condition is phrased on the image of the carrier under the canonical inclusion.",
       "source": "J. von Neumann, Zur Algebra der Funktionaloperationen und Theorie der normalen Operatoren, Math. Ann. 102 (1930), 370-427.",
       "informal_solution": "One direction: centralizers are WOT-closed, so any set equal to its double commutant is WOT-closed; norm topology refines WOT refines SOT for continuity of evaluation, and closedness under a finer convex topology is implied by closedness under a coarser one (via Hahn-Banach for convex sets). Hard direction: given a unital *-subalgebra S that is SOT-closed, for any T in S'' and any finite family of vectors use the amplification S \u2297 1_n acting diagonally on H^n together with the projection onto the closure of (S \u2297 1_n) applied to the vector to produce a net in S converging SOT to T.",
@@ -320,8 +452,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.RepresentationTheory.SchurWeyl",
-      "theorem": "symAction_range_eq_centralizer_glAction",
-      "statement": "{R : Type*} [Field R]\n    {M : Type*} [AddCommGroup M] [Module R M] [FiniteDimensional R M]\n    {k : \u2115} [Invertible (k.factorial : R)] :\n    Algebra.adjoin R (Set.range (symAction R M k)) =\n      Subalgebra.centralizer R (Set.range (glAction R M k))",
+      "holes": [
+        {
+          "name": "LeanEval.RepresentationTheory.symAction_range_eq_centralizer_glAction",
+          "basename": "symAction_range_eq_centralizer_glAction",
+          "kind": "theorem",
+          "body": "/-- One direction of Schur\u2013Weyl duality: the subalgebra generated by the `S_k` action equals\nthe centralizer of the subalgebra generated by the `GL(V)` action. The hypothesis\n`Invertible (k! : R)` over a field is the Maschke condition for `R[S_k]`. -/\ntheorem symAction_range_eq_centralizer_glAction\n    {R : Type*} [Field R]\n    {M : Type*} [AddCommGroup M] [Module R M] [FiniteDimensional R M]\n    {k : \u2115} [Invertible (k.factorial : R)] :\n    Algebra.adjoin R (Set.range (symAction R M k)) =\n      Subalgebra.centralizer R (Set.range (glAction R M k)) := by\n  sorry"
+        }
+      ],
       "notes": "One direction of Schur-Weyl duality: the subalgebra of End(V^\u2297k) generated by the S_k action (permuting factors) equals the centralizer of the subalgebra generated by the diagonal GL(V) action. Hypothesis `Invertible (k! : R)` over a field is exactly the Maschke condition for R[S_k].",
       "source": "H. Weyl, The Classical Groups, 1939; I. Schur, \u00dcber die rationalen Darstellungen der allgemeinen linearen Gruppe, 1927.",
       "informal_solution": "Classical proof: any T \u2208 End(V^\u2297k) commuting with GL(V) acts the same way on tensors related by g^\u2297k for every g, and by polarization (which uses k! invertible) the subalgebra {g^\u2297k : g \u2208 GL(V)} linearly spans the image of Sym^k(End V) in End(V^\u2297k). Together with the semisimplicity of R[S_k] (Maschke, from the same k! hypothesis) and double commutant for finite-dimensional semisimple algebras, T lies in the R-subalgebra generated by the S_k action.",
@@ -334,8 +472,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.RepresentationTheory.SchurWeyl",
-      "theorem": "glAction_range_eq_centralizer_symAction",
-      "statement": "{R : Type*} [Field R]\n    {M : Type*} [AddCommGroup M] [Module R M] [FiniteDimensional R M]\n    {k : \u2115} [Invertible (k.factorial : R)] :\n    Algebra.adjoin R (Set.range (glAction R M k)) =\n      Subalgebra.centralizer R (Set.range (symAction R M k))",
+      "holes": [
+        {
+          "name": "LeanEval.RepresentationTheory.glAction_range_eq_centralizer_symAction",
+          "basename": "glAction_range_eq_centralizer_symAction",
+          "kind": "theorem",
+          "body": "/-- The other direction of Schur\u2013Weyl duality: the subalgebra generated by the `GL(V)` action\nequals the centralizer of the subalgebra generated by the `S_k` action. -/\ntheorem glAction_range_eq_centralizer_symAction\n    {R : Type*} [Field R]\n    {M : Type*} [AddCommGroup M] [Module R M] [FiniteDimensional R M]\n    {k : \u2115} [Invertible (k.factorial : R)] :\n    Algebra.adjoin R (Set.range (glAction R M k)) =\n      Subalgebra.centralizer R (Set.range (symAction R M k)) := by\n  sorry"
+        }
+      ],
       "notes": "The other direction of Schur-Weyl duality: the subalgebra of End(V^\u2297k) generated by the diagonal GL(V) action equals the centralizer of the subalgebra generated by the S_k action.",
       "source": "H. Weyl, The Classical Groups, 1939; I. Schur, \u00dcber die rationalen Darstellungen der allgemeinen linearen Gruppe, 1927.",
       "informal_solution": "By polarization over R with k! invertible, the subalgebra generated by {g^\u2297k : g \u2208 GL(V)} is precisely the image of Sym^k(End V), i.e., the endomorphisms of V^\u2297k fixed by the S_k-action on tensor factors of End V. An endomorphism of V^\u2297k fixed by this action is exactly one commuting with the S_k action on V^\u2297k.",
@@ -348,8 +492,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare",
-      "theorem": "g2_irrep_tensor_square_decomp",
-      "statement": ":\n    \u2203 (V : Type) (_ : AddCommGroup V) (_ : Module \u2102 V)\n      (_ : LieRingModule (LieAlgebra.g\u2082 \u2102) V) (_ : LieModule \u2102 (LieAlgebra.g\u2082 \u2102) V),\n      Module.finrank \u2102 V = 64 \u2227\n      LieModule.IsIrreducible \u2102 (LieAlgebra.g\u2082 \u2102) V \u2227\n      (isotypicComponents (UniversalEnvelopingAlgebra \u2102 (LieAlgebra.g\u2082 \u2102))\n        (V \u2297[\u2102] V)).ncard = 14",
+      "holes": [
+        {
+          "name": "LeanEval.RepresentationTheory.g2_irrep_tensor_square_decomp",
+          "basename": "g2_irrep_tensor_square_decomp",
+          "kind": "theorem",
+          "body": "theorem g2_irrep_tensor_square_decomp :\n    \u2203 (V : Type) (_ : AddCommGroup V) (_ : Module \u2102 V)\n      (_ : LieRingModule (LieAlgebra.g\u2082 \u2102) V) (_ : LieModule \u2102 (LieAlgebra.g\u2082 \u2102) V),\n      Module.finrank \u2102 V = 64 \u2227\n      LieModule.IsIrreducible \u2102 (LieAlgebra.g\u2082 \u2102) V \u2227\n      (isotypicComponents (UniversalEnvelopingAlgebra \u2102 (LieAlgebra.g\u2082 \u2102))\n        (V \u2297[\u2102] V)).ncard = 14 := by\n  sorry"
+        }
+      ],
       "notes": "g\u2082 is the smallest exceptional Lie algebra, defined here by the Serre construction (Mathlib's `LieAlgebra.g\u2082`). The formal statement is existential: it asks for some 64-dimensional irreducible representation whose tensor square has 14 isotypic components. In the intended solution, one constructs such a witness using the highest-weight representation with highest weight \u03c9\u2081 + \u03c9\u2082 (the sum of the two fundamental weights). The U(g)-module structure on V \u2297 V used in the statement comes from lifting the Lie action via the universal enveloping algebra.",
       "source": "Classical: representation theory of the exceptional Lie algebra g\u2082.",
       "informal_solution": "Construct V as the irreducible 64-dim representation V(\u03c9\u2081+\u03c9\u2082). Decomposition (LiE-verified): V\u2297V = V(0,0) + V(1,0) + 2V(0,1) + 2V(2,0) + 2V(1,1) + 2V(0,2) + 3V(3,0) + 3V(2,1) + V(1,2) + V(0,3) + 2V(4,0) + 2V(3,1) + V(2,2) + V(5,0). This is used to produce the existential witness required by the formal statement.",
@@ -362,8 +512,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.RepresentationTheory.ExceptionalLieTensorSquare",
-      "theorem": "e8_irrep_tensor_square_decomp",
-      "statement": ":\n    \u2203 (V : Type) (_ : AddCommGroup V) (_ : Module \u2102 V)\n      (_ : LieRingModule (LieAlgebra.e\u2088 \u2102) V) (_ : LieModule \u2102 (LieAlgebra.e\u2088 \u2102) V),\n      Module.finrank \u2102 V = 779247 \u2227\n      LieModule.IsIrreducible \u2102 (LieAlgebra.e\u2088 \u2102) V \u2227\n      (isotypicComponents (UniversalEnvelopingAlgebra \u2102 (LieAlgebra.e\u2088 \u2102))\n        (V \u2297[\u2102] V)).ncard = 40",
+      "holes": [
+        {
+          "name": "LeanEval.RepresentationTheory.e8_irrep_tensor_square_decomp",
+          "basename": "e8_irrep_tensor_square_decomp",
+          "kind": "theorem",
+          "body": "theorem e8_irrep_tensor_square_decomp :\n    \u2203 (V : Type) (_ : AddCommGroup V) (_ : Module \u2102 V)\n      (_ : LieRingModule (LieAlgebra.e\u2088 \u2102) V) (_ : LieModule \u2102 (LieAlgebra.e\u2088 \u2102) V),\n      Module.finrank \u2102 V = 779247 \u2227\n      LieModule.IsIrreducible \u2102 (LieAlgebra.e\u2088 \u2102) V \u2227\n      (isotypicComponents (UniversalEnvelopingAlgebra \u2102 (LieAlgebra.e\u2088 \u2102))\n        (V \u2297[\u2102] V)).ncard = 40 := by\n  sorry"
+        }
+      ],
       "notes": "e\u2088 is the largest exceptional Lie algebra (dim 248), defined here by the Serre construction (Mathlib's `LieAlgebra.e\u2088`). The formal statement is existential: it asks for some 779247-dimensional irreducible representation whose tensor square has 40 isotypic components. In the intended solution, one constructs such a witness using the highest-weight representation with highest weight \u03c9\u2081 + \u03c9\u2088 (the sum of the first and last fundamental weights, in Bourbaki labelling). The U(g)-module structure on V \u2297 V used in the statement comes from lifting the Lie action via the universal enveloping algebra.",
       "source": "Classical: representation theory of the exceptional Lie algebra e\u2088.",
       "informal_solution": "Construct V as V(\u03c9\u2081+\u03c9\u2088), the unique 779247-dim irrep of e\u2088. Tensor square (LiE-verified) has 40 distinct simple summand isomorphism classes (155 components with multiplicity), with the smallest being the trivial 1-dim, the 248-dim adjoint (mult 2), the 3875-dim V(\u03c9\u2081), and so on up to the 85,424,220,000-dim summand. This is used to produce the existential witness required by the formal statement.",
@@ -376,8 +532,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Topology.CerfGammaFour",
-      "theorem": "cerf_gamma_four",
-      "statement": "(f : sphere (0 : EuclideanSpace \u211d (Fin 4)) 1 \u2243\u2098\u27ee\ud835\udce1 3, \ud835\udce1 3\u27ef\n         sphere (0 : EuclideanSpace \u211d (Fin 4)) 1) :\n    \u2203 (A : Matrix.orthogonalGroup (Fin 4) \u211d)\n      (F F' : unitInterval \u00d7 sphere (0 : EuclideanSpace \u211d (Fin 4)) 1 \u2192\n              sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n      ContMDiff ((\ud835\udce1\u2202 1).prod (\ud835\udce1 3)) (\ud835\udce1 3) \u221e F \u2227\n      ContMDiff ((\ud835\udce1\u2202 1).prod (\ud835\udce1 3)) (\ud835\udce1 3) \u221e F' \u2227\n      (\u2200 t p, F  (t, F' (t, p)) = p) \u2227\n      (\u2200 t p, F' (t, F  (t, p)) = p) \u2227\n      (\u2200 p, F (0, p) = f p) \u2227\n      (\u2200 p, (F (1, p) : EuclideanSpace \u211d (Fin 4)) =\n            Matrix.UnitaryGroup.toLinearEquiv A\n              (p : EuclideanSpace \u211d (Fin 4)))",
+      "holes": [
+        {
+          "name": "LeanEval.Topology.cerf_gamma_four",
+          "basename": "cerf_gamma_four",
+          "kind": "theorem",
+          "body": "/-- **Cerf's theorem \u0393\u2084 = 0.** Every self-diffeomorphism of S\u00b3 is smoothly isotopic to\nthe restriction of a linear isometry of \u211d\u2074. -/\ntheorem cerf_gamma_four\n    (f : sphere (0 : EuclideanSpace \u211d (Fin 4)) 1 \u2243\u2098\u27ee\ud835\udce1 3, \ud835\udce1 3\u27ef\n         sphere (0 : EuclideanSpace \u211d (Fin 4)) 1) :\n    \u2203 (A : Matrix.orthogonalGroup (Fin 4) \u211d)\n      (F F' : unitInterval \u00d7 sphere (0 : EuclideanSpace \u211d (Fin 4)) 1 \u2192\n              sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n      ContMDiff ((\ud835\udce1\u2202 1).prod (\ud835\udce1 3)) (\ud835\udce1 3) \u221e F \u2227\n      ContMDiff ((\ud835\udce1\u2202 1).prod (\ud835\udce1 3)) (\ud835\udce1 3) \u221e F' \u2227\n      (\u2200 t p, F  (t, F' (t, p)) = p) \u2227\n      (\u2200 t p, F' (t, F  (t, p)) = p) \u2227\n      (\u2200 p, F (0, p) = f p) \u2227\n      (\u2200 p, (F (1, p) : EuclideanSpace \u211d (Fin 4)) =\n            Matrix.UnitaryGroup.toLinearEquiv A\n              (p : EuclideanSpace \u211d (Fin 4))) := by\n  sorry"
+        }
+      ],
       "notes": "Cerf's 1968 theorem, the X = point (unparameterized) case of the Smale conjecture. Stated as the existence of a smooth isotopy [0,1] x S3 -> S3 from f to a linear isometry, witnessed by a smooth slice-inverse to encode the diffeomorphism property of each slice without needing a topology on Diffeomorph.",
       "source": "J. Cerf, Sur les diffeomorphismes de la sphere de dimension trois, Lecture Notes in Mathematics 53, Springer (1968).",
       "informal_solution": "Cerf's original proof uses pseudo-isotopy theory: a self-diffeomorphism of S3 extends to a pseudo-isotopy of D4, and Cerf's theorem on the triviality of pi_0 of the pseudo-isotopy space in dimension 4 implies the extension is isotopic to a genuine isotopy. Hatcher (1983) reproved this as a corollary of the full Smale conjecture using configurations of 2-spheres.",
@@ -390,8 +552,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Topology.SmaleConjecture",
-      "theorem": "smale_conjecture",
-      "statement": "{n : \u2115} [NeZero n]\n    (X : Type) [TopologicalSpace X] [T2Space X] [SecondCountableTopology X]\n    [ChartedSpace (EuclideanHalfSpace n) X] [IsManifold (\ud835\udce1\u2202 n) \u221e X]\n    [CompactSpace X]\n    (F F' : X \u00d7 sphere (0 : EuclideanSpace \u211d (Fin 4)) 1 \u2192\n            sphere (0 : EuclideanSpace \u211d (Fin 4)) 1)\n    (hF  : ContMDiff ((\ud835\udce1\u2202 n).prod (\ud835\udce1 3)) (\ud835\udce1 3) \u221e F)\n    (hF' : ContMDiff ((\ud835\udce1\u2202 n).prod (\ud835\udce1 3)) (\ud835\udce1 3) \u221e F')\n    (hFinv\u2081 : \u2200 x p, F  (x, F' (x, p)) = p)\n    (hFinv\u2082 : \u2200 x p, F' (x, F  (x, p)) = p)\n    (\u03c8_bdry : (\ud835\udce1\u2202 n).boundary X \u2192 Matrix.orthogonalGroup (Fin 4) \u211d)\n    (h\u03c8_bdry_cont : Continuous \u03c8_bdry)\n    (hF_bdry : \u2200 (b : (\ud835\udce1\u2202 n).boundary X)\n                 (p : sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n              (F ((b : X), p) : EuclideanSpace \u211d (Fin 4)) =\n                Matrix.UnitaryGroup.toLinearEquiv (\u03c8_bdry b)\n                  (p : EuclideanSpace \u211d (Fin 4))) :\n    \u2203 (\u03c8 : X \u2192 Matrix.orthogonalGroup (Fin 4) \u211d)\n      (H H' : X \u00d7 unitInterval \u00d7 sphere (0 : EuclideanSpace \u211d (Fin 4)) 1 \u2192\n              sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n      Continuous \u03c8 \u2227\n      (\u2200 b : (\ud835\udce1\u2202 n).boundary X, \u03c8 (b : X) = \u03c8_bdry b) \u2227\n      ContMDiff ((\ud835\udce1\u2202 n).prod ((\ud835\udce1\u2202 1).prod (\ud835\udce1 3))) (\ud835\udce1 3) \u221e H \u2227\n      ContMDiff ((\ud835\udce1\u2202 n).prod ((\ud835\udce1\u2202 1).prod (\ud835\udce1 3))) (\ud835\udce1 3) \u221e H' \u2227\n      (\u2200 x t p, H  (x, t, H' (x, t, p)) = p) \u2227\n      (\u2200 x t p, H' (x, t, H  (x, t, p)) = p) \u2227\n      (\u2200 x p, H (x, 0, p) = F (x, p)) \u2227\n      (\u2200 x (p : sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n              (H (x, 1, p) : EuclideanSpace \u211d (Fin 4)) =\n              Matrix.UnitaryGroup.toLinearEquiv (\u03c8 x)\n                (p : EuclideanSpace \u211d (Fin 4))) \u2227\n      (\u2200 (b : (\ud835\udce1\u2202 n).boundary X)\n         (t : unitInterval)\n         (p : sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n              H ((b : X), t, p) = F ((b : X), p))",
+      "holes": [
+        {
+          "name": "LeanEval.Topology.smale_conjecture",
+          "basename": "smale_conjecture",
+          "kind": "theorem",
+          "body": "/-- **Smale conjecture (Hatcher 1983), relative parameterized form.**\nFor every compact smooth manifold-with-boundary `X` and every smooth family `F` of\nself-diffeomorphisms of `S\u00b3` parameterized by `X` whose boundary restriction already\nfactors through the linear action of `O(4)`, there is a smooth isotopy of `F`, rel\n`\u2202X`, to a family fully factoring through `O(4)`. -/\ntheorem smale_conjecture\n    {n : \u2115} [NeZero n]\n    (X : Type) [TopologicalSpace X] [T2Space X] [SecondCountableTopology X]\n    [ChartedSpace (EuclideanHalfSpace n) X] [IsManifold (\ud835\udce1\u2202 n) \u221e X]\n    [CompactSpace X]\n    (F F' : X \u00d7 sphere (0 : EuclideanSpace \u211d (Fin 4)) 1 \u2192\n            sphere (0 : EuclideanSpace \u211d (Fin 4)) 1)\n    (hF  : ContMDiff ((\ud835\udce1\u2202 n).prod (\ud835\udce1 3)) (\ud835\udce1 3) \u221e F)\n    (hF' : ContMDiff ((\ud835\udce1\u2202 n).prod (\ud835\udce1 3)) (\ud835\udce1 3) \u221e F')\n    (hFinv\u2081 : \u2200 x p, F  (x, F' (x, p)) = p)\n    (hFinv\u2082 : \u2200 x p, F' (x, F  (x, p)) = p)\n    (\u03c8_bdry : (\ud835\udce1\u2202 n).boundary X \u2192 Matrix.orthogonalGroup (Fin 4) \u211d)\n    (h\u03c8_bdry_cont : Continuous \u03c8_bdry)\n    (hF_bdry : \u2200 (b : (\ud835\udce1\u2202 n).boundary X)\n                 (p : sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n              (F ((b : X), p) : EuclideanSpace \u211d (Fin 4)) =\n                Matrix.UnitaryGroup.toLinearEquiv (\u03c8_bdry b)\n                  (p : EuclideanSpace \u211d (Fin 4))) :\n    \u2203 (\u03c8 : X \u2192 Matrix.orthogonalGroup (Fin 4) \u211d)\n      (H H' : X \u00d7 unitInterval \u00d7 sphere (0 : EuclideanSpace \u211d (Fin 4)) 1 \u2192\n              sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n      Continuous \u03c8 \u2227\n      (\u2200 b : (\ud835\udce1\u2202 n).boundary X, \u03c8 (b : X) = \u03c8_bdry b) \u2227\n      ContMDiff ((\ud835\udce1\u2202 n).prod ((\ud835\udce1\u2202 1).prod (\ud835\udce1 3))) (\ud835\udce1 3) \u221e H \u2227\n      ContMDiff ((\ud835\udce1\u2202 n).prod ((\ud835\udce1\u2202 1).prod (\ud835\udce1 3))) (\ud835\udce1 3) \u221e H' \u2227\n      (\u2200 x t p, H  (x, t, H' (x, t, p)) = p) \u2227\n      (\u2200 x t p, H' (x, t, H  (x, t, p)) = p) \u2227\n      (\u2200 x p, H (x, 0, p) = F (x, p)) \u2227\n      (\u2200 x (p : sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n              (H (x, 1, p) : EuclideanSpace \u211d (Fin 4)) =\n              Matrix.UnitaryGroup.toLinearEquiv (\u03c8 x)\n                (p : EuclideanSpace \u211d (Fin 4))) \u2227\n      (\u2200 (b : (\ud835\udce1\u2202 n).boundary X)\n         (t : unitInterval)\n         (p : sphere (0 : EuclideanSpace \u211d (Fin 4)) 1),\n              H ((b : X), t, p) = F ((b : X), p)) := by\n  sorry"
+        }
+      ],
       "notes": "Hatcher's 1983 theorem that Diff(S3) is homotopy equivalent to O(4), stated in the relative-parameterized-family form (families on a compact manifold-with-boundary X whose boundary already factors through O(4) deform rel boundary to a family fully factoring through O(4)). Mathlib does not yet carry the C-infinity topology on Diffeomorph, which would be needed for the direct homotopy-equivalence formulation.",
       "source": "A. Hatcher, A proof of the Smale conjecture, Diff(S3) = O(4), Ann. of Math. 117 (1983).",
       "informal_solution": "Hatcher proves Diff(S3) is homotopy equivalent to O(4) by analyzing configurations of 2-spheres in S3 (the bigon criterion) and deducing by induction that every self-diffeomorphism is isotopic to a linear one, with all higher parameterized versions handled by the same incompressible-surface machinery.",
@@ -404,8 +572,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.NumberTheory.SmallHouse",
-      "theorem": "cyclotomic_integer_house_le_two",
-      "statement": "{K : Type*} [Field K] [NumberField K] [Algebra \u211a K]\n    (n : \u2115) [NeZero n] [IsCyclotomicExtension {n} \u211a K] {\u03b2 : K}\n    (h\u03b2_int : IsIntegral \u2124 \u03b2)\n    (h\u03b2_real : \u03b2 \u2208 NumberField.maximalRealSubfield K) :\n    house \u03b2 \u2264 2 \u2192\n      house \u03b2 = 2 \u2228 \u2203 m : \u2115, 0 < m \u2227 house \u03b2 = 2 * Real.cos (Real.pi / m)",
+      "holes": [
+        {
+          "name": "LeanEval.NumberTheory.cyclotomic_integer_house_le_two",
+          "basename": "cyclotomic_integer_house_le_two",
+          "kind": "theorem",
+          "body": "theorem cyclotomic_integer_house_le_two\n    {K : Type*} [Field K] [NumberField K] [Algebra \u211a K]\n    (n : \u2115) [NeZero n] [IsCyclotomicExtension {n} \u211a K] {\u03b2 : K}\n    (h\u03b2_int : IsIntegral \u2124 \u03b2)\n    (h\u03b2_real : \u03b2 \u2208 NumberField.maximalRealSubfield K) :\n    house \u03b2 \u2264 2 \u2192\n      house \u03b2 = 2 \u2228 \u2203 m : \u2115, 0 < m \u2227 house \u03b2 = 2 * Real.cos (Real.pi / m) := by\n  sorry"
+        }
+      ],
       "notes": "The <= 2 branch of Theorem 1.0.5 from Calegari--Morrison--Snyder, stated using Mathlib's NumberField.house.",
       "source": "https://arxiv.org/pdf/1004.0665",
       "informal_solution": "If the house is at most 2, then it equals 2 cos(pi / m) for some positive integer m.",
@@ -418,8 +592,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.NumberTheory.SmallHouse",
-      "theorem": "cyclotomic_integer_house_between_two_and_76_33",
-      "statement": "{K : Type*} [Field K] [NumberField K] [Algebra \u211a K]\n    (n : \u2115) [NeZero n] [IsCyclotomicExtension {n} \u211a K] {\u03b2 : K}\n    (h\u03b2_int : IsIntegral \u2124 \u03b2)\n    (h\u03b2_real : \u03b2 \u2208 NumberField.maximalRealSubfield K) :\n    (2 < house \u03b2 \u2227 house \u03b2 < (76 : \u211d) / 33) \u2192\n      house \u03b2 = (7 + Real.sqrt 3) / 2 \u2228\n      house \u03b2 = Real.sqrt 5 \u2228\n      house \u03b2 = 1 + 2 * Real.cos (2 * Real.pi / 7) \u2228\n      house \u03b2 = (1 + Real.sqrt 5) / Real.sqrt 2 \u2228\n      house \u03b2 = (1 + Real.sqrt 13) / 2",
+      "holes": [
+        {
+          "name": "LeanEval.NumberTheory.cyclotomic_integer_house_between_two_and_76_33",
+          "basename": "cyclotomic_integer_house_between_two_and_76_33",
+          "kind": "theorem",
+          "body": "theorem cyclotomic_integer_house_between_two_and_76_33\n    {K : Type*} [Field K] [NumberField K] [Algebra \u211a K]\n    (n : \u2115) [NeZero n] [IsCyclotomicExtension {n} \u211a K] {\u03b2 : K}\n    (h\u03b2_int : IsIntegral \u2124 \u03b2)\n    (h\u03b2_real : \u03b2 \u2208 NumberField.maximalRealSubfield K) :\n    (2 < house \u03b2 \u2227 house \u03b2 < (76 : \u211d) / 33) \u2192\n      house \u03b2 = (7 + Real.sqrt 3) / 2 \u2228\n      house \u03b2 = Real.sqrt 5 \u2228\n      house \u03b2 = 1 + 2 * Real.cos (2 * Real.pi / 7) \u2228\n      house \u03b2 = (1 + Real.sqrt 5) / Real.sqrt 2 \u2228\n      house \u03b2 = (1 + Real.sqrt 13) / 2 := by\n  sorry"
+        }
+      ],
       "notes": "The 2 < house < 76/33 branch of Theorem 1.0.5 from Calegari--Morrison--Snyder, stated using Mathlib's NumberField.house.",
       "source": "https://arxiv.org/pdf/1004.0665",
       "informal_solution": "If the house lies in (2, 76/33), then it is one of the five explicitly listed values.",
@@ -432,8 +612,14 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Analysis.Gleason",
-      "theorem": "gleason_theorem_finite",
-      "statement": "{H : Type*} [NormedAddCommGroup H] [InnerProductSpace \u2102 H]\n      [CompleteSpace H] [FiniteDimensional \u2102 H]\n    (hdim : 3 \u2264 Module.finrank \u2102 H)\n    (f : FrameFunction H) :\n    \u2203! \u03c1 : H \u2192L[\u2102] H,\n      ContinuousLinearMap.IsPositive \u03c1 \u2227\n      reTr \u03c1 = 1 \u2227\n      \u2200 P : H \u2192L[\u2102] H, IsOrthProj P \u2192 f.\u03bc P = reTr (\u03c1 * P)",
+      "holes": [
+        {
+          "name": "LeanEval.Analysis.gleason_theorem_finite",
+          "basename": "gleason_theorem_finite",
+          "kind": "theorem",
+          "body": "/-- **Gleason's theorem**, finite-dimensional version. For `dim H \u2265 3`, every frame\nfunction on the projection lattice of `H` is given by `P \u21a6 re Tr(\u03c1 P)` for the unique\ndensity operator `\u03c1` (positive, `re Tr \u03c1 = 1`). -/\ntheorem gleason_theorem_finite\n    {H : Type*} [NormedAddCommGroup H] [InnerProductSpace \u2102 H]\n      [CompleteSpace H] [FiniteDimensional \u2102 H]\n    (hdim : 3 \u2264 Module.finrank \u2102 H)\n    (f : FrameFunction H) :\n    \u2203! \u03c1 : H \u2192L[\u2102] H,\n      ContinuousLinearMap.IsPositive \u03c1 \u2227\n      reTr \u03c1 = 1 \u2227\n      \u2200 P : H \u2192L[\u2102] H, IsOrthProj P \u2192 f.\u03bc P = reTr (\u03c1 * P) := by\n  sorry"
+        }
+      ],
       "notes": "Gleason's theorem in finite dimensions: every frame function on the orthogonal projections of a complex Hilbert space of dimension at least 3 is given by P \u21a6 Tr(\u03c1 P) for the unique density operator \u03c1. Stated using a bespoke `FrameFunction` structure (non-negative, additive on orthogonal projection pairs, normalized at the identity) and the standard Mathlib trace `LinearMap.trace`. Finite additivity on orthogonal pairs already implies countable additivity in finite dimensions, so the hypothesis matches Gleason's original \u03c3-additive frame functions.",
       "source": "A. M. Gleason, Measures on the closed subspaces of a Hilbert space, J. Math. Mech. 6 (1957), 885-893.",
       "informal_solution": "Gleason's original proof analyses regular frame functions on the unit sphere of R^3 by showing they are continuous and then quadratic, then promotes the resulting positive quadratic form on every 3-dimensional real subspace of H to a positive operator \u03c1 on H whose diagonal in any orthonormal basis recovers the frame function, with Tr(\u03c1) = \u03bc(I) = 1 ensuring \u03c1 is a density operator.",
@@ -446,13 +632,297 @@
       "test": false,
       "submitter": "Kim Morrison",
       "module": "LeanEval.Analysis.Gleason",
-      "theorem": "gleason_theorem_separable",
-      "statement": "{H : Type*} [NormedAddCommGroup H] [InnerProductSpace \u2102 H]\n      [CompleteSpace H] [TopologicalSpace.SeparableSpace H]\n    (hdim : 3 \u2264 Module.rank \u2102 H)\n    (f : SphereFrameFunction H) :\n    \u2203 \u03c1 : H \u2192L[\u2102] H,\n      ContinuousLinearMap.IsPositive \u03c1 \u2227\n      \u2200 x : Metric.sphere (0 : H) 1,\n        f.f x = (inner \u2102 (x : H) (\u03c1 (x : H))).re",
+      "holes": [
+        {
+          "name": "LeanEval.Analysis.gleason_theorem_separable",
+          "basename": "gleason_theorem_separable",
+          "kind": "theorem",
+          "body": "/-- **Gleason's theorem**, separable Hilbert space version (Gleason's original 1957\nformulation). For a separable complex Hilbert space `H` of dimension at least `3`, every\nframe function on the unit sphere of `H` is given by `x \u21a6 re \u27e8x, \u03c1 x\u27e9` for some positive\nbounded operator `\u03c1`. (The Lean conclusion does not separately assert trace-class /\n`Tr \u03c1 = 1`; see the file docstring.) -/\ntheorem gleason_theorem_separable\n    {H : Type*} [NormedAddCommGroup H] [InnerProductSpace \u2102 H]\n      [CompleteSpace H] [TopologicalSpace.SeparableSpace H]\n    (hdim : 3 \u2264 Module.rank \u2102 H)\n    (f : SphereFrameFunction H) :\n    \u2203 \u03c1 : H \u2192L[\u2102] H,\n      ContinuousLinearMap.IsPositive \u03c1 \u2227\n      \u2200 x : Metric.sphere (0 : H) 1,\n        f.f x = (inner \u2102 (x : H) (\u03c1 (x : H))).re := by\n  sorry"
+        }
+      ],
       "notes": "Gleason's theorem for a separable complex Hilbert space H of dimension at least 3, in Gleason's original `frame function on the unit sphere' formulation: any non-negative function on the unit sphere whose values sum to 1 along every Hilbert basis is given by x \u21a6 re \u27e8x, \u03c1 x\u27e9 for some positive bounded operator \u03c1. The Lean conclusion does not assert that \u03c1 is trace-class with Tr(\u03c1) = 1; stating that would require trace-class infrastructure not yet at this Mathlib pin. This side-steps the absence of Schatten 1 / trace-class infrastructure in Mathlib at the time of writing.",
       "source": "A. M. Gleason, Measures on the closed subspaces of a Hilbert space, J. Math. Mech. 6 (1957), 885-893.",
       "informal_solution": "Reduce to the real 3-dimensional case via restriction to real subspaces of H, where Gleason's continuity argument plus an analysis of regular frame functions on S^2 gives a positive quadratic form. Patch these forms together using rotation-invariance and the assumed basis-sum normalization to obtain a globally defined positive bounded operator \u03c1 on H reproducing the frame function on every unit vector.",
       "challenge_path": "generated/gleason_theorem_separable",
       "sort_index": 31
+    },
+    {
+      "id": "jacobian_challenge_diffgeo",
+      "title": "Jacobian of a compact Riemann surface (Buzzard challenge)",
+      "test": false,
+      "submitter": "Kevin Buzzard",
+      "module": "LeanEval.Geometry.JacobianChallenge",
+      "holes": [
+        {
+          "name": "JacobianChallenge.genus",
+          "basename": "genus",
+          "kind": "def",
+          "body": "def genus (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]\n    [Nonempty X] [ChartedSpace \u2102 X] [IsManifold (modelWithCornersSelf \u2102 \u2102) \u03c9 X] : \u2115 := sorry"
+        },
+        {
+          "name": "JacobianChallenge.genus_eq_zero_iff_homeo",
+          "basename": "genus_eq_zero_iff_homeo",
+          "kind": "theorem",
+          "body": "theorem genus_eq_zero_iff_homeo :\n    genus X = 0 \u2194 Nonempty (X \u2243\u209c (Metric.sphere (0 : EuclideanSpace \u211d (Fin 3)) 1)) :=\n  sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian",
+          "basename": "Jacobian",
+          "kind": "def",
+          "body": "def Jacobian (X : Type u) [TopologicalSpace X] [T2Space X] [CompactSpace X] [ConnectedSpace X]\n    [Nonempty X] [ChartedSpace \u2102 X] [IsManifold (modelWithCornersSelf \u2102 \u2102) \u03c9 X] : Type u := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.instAddCommGroup",
+          "basename": "instAddCommGroup",
+          "kind": "def",
+          "body": "instance instAddCommGroup : AddCommGroup (Jacobian X) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.instTopologicalSpace",
+          "basename": "instTopologicalSpace",
+          "kind": "def",
+          "body": "instance instTopologicalSpace : TopologicalSpace (Jacobian X) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.instT2Space",
+          "basename": "instT2Space",
+          "kind": "theorem",
+          "body": "instance instT2Space : T2Space (Jacobian X) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.instCompactSpace",
+          "basename": "instCompactSpace",
+          "kind": "theorem",
+          "body": "instance instCompactSpace : CompactSpace (Jacobian X) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.instChartedSpace",
+          "basename": "instChartedSpace",
+          "kind": "def",
+          "body": "instance instChartedSpace : ChartedSpace (Fin (genus X) \u2192 \u2102) (Jacobian X) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.instIsManifold",
+          "basename": "instIsManifold",
+          "kind": "theorem",
+          "body": "instance instIsManifold :\n    IsManifold (modelWithCornersSelf \u2102 (Fin (genus X) \u2192 \u2102)) \u03c9 (Jacobian X) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.instLieAddGroup",
+          "basename": "instLieAddGroup",
+          "kind": "theorem",
+          "body": "instance instLieAddGroup :\n    LieAddGroup (modelWithCornersSelf \u2102 (Fin (genus X) \u2192 \u2102)) \u03c9 (Jacobian X) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.ofCurve",
+          "basename": "ofCurve",
+          "kind": "def",
+          "body": "def ofCurve (P : X) : X \u2192 Jacobian X := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.ofCurve_contMDiff",
+          "basename": "ofCurve_contMDiff",
+          "kind": "theorem",
+          "body": "theorem ofCurve_contMDiff (P : X) :\n    ContMDiff (modelWithCornersSelf \u2102 \u2102)\n      (modelWithCornersSelf \u2102 (Fin (genus X) \u2192 \u2102)) \u03c9 (ofCurve P) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.ofCurve_self",
+          "basename": "ofCurve_self",
+          "kind": "theorem",
+          "body": "theorem ofCurve_self (P : X) : ofCurve P P = 0 := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.ofCurve_inj",
+          "basename": "ofCurve_inj",
+          "kind": "theorem",
+          "body": "theorem ofCurve_inj (P : X) (h : 0 < genus X) : Function.Injective (ofCurve P) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pushforward",
+          "basename": "pushforward",
+          "kind": "def",
+          "body": "def pushforward (f : X \u2192 Y)\n    (hf : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 f) :\n    Jacobian X \u2192\u209c+ Jacobian Y := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pushforward_contMDiff",
+          "basename": "pushforward_contMDiff",
+          "kind": "theorem",
+          "body": "theorem pushforward_contMDiff (f : X \u2192 Y)\n    (hf : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 f) :\n    ContMDiff (modelWithCornersSelf \u2102 (Fin (genus X) \u2192 \u2102))\n      (modelWithCornersSelf \u2102 (Fin (genus Y) \u2192 \u2102)) \u03c9 (pushforward f hf) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pushforward_id_apply",
+          "basename": "pushforward_id_apply",
+          "kind": "theorem",
+          "body": "theorem pushforward_id_apply (P : Jacobian X) :\n    pushforward id contMDiff_id P = P := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pushforward_comp_apply",
+          "basename": "pushforward_comp_apply",
+          "kind": "theorem",
+          "body": "theorem pushforward_comp_apply (f : X \u2192 Y)\n    (hf : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 f)\n    (g : Y \u2192 Z) (hg : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 g)\n    (P : Jacobian X) :\n    pushforward (g \u2218 f) (hg.comp hf) P = pushforward g hg (pushforward f hf P) :=\n  sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pullback",
+          "basename": "pullback",
+          "kind": "def",
+          "body": "def pullback (f : X \u2192 Y)\n    (hf : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 f) :\n    Jacobian Y \u2192\u209c+ Jacobian X := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pullback_contMDiff",
+          "basename": "pullback_contMDiff",
+          "kind": "theorem",
+          "body": "theorem pullback_contMDiff (f : X \u2192 Y)\n    (hf : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 f) :\n    ContMDiff (modelWithCornersSelf \u2102 (Fin (genus Y) \u2192 \u2102))\n      (modelWithCornersSelf \u2102 (Fin (genus X) \u2192 \u2102)) \u03c9 (pullback f hf) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pullback_id_apply",
+          "basename": "pullback_id_apply",
+          "kind": "theorem",
+          "body": "theorem pullback_id_apply (P : Jacobian X) :\n    pullback id contMDiff_id P = P := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pullback_comp_apply",
+          "basename": "pullback_comp_apply",
+          "kind": "theorem",
+          "body": "theorem pullback_comp_apply (f : X \u2192 Y)\n    (hf : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 f)\n    (g : Y \u2192 Z) (hg : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 g)\n    (P : Jacobian Z) :\n    pullback (g.comp f) (hg.comp hf) P = pullback f hf (pullback g hg P) := sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.degree",
+          "basename": "degree",
+          "kind": "def",
+          "body": "def degree (f : X \u2192 Y)\n    (hf : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 f) : \u2115 :=\n  sorry"
+        },
+        {
+          "name": "JacobianChallenge.Jacobian.pushforward_pullback",
+          "basename": "pushforward_pullback",
+          "kind": "theorem",
+          "body": "theorem pushforward_pullback (f : X \u2192 Y)\n    (hf : ContMDiff (modelWithCornersSelf \u2102 \u2102) (modelWithCornersSelf \u2102 \u2102) \u03c9 f)\n    (P : Jacobian Y) :\n    pushforward f hf (pullback f hf P) = (degree f hf) \u2022 P := sorry"
+        }
+      ],
+      "notes": null,
+      "source": "https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge",
+      "informal_solution": "Construct J(X) as H^0(X, Omega^1)* / H_1(X, Z), the period lattice quotient; the Abel-Jacobi map sends a point to the linear functional 'integrate from a fixed basepoint to here'. Functoriality and the projection formula come from pushforward and pullback of differential forms.",
+      "challenge_path": "generated/jacobian_challenge_diffgeo",
+      "sort_index": 32
+    },
+    {
+      "id": "jacobian_challenge_alggeo",
+      "title": "Jacobian of a smooth proper curve (Merten challenge)",
+      "test": false,
+      "submitter": "Christian Merten",
+      "module": "LeanEval.AlgebraicGeometry.JacobianChallenge",
+      "holes": [
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.genus",
+          "basename": "genus",
+          "kind": "def",
+          "body": "/-- The genus of a smooth proper curve. -/\ndef genus (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]\n    [GeometricallyIrreducible C.hom] : \u2115 :=\n  sorry"
+        },
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.Jacobian",
+          "basename": "Jacobian",
+          "kind": "def",
+          "body": "/-- The Jacobian of a smooth, proper curve over a field `k`. -/\ndef Jacobian (C : Over (Spec (.of k))) [IsProper C.hom] [SmoothOfRelativeDimension 1 C.hom]\n    [GeometricallyIrreducible C.hom] : Over (Spec (.of k)) :=\n  sorry"
+        },
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.Jacobian.instGrpObj",
+          "basename": "instGrpObj",
+          "kind": "def",
+          "body": "/-- The group scheme structure on the Jacobian of the curve `C`. -/\ninstance instGrpObj : GrpObj (Jacobian C) :=\n  sorry"
+        },
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.Jacobian.smoothOfRelativeDimension_genus",
+          "basename": "smoothOfRelativeDimension_genus",
+          "kind": "theorem",
+          "body": "/-- The Jacobian of `C` is smooth of relative dimension `g` over `k`, where `g` is the\ngenus of `C`. -/\ninstance smoothOfRelativeDimension_genus :\n    SmoothOfRelativeDimension (genus C) (Jacobian C).hom :=\n  sorry"
+        },
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.Jacobian.instIsProper",
+          "basename": "instIsProper",
+          "kind": "theorem",
+          "body": "/-- The Jacobian of `C` is proper over `k`. -/\ninstance instIsProper : IsProper (Jacobian C).hom :=\n  sorry"
+        },
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.Jacobian.instGeometricallyIrreducible",
+          "basename": "instGeometricallyIrreducible",
+          "kind": "theorem",
+          "body": "/-- The Jacobian of `C` is geometrically irreducible over `k`. -/\ninstance instGeometricallyIrreducible : GeometricallyIrreducible (Jacobian C).hom :=\n  sorry"
+        },
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.Jacobian.ofCurve",
+          "basename": "ofCurve",
+          "kind": "def",
+          "body": "/-- The Abel-Jacobi map from a smooth, proper curve to its Jacobian associated\nto a `k`-rational point of `C`. -/\ndef ofCurve (P : \ud835\udfd9_ (Over (Spec (.of k))) \u27f6 C) : C \u27f6 Jacobian C :=\n  sorry"
+        },
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.Jacobian.comp_ofCurve",
+          "basename": "comp_ofCurve",
+          "kind": "theorem",
+          "body": "/-- The Abel-Jacobi map sends the `k`-rational point `P` to `0`, where `0` (denoted by `\u03b7` below) is\nthe neutral element of the group scheme `Jacobian C`. -/\ntheorem comp_ofCurve (C : Over (Spec (.of k))) [IsProper C.hom]\n    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]\n    (P : \ud835\udfd9_ (Over (Spec (.of k))) \u27f6 C) :\n    P \u226b ofCurve P = \u03b7[Jacobian C] :=\n  sorry"
+        },
+        {
+          "name": "AlgebraicGeometry.JacobianChallenge.Jacobian.exists_unique_ofCurve_comp",
+          "basename": "exists_unique_ofCurve_comp",
+          "kind": "theorem",
+          "body": "/--\nThe universal property of the Jacobian variety: For any abelian variety `A`,\nany morphism `f : C \u27f6 A` such that `f(P) = 0` factors uniquely through the\nJacobian of `C`.\nIn other words, `Jacobian C` is the Albanese variety of `C`.\n-/\ntheorem exists_unique_ofCurve_comp (C : Over (Spec (.of k))) [IsProper C.hom]\n    [SmoothOfRelativeDimension 1 C.hom] [GeometricallyIrreducible C.hom]\n    (P : \ud835\udfd9_ (Over (Spec (.of k))) \u27f6 C)\n    {A : Over (Spec (.of k))} [Smooth A.hom] [IsProper A.hom] [GrpObj A]\n    [GeometricallyIrreducible A.hom] (f : C \u27f6 A) (hf : P \u226b f = \u03b7[A]) :\n    \u2203! (g : Jacobian C \u27f6 A), f = ofCurve P \u226b g :=\n  sorry"
+        }
+      ],
+      "notes": null,
+      "source": "https://leanprover.zulipchat.com/#narrow/stream/583336-Autoformalization/topic/Jacobian%20challenge/near/587802685",
+      "informal_solution": "Build the Albanese variety of C as the universal abelian variety receiving a pointed map from C; Weil's construction of the Jacobian of a curve makes this concrete via Pic^0(C). The universal property is the no-cheating clamp.",
+      "challenge_path": "generated/jacobian_challenge_alggeo",
+      "sort_index": 33
+    },
+    {
+      "id": "def_hole_example",
+      "title": "def-hole minimal example",
+      "test": true,
+      "submitter": "Kim Morrison",
+      "module": "LeanEval.Sandbox.DefHoleExample",
+      "holes": [
+        {
+          "name": "foo",
+          "basename": "foo",
+          "kind": "def",
+          "body": "def foo : Nat := sorry"
+        },
+        {
+          "name": "foo_def",
+          "basename": "foo_def",
+          "kind": "theorem",
+          "body": "theorem foo_def : foo = 37 := sorry"
+        }
+      ],
+      "notes": "Minimal example exercising def + theorem holes through the comparator def-hole pipeline.",
+      "source": null,
+      "informal_solution": null,
+      "challenge_path": "generated/def_hole_example",
+      "sort_index": 34
+    },
+    {
+      "id": "instance_hole_example",
+      "title": "instance-hole minimal example",
+      "test": true,
+      "submitter": "Kim Morrison",
+      "module": "LeanEval.Sandbox.InstanceHoleExample",
+      "holes": [
+        {
+          "name": "WidgetCarrier",
+          "basename": "WidgetCarrier",
+          "kind": "def",
+          "body": "def WidgetCarrier : Type := sorry"
+        },
+        {
+          "name": "instInhabitedWidget",
+          "basename": "instInhabitedWidget",
+          "kind": "def",
+          "body": "instance instInhabitedWidget : Inhabited WidgetCarrier := sorry"
+        }
+      ],
+      "notes": "Minimal example exercising instance + theorem holes; instances must be named so the comparator can address them.",
+      "source": null,
+      "informal_solution": null,
+      "challenge_path": "generated/instance_hole_example",
+      "sort_index": 35
     }
   ]
 }

--- a/site-data/problems.json
+++ b/site-data/problems.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "generated_at": "2026-04-30T13:27:53Z",
+  "generated_at": "2026-04-30T14:40:39Z",
   "benchmark": {
     "repo": "leanprover/lean-eval",
     "commit": "a6091941f833b240fdfa4a37855fe2da0fca1dbd"

--- a/site-data/problems.json
+++ b/site-data/problems.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "generated_at": "2026-04-30T13:21:36Z",
+  "generated_at": "2026-04-30T13:27:53Z",
   "benchmark": {
     "repo": "leanprover/lean-eval",
     "commit": "a6091941f833b240fdfa4a37855fe2da0fca1dbd"

--- a/site-data/problems.json
+++ b/site-data/problems.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 3,
-  "generated_at": "2026-04-30T13:12:58Z",
+  "generated_at": "2026-04-30T13:21:36Z",
   "benchmark": {
     "repo": "leanprover/lean-eval",
     "commit": "a6091941f833b240fdfa4a37855fe2da0fca1dbd"

--- a/static/style.css
+++ b/static/style.css
@@ -629,6 +629,14 @@ nav.top .home {
   color: #d7e2e6;
 }
 
+/* Stack multi-hole anchor blocks with a small gap. Used both inside the
+   popover (`.theorem-card .hole`) and on the problems page, where each
+   `@[eval_problem]`-annotated declaration tied to a manifest entry is
+   rendered as its own highlighted block. */
+.hole + .hole {
+  margin-top: 0.75rem;
+}
+
 .theorem-card-rendered .hl.lean.block {
   margin: 8px 0 0;
   padding: 14px;


### PR DESCRIPTION
This PR teaches the leaderboard's site generator and Verso renderer about the multi-hole problem schema introduced upstream by https://github.com/leanprover/lean-eval/pull/36 (and the per-hole metadata published in https://github.com/leanprover/lean-eval/pull/38). Every `@[eval_problem]`-annotated declaration tied to a single `manifests/problems.toml` entry now renders as its own highlighted Verso block, both on the problems page and inside the home-page hover-popovers.

`site-data/problems.json` bumps to `schema_version: 3`, replacing the scalar `theorem` / `statement` fields with a `holes: [{name, basename, kind, body}]` array per problem, sourced from the benchmark's `generated/<id>/holes.json` artifact. `benchmark-snapshot/BenchmarkProblems/Catalog.lean` now emits one `-- ANCHOR: <id>__<basename>` block per hole; legacy single-theorem entries keep the same one-element shape and render byte-equivalently.

`LeaderboardSite/Data.lean` carries a new `Hole` struct, replaces `theoremName` / `statementText` on `ProblemEntry` with `holes : Array Hole`, and exposes per-hole `anchorSourceText` / `anchorBlockTerms` helpers. `LeaderboardSite/Pages/Problems.lean` iterates the holes and emits one anchor block per hole, wrapped in `<div class=\"hole\">` so the new CSS rule stacks them with a small gap. `LeaderboardSite/Leaderboard.lean`'s home-page popover map becomes `HashMap String (Array (Block Page))`, and the popover stacks every hole; the plain-text fallback joins hole bodies on blank lines.

`scripts/generate_site_data.py` reads `holes.json` from the benchmark workspace and dispatches: legacy single-theorem problems flow through the existing ChallengeDeps / qualification path, multi-hole problems wrap each hole's verbatim body with its own anchor inside the per-problem namespace. `strip_imports` now hoists `import` lines out of `Challenge.lean` regardless of position (the multi-hole sources interleave imports with copyright comments).

The deploy-time `lake exe lean-eval-leaderboard --output _site` build exercises every anchor lookup, so the new shape is validated end-to-end by the existing GitHub Pages CI.

Depends on: https://github.com/leanprover/lean-eval/pull/38 (publishes `generated/<id>/holes.json`).

🤖 Prepared with Claude Code