### PR TITLE
fix: replace root-absolute /submit link with relative URL

### DIFF
--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -119,7 +119,7 @@ private def introParagraphTerms : TermElabM (Array (TSyntax `term)) := do
     ]),
     ← `(paragraph #[
       textInline "Authors are encouraged to submit new problems via PRs to that repository, for inclusion in future benchmark releases. See ",
-      linkInline "Submit" "/submit",
+      linkInline "Submit" "../submit/",
       textInline " for details on submitting solutions."
     ])
   ]


### PR DESCRIPTION
This PR replaces the root-absolute `/submit` link on the Problems page with the relative URL `../submit/`, so the link resolves correctly on GitHub Pages project deployments without relying on Verso's depth-aware `<base href>` injection.

Closes #14.

🤖 Prepared with Claude Code