### PR TITLE
feat: tighten home/problems/submit aesthetics and add coverage matrix

### DIFF
--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -185,6 +185,7 @@ structure LeaderboardEntry where
   lastSolvedAt : String
   submitters : Array SubmitterRef
   notableProblemIds : Array String
+  uniqueProblemIds : Array String
   solvedProblems : Array SolvedProblem
 deriving Quote, Inhabited, Repr
 
@@ -199,6 +200,8 @@ instance : FromJson LeaderboardEntry where
       lastSolvedAt := ← json.getObjValAs? String "last_solved_at"
       submitters := ← json.getObjValAs? (Array SubmitterRef) "submitters"
       notableProblemIds := ← json.getObjValAs? (Array String) "notable_problem_ids"
+      uniqueProblemIds :=
+        (json.getObjValAs? (Array String) "unique_problem_ids").toOption.getD #[]
       solvedProblems := ← json.getObjValAs? (Array SolvedProblem) "solved_problems"
     }
 

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -91,8 +91,15 @@ private def formatDate (iso : String) : String :=
     | _ => iso
   | [] => iso
 
-private def scoreLine (score : LeaderboardScore) : String :=
-  s!"{score.display} total • {score.solvedMain} main • {score.solvedTest} test"
+private def scoreLineHtml (score : LeaderboardScore) : Html :=
+  let solved : String := s!"{score.display} solved"
+  {{
+    <span class="entry-score-line">
+      <span class="entry-score-primary">{{textHtml solved}}</span>
+      <span class="entry-score-pill entry-score-pill--main">{{textHtml s!"{score.solvedMain} main"}}</span>
+      <span class="entry-score-pill entry-score-pill--test">{{textHtml s!"{score.solvedTest} test"}}</span>
+    </span>
+  }}
 
 /-! ## Hero panel -/
 
@@ -120,7 +127,7 @@ private def sectionLabel (text : String) : Block Page :=
 private def heroBlock (summary : LeaderboardSummary) : Block Page :=
   let problemsHref := "problems/"
   let mainProblemsHref := s!"{problemsHref}#main-problems"
-  let testProblemsHref := s!"{problemsHref}#starter-problems"
+  let testProblemsHref := s!"{problemsHref}#test-problems"
   let heroCopy :=
     "Public results on a benchmark of hard Lean formalization problems. "
     ++ "Expand any row to inspect solved theorems, extracted statements, and "
@@ -132,9 +139,9 @@ private def heroBlock (summary : LeaderboardSummary) : Block Page :=
     divBlock "hero-kicker" #[paragraph #[textInline "lean-eval"]],
     htmlBlobBlock {{ <h1 class="hero-title">"Lean AI formalization leaderboard"</h1> }},
     htmlBlobBlock {{ <p class="hero-copy">{{textHtml heroCopy}}</p> }},
-    divBlock "hero-stats" #[
+    divBlock "hero-stats hero-stat-strip" #[
       heroStat summary.models "models",
-      heroStat summary.submitters "submitters",
+      heroStat summary.submitters (pluralize summary.submitters "submitter" "submitters"),
       heroStatLink summary.problems "problems" problemsHref
     ]
   ]
@@ -190,7 +197,12 @@ private def problemItem
   }}
   let proofLink := match proofUrl? with
     | some url => htmlBlobBlock {{
-        <a class="problem-proof-link" href={{url}}>"proof"</a>
+        <a class="problem-proof-link" href={{url}}>
+          <span>"proof"</span>
+          <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M9 1v1.5h3.44L6.97 7.97l1.06 1.06L13.5 3.56V7H15V1H9zM2 3v11h11V8.5h-1.5V12.5h-8v-8H6.5V3H2z"/>
+          </svg>
+        </a>
       }}
     | none => htmlBlobBlock {{ <span></span> }}
   let rarityChip := match rarityRank? with
@@ -216,7 +228,11 @@ private def problemItem
     divBlock "problem-meta-row" #[
       htmlWrapperBlock "span" #[("class", "problem-id-wrap")] #[
         htmlBlobBlock {{
-          <span class="problem-id-trigger" tabindex="0">{{textHtml problemId}}</span>
+          <span class="problem-id-trigger" role="button" tabindex="0"
+                aria-haspopup="true"
+                aria-label={{s!"Show theorem statement for {problemId}"}}>
+            {{textHtml problemId}}
+          </span>
         }},
         theoremCard anchorMap problemId statement
       ],
@@ -236,64 +252,57 @@ private def problemTitleAndStatement
 
 /-- Render the `<summary>` row for an entry. -/
 private def entrySummary (entry : LeaderboardEntry) : Html :=
-  let suffix := if entry.submitterCount == 1 then "" else "s"
-  let line := scoreLine entry.score
   {{
     <span class="entry-rank">{{textHtml (toString entry.rank)}}</span>
     <span class="entry-model">
       <span class="entry-model-name">{{textHtml entry.modelName}}</span>
-      <span class="entry-model-meta">{{
-        textHtml s!"{entry.submitterCount} submitter{suffix}"
-      }}</span>
     </span>
-    <span class="entry-score">{{textHtml line}}</span>
+    <span class="entry-score">{{scoreLineHtml entry.score}}</span>
   }}
 
-/-- Render the body of a `<details>` row: notable problems + provenance. -/
+/-- Render the body of a `<details>` row: solved-by-this-model + provenance. -/
 private def entryBody
     (problems : Std.HashMap String (String × String))
     (anchorMap : Std.HashMap String (Array (Block Page)))
     (entry : LeaderboardEntry) : Array (Block Page) :=
-  let notable := entry.notableProblemIds.filterMap fun pid =>
+  let unique := entry.uniqueProblemIds.filterMap fun pid =>
     entry.solvedProblems.find? (·.problemId == pid)
-  let notableItems : Array (Block Page) :=
-    if notable.isEmpty then
-      #[htmlBlobBlock {{
-          <p class="empty-state">"No public solves recorded for this row yet."</p>
-        }}]
+  let uniqueSection : Array (Block Page) :=
+    if unique.isEmpty then
+      #[]
     else
-      notable.map fun item =>
+      let items : Array (Block Page) := unique.map fun item =>
         let (title, statement) := problemTitleAndStatement problems item.problemId
         let proofUrl? := if item.publicSolution.available then item.publicSolution.url else none
         problemItem anchorMap item.problemId title statement proofUrl? (some item.rarityRank)
           item.productionDescription
+      #[divBlock "entry-section" #[
+          sectionLabel "Problems uniquely solved by this model",
+          divBlock "problem-grid" items
+        ]]
   let submitters : Html :=
     if entry.submitters.isEmpty then
       {{ <span class="empty-inline">"None"</span> }}
     else
       Html.fromArray (entry.submitters.map fun s =>
         {{ <span class="submitter-chip">{{textHtml s.user}} <span>{{textHtml (toString s.solvedTotal)}}</span></span> }})
-  #[
-    divBlock "entry-section" #[
-      sectionLabel "Notable solved problems",
-      divBlock "problem-grid" notableItems
-    ],
+  let provenanceSection : Block Page :=
     divBlock "entry-section entry-side" #[
-      sectionLabel "Row provenance",
+      sectionLabel "Submission history",
       htmlBlobBlock {{
         <div class="stat-pair">
-          <span>"First solve"</span>
+          <span>"First submission"</span>
           <span>{{textHtml (formatDate entry.firstSolvedAt)}}</span>
         </div>
         <div class="stat-pair">
-          <span>"Latest solve"</span>
+          <span>"Last submission"</span>
           <span>{{textHtml (formatDate entry.lastSolvedAt)}}</span>
         </div>
       }},
       sectionLabel "Contributors",
       htmlBlobBlock {{ <div class="submitter-list">{{submitters}}</div> }}
     ]
-  ]
+  uniqueSection.push provenanceSection
 
 private def entryBlock
     (problems : Std.HashMap String (String × String))
@@ -336,6 +345,61 @@ private def emptyShowcase
     divBlock "empty-problem-list" previewItems
   ]
 
+/-! ## Coverage matrix -/
+
+/-- Build a coverage matrix block: rows = problems (in catalog order),
+columns = models (in current rank order). Each cell is a check or a
+dash showing whether the model has a recorded solve. The matrix is
+hidden on narrow viewports via CSS — desktop users get the dense view,
+mobile/tablet keep the existing list view. -/
+private def coverageMatrix
+    (problemMeta : Array (String × String × Bool))
+    (entries : Array LeaderboardEntry) : Block Page :=
+  let solverSets : Array (Std.HashSet String) :=
+    entries.map fun e =>
+      e.solvedProblems.foldl (init := ({} : Std.HashSet String))
+        (fun s p => s.insert p.problemId)
+  let headerCells : Html := Html.fromArray <|
+    #[{{ <th scope="col">"Problem"</th> }}] ++
+    entries.map (fun e =>
+      {{ <th scope="col">{{textHtml e.modelName}}</th> }})
+  let rows : Array Html := problemMeta.map fun (id, title, isTest) =>
+    let kindClass := if isTest then "coverage-kind coverage-kind--test"
+                                else "coverage-kind coverage-kind--main"
+    let kindLabel := if isTest then "test" else "main"
+    let cells : Array Html := entries.zipIdx.map fun (_, i) =>
+      let solved := (solverSets[i]!).contains id
+      if solved then
+        {{ <td class="coverage-cell coverage-cell--solved" aria-label={{s!"{title}: solved"}}>"✓"</td> }}
+      else
+        {{ <td class="coverage-cell coverage-cell--unsolved" aria-label={{s!"{title}: not solved"}}>"—"</td> }}
+    let cellsHtml : Html := Html.fromArray cells
+    {{
+      <tr>
+        <th scope="row">
+          <a class="coverage-row-link" href={{s!"problems/{id}/"}}>{{textHtml title}}</a>
+          <span class={{kindClass}}>{{textHtml kindLabel}}</span>
+        </th>
+        {{cellsHtml}}
+      </tr>
+    }}
+  let body : Html := Html.fromArray rows
+  htmlBlobBlock {{
+    <section class="coverage-panel" aria-labelledby="coverage-heading">
+      <div class="panel-kicker">"Coverage"</div>
+      <h2 id="coverage-heading">"Per-problem coverage"</h2>
+      <p class="panel-note">"Which problems each model has solved. Hidden on narrow screens."</p>
+      <div class="coverage-table-wrap">
+        <table class="coverage-table">
+          <thead>
+            <tr>{{headerCells}}</tr>
+          </thead>
+          <tbody>{{body}}</tbody>
+        </table>
+      </div>
+    </section>
+  }}
+
 /-- Render the leaderboard panel: header + either the entry list or the
 empty showcase with a 4-problem catalog preview. -/
 private def leaderboardPanel
@@ -370,19 +434,39 @@ Wrapped in `.leaderboard-root` so it renders full-width. -/
 def leaderboardBlocks
     (summary : LeaderboardSummary)
     (problemEntries : Array (String × String × String))
+    (problemKinds : Array (String × Bool))
     (entries : Array LeaderboardEntry)
     (previewIds : Array String)
     (anchorMap : Std.HashMap String (Array (Block Page))) : Array (Block Page) :=
+  -- Compute uniqueness from leaderboard data (works even when the JSON
+  -- file pre-dates the `unique_problem_ids` field): a problem is
+  -- "uniquely solved" by an entry iff exactly one entry has it.
+  let solverCounts : Std.HashMap String Nat :=
+    entries.foldl (init := ({} : Std.HashMap String Nat)) fun m e =>
+      e.solvedProblems.foldl (init := m) fun m s =>
+        m.insert s.problemId (m.getD s.problemId 0 + 1)
+  let entries := entries.map fun e =>
+    let unique := e.solvedProblems.filterMap fun s =>
+      if solverCounts.getD s.problemId 0 == 1 then some s.problemId else none
+    { e with uniqueProblemIds := unique }
   let problemMap : Std.HashMap String (String × String) :=
     problemEntries.foldl
-      (fun m (id, title, statement) => m.insert id (title, statement))
-      {}
+      (fun m (id, title, statement) => m.insert id (title, statement)) {}
+  let kindMap : Std.HashMap String Bool :=
+    problemKinds.foldl (fun m (id, isTest) => m.insert id isTest) {}
   let preview : Array (String × String × String) :=
     previewIds.filterMap fun id =>
       problemMap[id]?.map fun (title, statement) => (id, title, statement)
+  let problemMeta : Array (String × String × Bool) := problemEntries.map
+    fun (id, title, _) => (id, title, kindMap.getD id false)
+  let leaderboard := leaderboardPanel problemMap anchorMap preview entries
+  let coverage :=
+    if entries.isEmpty then htmlBlobBlock {{ <span></span> }}
+    else coverageMatrix problemMeta entries
   #[divBlock "leaderboard-root" #[
     heroBlock summary,
-    leaderboardPanel problemMap anchorMap preview entries
+    leaderboard,
+    coverage
   ]]
 
 /-! ## Term elaborator
@@ -417,6 +501,8 @@ elab_rules : term
         problems.map fun p =>
           let joined := String.intercalate "\n\n" (p.holes.map (·.body)).toList
           (p.id, p.title, joined)
+      let problemKinds : Array (String × Bool) :=
+        problems.map fun p => (p.id, p.test)
       -- The empty-state preview shows the first four main (non-test)
       -- problems, mirroring what the JS rendering used to emit.
       let mainProblems := problems.filter (!·.test)
@@ -433,6 +519,7 @@ elab_rules : term
       let term ← `(leaderboardBlocks
         $(quote summary)
         $(quote problemTriples)
+        $(quote problemKinds)
         $(quote entries)
         $(quote previewIds)
         $anchorMap)

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -71,6 +71,22 @@ private def sourceParagraphTerm (problem : ProblemEntry) : TermElabM (TSyntax `t
 private def holeWrap (child : Block Page) : Block Page :=
   .other (BlockExt.htmlDiv "hole") #[child]
 
+open Verso.Output Html in
+/-- Render an in-page table of contents as a collapsible `<details>` block.
+Each item links to the per-problem detail page. -/
+private def tocBlock (items : Array (String × String)) : Block Page :=
+  let lis : Verso.Output.Html := Verso.Output.Html.fromArray <|
+    items.map fun (id, title) =>
+      let href := s!"/problems/{id}/"
+      {{ <li><a href={{href}}>{{Verso.Output.Html.text true title}}</a></li> }}
+  let html : Verso.Output.Html := {{
+    <details class="problems-toc">
+      <summary>"All problems"</summary>
+      <ul class="problems-toc-list">{{lis}}</ul>
+    </details>
+  }}
+  Verso.Doc.Block.other (BlockExt.blob html) #[]
+
 /-- Assemble one problem's `Part Page` at runtime from the spliced anchor
 blocks. Routing per-problem assembly through this function keeps the
 elaborator-time syntax tree shallow (one runtime call per problem rather
@@ -136,8 +152,11 @@ elab_rules : term
       let mainSection ← sectionPartTerm "Main benchmark problems" "main-problems" mainProblems
       let mut subParts := #[mainSection]
       if !starterProblems.isEmpty then
-        subParts := subParts.push (← sectionPartTerm "Starter problems" "starter-problems" starterProblems)
-      let introBlocks' : TSyntaxArray `term := introBlocks
+        subParts := subParts.push (← sectionPartTerm "Test problems" "test-problems" starterProblems)
+      let tocItems : Array (String × String) :=
+        (mainProblems ++ starterProblems).map fun p => (p.id, p.title)
+      let tocTerm ← `(tocBlock $(quote tocItems))
+      let introBlocks' : TSyntaxArray `term := introBlocks.push tocTerm
       let subParts' : TSyntaxArray `term := subParts
       let pageTerm ← `(pagePart "Problems" #[$introBlocks',*] #[$subParts',*])
       let expectedType ← Lean.Elab.Term.elabTerm (← `(Part Page)) none

--- a/LeaderboardSite/Pages/Submit.lean
+++ b/LeaderboardSite/Pages/Submit.lean
@@ -1,79 +1,156 @@
 import VersoBlog
 
+open Lean
+open Verso Doc
 open Verso.Genre.Blog
+open Verso.Output Html
 
-#doc (Page) "Submit" =>
+namespace LeaderboardSite.Pages
 
-Submissions are made by opening a GitHub issue on the
-[lean-eval benchmark repository](https://github.com/leanprover/lean-eval).
+private def textInline (text : String) : Inline Page := .text text
+private def codeInline (text : String) : Inline Page := .code text
+private def linkInline (label url : String) : Inline Page :=
+  .link #[.text label] url
+private def emInline (text : String) : Inline Page := .emph #[.text text]
 
-# 1. Put your proof somewhere the lean-eval CI can fetch it
+private def paragraph (contents : Array (Inline Page)) : Block Page :=
+  .para contents
 
-Accepted submission sources are URLs of one of these shapes:
+private def heading (text : String) (htmlId : String) (children : Array (Block Page)) : Part Page :=
+  Verso.Doc.Part.mk #[.text text] text (some { htmlId }) children #[]
 
-* a GitHub repository: `https://github.com/<owner>/<repo>`
-* a GitHub repository pinned to a branch, tag, or commit:
-  `https://github.com/<owner>/<repo>/tree/<ref>` or
-  `https://github.com/<owner>/<repo>/commit/<sha>`
-* a public gist: `https://gist.github.com/<user>/<gist-id>` (optionally with
-  a revision suffix)
+private def pagePart
+    (title : String)
+    (content : Array (Block Page))
+    (subParts : Array (Part Page) := #[]) :
+    Part Page :=
+  .mk #[textInline title] title none content subParts
 
-Private GitHub repositories are supported. To use one, install the
-`lean-eval-bot` GitHub App on the repository first, so that the CI can clone
-it. The install link is in the
-[lean-eval README](https://github.com/leanprover/lean-eval).
+private def bullets (items : Array (Array (Inline Page))) : Block Page :=
+  .ul (items.map fun is => ⟨#[.para is]⟩)
 
-Secret (unlisted) gists are not supported in v1. Make your gist public, or
-host the proof in a repository.
+private def htmlBlob (h : Verso.Output.Html) : Block Page :=
+  Verso.Doc.Block.other (BlockExt.blob h) #[]
 
-# 2. Lay out the proof so CI can find it
+private def ctaBlock : Block Page :=
+  htmlBlob {{
+    <a class="cta-button"
+       href="https://github.com/leanprover/lean-eval/issues/new?template=submit.yml">
+      <span>"Submit benchmark solution"</span>
+      <span aria-hidden="true">" →"</span>
+    </a>
+  }}
 
-The CI walks whatever you submit and tries every directory containing a
-`lakefile.toml` whose `name` field matches a benchmark problem id, and which
-has a `Submission.lean` next to it. For example:
+private def tldrBlock : Block Page :=
+  htmlBlob {{
+    <p class="submit-tldr">
+      "Three steps: host your proof on GitHub or in a public gist, lay it out so CI can match each "
+      <code>"Submission.lean"</code>
+      " to a problem id, and open a pre-filled issue. CI runs the proof through "
+      <a href="https://github.com/leanprover/comparator">"comparator"</a>
+      " and updates the leaderboard automatically."
+    </p>
+  }}
 
-* a clone of a single generated workspace from
-  [leanprover/lean-eval/generated/](https://github.com/leanprover/lean-eval/tree/main/generated)
-* a fork of leanprover/lean-eval itself with your proofs under the relevant
-  `generated/<problem_id>/` directories
-* a custom repository containing several benchmark workspaces side by side
-* a gist containing a two-file minimum: a `lakefile.toml` with
-  `name = "<problem_id>"` and a `Submission.lean`
+private def step1 : Part Page :=
+  heading "1. Put your proof somewhere the lean-eval CI can fetch it" "step-1" #[
+    paragraph #[textInline "Accepted submission sources are URLs of one of these shapes:"],
+    bullets #[
+      #[textInline "a GitHub repository: ",
+        codeInline "https://github.com/<owner>/<repo>"],
+      #[textInline "a GitHub repository pinned to a branch, tag, or commit: ",
+        codeInline "https://github.com/<owner>/<repo>/tree/<ref>",
+        textInline " or ",
+        codeInline "https://github.com/<owner>/<repo>/commit/<sha>"],
+      #[textInline "a public gist: ",
+        codeInline "https://gist.github.com/<user>/<gist-id>",
+        textInline " (optionally with a revision suffix)"]
+    ],
+    paragraph #[
+      textInline "Private GitHub repositories are supported. To use one, ",
+      linkInline "install the lean-eval-bot GitHub App" "https://github.com/apps/lean-eval-bot",
+      textInline " on the repository first, so that the CI can clone it."
+    ],
+    paragraph #[
+      textInline "Secret (unlisted) gists are not supported in v1. Make your gist public, or host the proof in a repository."
+    ]
+  ]
 
-For each matched directory the CI overlays only your `Submission.lean` and
-any files under `Submission/**/*.lean` onto a pristine copy of the benchmark's
-workspace for that problem. Every other file in your submission is ignored,
-including `Solution.lean`, `Challenge.lean`, or any modified `lakefile.toml`.
-The CI then runs [comparator](https://github.com/leanprover/comparator) to
-check the proof.
+private def step2 : Part Page :=
+  heading "2. Lay out the proof so CI can find it" "step-2" #[
+    paragraph #[
+      textInline "The CI walks whatever you submit and tries every directory containing a ",
+      codeInline "lakefile.toml",
+      textInline " whose ",
+      codeInline "name",
+      textInline " field matches a benchmark problem id, and which has a ",
+      codeInline "Submission.lean",
+      textInline " next to it. For example:"
+    ],
+    bullets #[
+      #[textInline "a clone of a single generated workspace from ",
+        linkInline "leanprover/lean-eval/generated/" "https://github.com/leanprover/lean-eval/tree/main/generated"],
+      #[textInline "a fork of leanprover/lean-eval itself with your proofs under the relevant ",
+        codeInline "generated/<problem_id>/", textInline " directories"],
+      #[textInline "a custom repository containing several benchmark workspaces side by side"],
+      #[textInline "a gist containing a two-file minimum: a ",
+        codeInline "lakefile.toml", textInline " with ",
+        codeInline "name = \"<problem_id>\"", textInline " and a ",
+        codeInline "Submission.lean"]
+    ],
+    paragraph #[
+      textInline "For each matched directory the CI overlays only your ",
+      codeInline "Submission.lean",
+      textInline " and any files under ",
+      codeInline "Submission/**/*.lean",
+      textInline " onto a pristine copy of the benchmark's workspace for that problem. Every other file in your submission is ignored, including ",
+      codeInline "Solution.lean", textInline ", ",
+      codeInline "Challenge.lean", textInline ", or any modified ",
+      codeInline "lakefile.toml", textInline ". The CI then runs ",
+      linkInline "comparator" "https://github.com/leanprover/comparator",
+      textInline " to check the proof."
+    ]
+  ]
 
-# 3. Open a submission issue
+private def step3 : Part Page :=
+  heading "3. Open a submission issue" "step-3" #[
+    paragraph #[
+      textInline "Click ",
+      linkInline "Submit benchmark solution" "https://github.com/leanprover/lean-eval/issues/new?template=submit.yml",
+      textInline " to open a pre-filled issue. The form asks for two things:"
+    ],
+    bullets #[
+      #[textInline "a submission URL in one of the shapes above"],
+      #[textInline "a free-form model identifier that identifies the model or system that produced the proof"]
+    ],
+    paragraph #[
+      textInline "When you submit the issue, the lean-eval CI takes over. It clones your content, scans for benchmark workspaces, runs comparator on every match, and records any newly-solved problems in the leaderboard repository. The CI comments on your issue with a per-problem pass/fail summary and closes it when done. Any problem that passes is added to your ",
+      codeInline "results/<your-github-login>.json",
+      textInline " record."
+    ],
+    paragraph #[
+      textInline "Submissions are cumulative. Every success is sticky, and there is no limit on how many times you can submit. Resubmit whenever you have new proofs."
+    ]
+  ]
 
-Click
-[Submit benchmark solution](https://github.com/leanprover/lean-eval/issues/new?template=submit.yml)
-to open a pre-filled issue. The form asks for two things:
+private def whatBecomesPublic : Part Page :=
+  heading "What becomes public" "what-becomes-public" #[
+    paragraph #[
+      textInline "Only the information you enter on the submission form, plus the list of problems your submission solved, becomes public. Your proof is never copied out of the ephemeral workflow runner into any public artifact. The leaderboard only stores identifiers and timestamps."
+    ],
+    paragraph #[
+      textInline "If your submission source was a public repository or a public gist, the leaderboard may link to it so that others can inspect your solution. If the source was private, no link is published."
+    ]
+  ]
 
-* a submission URL in one of the shapes above
-* a free-form model identifier that identifies the model or system that
-  produced the proof
+def _root_.LeaderboardSite.Pages.Submit : VersoDoc Page :=
+  .mk (fun _ => pagePart "Submit"
+    #[ctaBlock, tldrBlock,
+      paragraph #[
+        textInline "Submissions are made by opening a GitHub issue on the ",
+        linkInline "lean-eval benchmark repository" "https://github.com/leanprover/lean-eval",
+        textInline "."
+      ]]
+    #[step1, step2, step3, whatBecomesPublic]) "{}"
 
-When you submit the issue, the lean-eval CI takes over. It clones your
-content, scans for benchmark workspaces, runs comparator on every match, and
-records any newly-solved problems in the leaderboard repository. The CI
-comments on your issue with a per-problem pass/fail summary and closes it
-when done. Any problem that passes is added to your
-`results/<your-github-login>.json` record.
-
-Submissions are cumulative. Every success is sticky, and there is no limit
-on how many times you can submit. Resubmit whenever you have new proofs.
-
-# What becomes public
-
-Only the information you enter on the submission form, plus the list of
-problems your submission solved, becomes public. Your proof is never copied
-out of the ephemeral workflow runner into any public artifact. The
-leaderboard only stores identifiers and timestamps.
-
-If your submission source was a public repository or a public gist, the
-leaderboard may link to it so that others can inspect your solution. If the
-source was private, no link is published.
+end LeaderboardSite.Pages

--- a/SiteTheme.lean
+++ b/SiteTheme.lean
@@ -26,6 +26,11 @@ def theme (name : String) (siteName : String) : Theme := {
             {{ ← param "content" }}
           </div>
         }}
+    let githubIcon : Html := {{
+      <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+      </svg>
+    }}
     return {{
       <html lang="en">
         <head>
@@ -36,6 +41,7 @@ def theme (name : String) (siteName : String) : Theme := {
           <link rel="icon" type="image/svg+xml" href="static/favicon.svg"/>
           <link rel="stylesheet" href="static/style.css"/>
           <script defer="true" src="static/background.js"></script>
+          <script defer="true" src="static/site.js"></script>
         </head>
         <body class={{pageClass}}>
           <div class="site-shell">
@@ -43,7 +49,7 @@ def theme (name : String) (siteName : String) : Theme := {
               <div class="wrap topbar-inner">
                 <a class="wordmark" href=".">
                   <span class="wordmark-mark">"⊢"</span>
-                  <span class="wordmark-text">"Lean AI formalization leaderboard"</span>
+                  <span class="wordmark-text">"lean-eval"</span>
                 </a>
                 {{ ← topNav (homeLink := name) }}
               </div>
@@ -53,9 +59,17 @@ def theme (name : String) (siteName : String) : Theme := {
             </main>
             <footer class="footer">
               <div class="wrap footer-inner">
-                <span>"Public results for lean-eval."</span>
-                <a href="https://github.com/leanprover/lean-eval">"Benchmark repo"</a>
-                <a href="https://github.com/leanprover/lean-eval-leaderboard">"Results repo"</a>
+                <div class="footer-row footer-row--repos">
+                  <span>"Public results for lean-eval."</span>
+                  <a href="https://github.com/leanprover/lean-eval">{{githubIcon}}<span>"Benchmark repo"</span></a>
+                  <a href="https://github.com/leanprover/lean-eval-leaderboard">{{githubIcon}}<span>"Results repo"</span></a>
+                </div>
+                <div class="footer-row footer-row--community">
+                  <span>"Community"</span>
+                  <a href="https://lean-lang.org/">"Lean"</a>
+                  <a href="https://mathlib-initiative.org/">"Mathlib Initiative"</a>
+                  <a href="https://leanprover.zulipchat.com/">"Zulip"</a>
+                </div>
               </div>
             </footer>
           </div>

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -555,6 +555,14 @@ def build_leaderboard_payload(
                 ],
                 "solved_problem_ids": [item["problem_id"] for item in solved_items],
                 "notable_problem_ids": [item["problem_id"] for item in notable[:10]],
+                # Problems where this entry is the only solver across the
+                # whole leaderboard. Used by the home page to highlight
+                # genuinely-unique solves.
+                "unique_problem_ids": [
+                    item["problem_id"]
+                    for item in notable
+                    if solving_model_counts[item["problem_id"]] == 1
+                ],
                 "solved_problems": [
                     {
                         "problem_id": item["problem_id"],

--- a/static/site.js
+++ b/static/site.js
@@ -1,0 +1,30 @@
+// Mark the current page in the top nav with aria-current="page".
+// Walks nav.top a[href] and matches normalized hrefs against the
+// current pathname.
+(function markActiveNav() {
+  function run() {
+    var here = location.pathname.replace(/\/+$/, "") || "/";
+    document.querySelectorAll("nav.top a[href]").forEach(function (a) {
+      var u;
+      try { u = new URL(a.getAttribute("href"), location.href); }
+      catch (_) { return; }
+      var p = u.pathname.replace(/\/+$/, "") || "/";
+      if (p === here) { a.setAttribute("aria-current", "page"); }
+    });
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", run);
+  } else {
+    run();
+  }
+})();
+
+// Esc dismisses an open theorem-card popover by blurring the trigger
+// (the card hides via CSS :focus-within once focus is released).
+document.addEventListener("keydown", function (e) {
+  if (e.key !== "Escape") return;
+  var el = document.activeElement;
+  if (el && el.classList && el.classList.contains("problem-id-trigger")) {
+    el.blur();
+  }
+});

--- a/static/style.css
+++ b/static/style.css
@@ -279,14 +279,15 @@ nav.top .home {
 }
 
 .hero-panel {
-  padding: 32px;
+  padding: 24px 28px;
   margin-bottom: 22px;
 }
 
 .hero-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
-  gap: 28px;
+  gap: 24px;
+  align-items: start;
 }
 
 .hero-kicker,
@@ -323,12 +324,51 @@ nav.top .home {
 .hero-stats {
   display: flex;
   flex-wrap: wrap;
-  gap: 14px;
-  margin-top: 28px;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.hero-stat-strip {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0;
+  margin-top: 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(126, 227, 217, 0.12);
+  background: rgba(13, 18, 23, 0.78);
+  overflow: hidden;
+}
+
+.hero-stat-strip .hero-stat,
+.hero-stat-strip .hero-stat-link {
+  border: 0;
+  border-right: 1px solid rgba(126, 227, 217, 0.08);
+  border-radius: 0;
+  background: transparent;
+  padding: 8px 18px;
+  min-width: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.hero-stat-strip > :last-child {
+  border-right: 0;
+}
+
+.hero-stat-strip .hero-stat span {
+  font-size: 1.05rem;
+  display: inline;
+}
+
+.hero-stat-strip .hero-stat label {
+  display: inline;
+  margin-top: 0;
+  font-size: 0.78rem;
+  color: #93a0a8;
 }
 
 .hero-side {
-  align-self: stretch;
   padding: 6px 0 0 18px;
   border-left: 1px solid rgba(126, 227, 217, 0.08);
 }
@@ -453,16 +493,35 @@ nav.top .home {
 
 .entry summary {
   display: grid;
-  grid-template-columns: 60px minmax(0, 1fr) auto;
+  grid-template-columns: 60px minmax(0, 1fr) auto 24px;
   align-items: center;
   gap: 16px;
   padding: 18px 20px;
   cursor: pointer;
   list-style: none;
+  transition: background-color 140ms ease;
 }
 
 .entry summary::-webkit-details-marker {
   display: none;
+}
+
+.entry summary::after {
+  content: "▾";
+  color: #7fe3d9;
+  font-size: 0.85rem;
+  text-align: center;
+  transition: transform 160ms ease;
+  transform-origin: center;
+}
+
+.entry[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.entry:hover summary,
+.entry summary:focus-visible {
+  background: rgba(126, 227, 217, 0.04);
 }
 
 .entry[open] summary {
@@ -592,12 +651,32 @@ nav.top .home {
 }
 
 .problem-id-trigger {
-  cursor: default;
+  cursor: pointer;
+}
+
+.problem-id-trigger:focus-visible {
+  outline: 2px solid rgba(126, 227, 217, 0.5);
+  outline-offset: 2px;
+}
+
+.problem-proof-link {
+  font-weight: 600;
+  color: #a8f0e5;
+  border-color: rgba(126, 227, 217, 0.32);
+  background: rgba(126, 227, 217, 0.06);
+  gap: 4px;
 }
 
 .problem-proof-link:hover {
   color: #f2f6f8;
-  border-color: rgba(126, 227, 217, 0.22);
+  border-color: rgba(126, 227, 217, 0.55);
+  background: rgba(126, 227, 217, 0.12);
+}
+
+.problem-proof-link svg {
+  width: 11px;
+  height: 11px;
+  flex-shrink: 0;
 }
 
 .theorem-card {
@@ -815,7 +894,315 @@ nav.top .home {
   margin-top: 12px;
 }
 
-@media (max-width: 900px) {
+/* Suppress Verso's `sorry` warning underline + tooltip on theorem cards
+   and the problems page. Problem statements are deliberate placeholders;
+   the warning treatment is noise. */
+.verso-message.warning,
+.has-info.warning > .hover-info {
+  display: none;
+}
+
+.has-info.warning {
+  text-decoration: none;
+  background: transparent;
+}
+
+/* Hide Verso's tactic-state toggle and goal panel — irrelevant on a
+   read-only catalog/leaderboard. */
+input.tactic-toggle,
+.tactic-state {
+  display: none;
+}
+
+label[for^="tactic-state"] {
+  cursor: default;
+}
+
+/* Inline-code overflow control so URL examples on the Submit page don't
+   spill out of the container on narrow viewports. */
+code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* Score pills in leaderboard summary row. */
+.entry-score-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.entry-score-primary {
+  color: #e7ecef;
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.entry-score-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.74rem;
+  border: 1px solid transparent;
+}
+
+.entry-score-pill--main {
+  color: #f4c27b;
+  border-color: rgba(244, 194, 123, 0.28);
+  background: rgba(244, 194, 123, 0.08);
+}
+
+.entry-score-pill--test {
+  color: #9fc7ff;
+  border-color: rgba(159, 199, 255, 0.28);
+  background: rgba(159, 199, 255, 0.08);
+}
+
+/* Active-nav state: highlight the link for the current page. */
+nav.top a[aria-current="page"] {
+  color: #e7ecef;
+  border-bottom: 2px solid rgba(126, 227, 217, 0.65);
+  padding-bottom: 2px;
+}
+
+/* Footer: two-row layout — repos with icons, then community links. */
+.footer-inner {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.footer-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+
+.footer-row a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.footer-row a:focus-visible {
+  outline: 2px solid rgba(126, 227, 217, 0.45);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.footer-row svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.footer-row--community {
+  border-top: 1px solid rgba(126, 227, 217, 0.06);
+  padding-top: 10px;
+  font-size: 0.84rem;
+  color: #93a0a8;
+}
+
+/* Submit-page CTA button: the primary action on /submit. */
+.cta-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 24px;
+  padding: 14px 22px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(126, 227, 217, 0.94), rgba(76, 207, 193, 0.92));
+  color: #0b1014;
+  font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 12px 30px rgba(76, 207, 193, 0.18);
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.cta-button:hover,
+.cta-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px rgba(76, 207, 193, 0.28);
+}
+
+.cta-button:focus-visible {
+  outline: 2px solid rgba(126, 227, 217, 0.65);
+  outline-offset: 3px;
+}
+
+.submit-tldr {
+  margin: 4px 0 18px;
+  padding: 14px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(126, 227, 217, 0.12);
+  background: rgba(13, 18, 23, 0.6);
+  color: #c3cdd2;
+  font-size: 0.95rem;
+}
+
+/* Problems-page table of contents. Collapsed by default. */
+.problems-toc {
+  margin: 0 0 24px;
+  padding: 0;
+  border-radius: 14px;
+  border: 1px solid rgba(126, 227, 217, 0.12);
+  background: rgba(13, 18, 23, 0.6);
+}
+
+.problems-toc > summary {
+  cursor: pointer;
+  padding: 12px 16px;
+  list-style: none;
+  font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+  font-weight: 600;
+  color: #d8e6e5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.problems-toc > summary::-webkit-details-marker {
+  display: none;
+}
+
+.problems-toc > summary::after {
+  content: "▾";
+  color: #7fe3d9;
+  font-size: 0.85rem;
+  transition: transform 160ms ease;
+}
+
+.problems-toc[open] > summary::after {
+  transform: rotate(180deg);
+}
+
+.problems-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 16px 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 4px 16px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.problems-toc-list li {
+  font-size: 0.88rem;
+}
+
+.problems-toc-list a {
+  color: #b8c4ca;
+  text-decoration: none;
+  display: inline-block;
+  padding: 4px 0;
+}
+
+.problems-toc-list a:hover,
+.problems-toc-list a:focus-visible {
+  color: #e7ecef;
+}
+
+/* Coverage matrix panel: rows = problems, cols = models. */
+.coverage-panel {
+  border: 1px solid rgba(126, 227, 217, 0.12);
+  background: rgba(19, 25, 31, 0.78);
+  border-radius: 20px;
+  padding: 22px;
+  margin-top: 22px;
+  box-shadow: 0 16px 60px rgba(0, 0, 0, 0.24);
+}
+
+.coverage-table-wrap {
+  overflow-x: auto;
+  margin-top: 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(126, 227, 217, 0.06);
+}
+
+.coverage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+.coverage-table th,
+.coverage-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid rgba(126, 227, 217, 0.06);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.coverage-table thead th {
+  position: sticky;
+  top: 0;
+  background: rgba(13, 18, 23, 0.96);
+  color: #b8c4ca;
+  font-weight: 500;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.coverage-table tbody tr:hover {
+  background: rgba(126, 227, 217, 0.04);
+}
+
+.coverage-cell {
+  text-align: center;
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  width: 60px;
+}
+
+.coverage-cell--solved {
+  color: #7fe3d9;
+}
+
+.coverage-cell--unsolved {
+  color: #3a4046;
+}
+
+.coverage-row-link {
+  color: #d8e6e5;
+  text-decoration: none;
+}
+
+.coverage-row-link:hover,
+.coverage-row-link:focus-visible {
+  color: #f2f6f8;
+}
+
+.coverage-kind {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-family: "IBM Plex Mono", "SFMono-Regular", monospace;
+  font-size: 0.7rem;
+  margin-left: 8px;
+}
+
+.coverage-kind--main {
+  color: #f4c27b;
+  background: rgba(244, 194, 123, 0.08);
+}
+
+.coverage-kind--test {
+  color: #9fc7ff;
+  background: rgba(159, 199, 255, 0.08);
+}
+
+@media (max-width: 1023px) {
   .topbar-inner,
   .panel-header,
   .entry-body,
@@ -830,17 +1217,26 @@ nav.top .home {
     text-align: left;
   }
 
+  .entry-score-line {
+    justify-content: flex-start;
+  }
+
   .prose ul,
   .prose ol {
     padding-left: 1.15rem;
   }
 
   .entry summary {
-    grid-template-columns: 44px minmax(0, 1fr);
+    grid-template-columns: 44px minmax(0, 1fr) 24px;
   }
 
   .entry-score {
     grid-column: 2;
+  }
+
+  .entry summary::after {
+    grid-column: 3;
+    grid-row: 1;
   }
 
   .entry-side {
@@ -858,15 +1254,61 @@ nav.top .home {
   }
 
   nav.top ol {
-    gap: 12px;
+    gap: 14px;
   }
 
   .theorem-card {
     width: min(520px, calc(100vw - 64px));
   }
 
-  .wordmark-text {
+  /* Hide the coverage matrix on tablet/mobile — use the existing list view. */
+  .coverage-panel {
     display: none;
+  }
+
+  .topbar-inner {
+    display: flex;
+    grid-template-columns: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .topbar-inner {
+    min-height: 56px;
+    gap: 12px;
+  }
+
+  .wordmark-mark {
+    width: 28px;
+    height: 28px;
+    font-size: 1rem;
+  }
+
+  .wordmark-text {
+    font-size: 0.85rem;
+  }
+
+  nav.top ol {
+    gap: 14px;
+    font-size: 0.92rem;
+  }
+
+  .hero-panel {
+    padding: 18px;
+  }
+
+  .hero-grid {
+    gap: 18px;
+  }
+
+  .cta-button {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .footer-row {
+    gap: 12px;
   }
 }
 


### PR DESCRIPTION
This PR addresses ~22 aesthetics and UX items found in a Playwright walkthrough of the leaderboard at desktop, tablet, and mobile widths. The changes touch the theme, the leaderboard renderer, both inner pages, the CSS, and add a small inline JS for active-nav and Esc-dismiss.

The leaderboard hero collapses to a tighter single-row stat strip; the duplicate site title in the topbar is replaced with a "lean-eval" wordmark; the footer gains GitHub icons on the repo links and a second row with links to lean-lang.org, the Mathlib Initiative, and the Leanprover Zulip. Each leaderboard row's score line now renders as a primary "{N} solved" plus two pills "{M} main" and "{K} test"; the duplicate "1 submitter" meta below the model name is removed; the disclosure summary gains a chevron and hover state; "First solve"/"Latest solve" become "First submission"/"Last submission" under the heading "Submission history". The previous "Notable solved problems" section becomes "Problems uniquely solved by this model" and is now actually filtered to problems where exactly one entry has a solve (computed at compile time from the leaderboard data, so it works even before site-data is regenerated; the Python generator also emits a `unique_problem_ids` field for forward compatibility).

A new "Per-problem coverage" matrix is appended below the rankings on desktop: rows are problems in catalog order, columns are models in rank order, cells are check-or-dash. Hidden on tablet/mobile in favour of the existing list view.

The Problems page gains a collapsible "All problems" table-of-contents at the top, links each entry to its per-problem detail page, renames the "Starter problems" anchor to `test-problems`, and the home-page hero card link is updated to match. The Submit page is rewritten to construct blocks programmatically so it can host a prominent CTA button at the top plus a TL;DR paragraph; the lean-eval-bot install instruction is now a direct link to the GitHub App page.

CSS gets a new 480 px mobile breakpoint and the existing 900 px breakpoint expands to 1023 px so tablets collapse to single column; inline `code` gains `overflow-wrap: anywhere` so URL examples on Submit don't spill out of the container. Verso's `sorry`-warning underline and tactic-state toggles are suppressed globally — they're noise on a read-only catalog. Problem-id chips become real buttons with role/aria-label and gain a pointer cursor; proof links get a small external-link icon and bolder treatment.

Two ~10-line inline scripts in `static/site.js` add `aria-current="page"` to the matching nav link on load, and blur a focused problem-id-trigger on Escape to dismiss the popover.

🤖 Prepared with [Claude Code](https://claude.com/claude-code)