### PR TITLE
fix: restore internal links broken by base path / TOC paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,13 +66,15 @@ jobs:
       - name: Build site
         run: lake exe lean-eval-leaderboard --output _site
 
-      - name: Install LinkChecker
+      - name: Check internal links resolve under the GitHub Pages base path
+        # GitHub Pages serves this site under `/lean-eval-leaderboard/`, so a
+        # link like `/foo` (root-absolute) or `../foo` (popping past the base
+        # path) 404s in production even though it might resolve fine against a
+        # flat `_site/` mount. `scripts/check_links.py` emulates the deployed
+        # URL shape and fails on any href/src that escapes the base path or
+        # points at a file that doesn't exist under `_site/`.
         run: |
-          pip install linkchecker
-
-      - name: Run LinkChecker (local links only)
-        run: |
-          linkchecker --config=.linkchecker/linkcheckerrc './_site/'
+          python3 scripts/check_links.py --site-dir _site --prefix lean-eval-leaderboard
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'

--- a/LeaderboardSite/Pages/ProblemDetail.lean
+++ b/LeaderboardSite/Pages/ProblemDetail.lean
@@ -125,7 +125,10 @@ private def sourceParagraph (value : Option String) : Block Page :=
   | none => paragraph #[textInline s!"Source: {unavailableText}"]
 
 private def backLink : Block Page :=
-  paragraph #[linkInline "← All problems" "../"]
+  -- Verso emits a `<base href>` pointing at the site root, so a plain
+  -- `problems/` href resolves to `<root>/problems/` rather than back up
+  -- past the GitHub Pages base path.
+  paragraph #[linkInline "← All problems" "problems/"]
 
 /-- Assemble one detail page's `Part Page` at runtime from spliced anchor
 blocks plus the (already-flattened) solver list. Routing assembly through a

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -75,9 +75,13 @@ open Verso.Output Html in
 /-- Render an in-page table of contents as a collapsible `<details>` block.
 Each item links to the per-problem detail page. -/
 private def tocBlock (items : Array (String × String)) : Block Page :=
+  -- Verso emits a `<base href>` pointing at the site root, so all
+  -- relative URLs in the page resolve from there. We want each TOC
+  -- entry to point at `<root>/problems/<id>/`, so use the explicit
+  -- `problems/<id>/` shape (no leading slash, no `..`).
   let lis : Verso.Output.Html := Verso.Output.Html.fromArray <|
     items.map fun (id, title) =>
-      let href := s!"/problems/{id}/"
+      let href := s!"problems/{id}/"
       {{ <li><a href={{href}}>{{Verso.Output.Html.text true title}}</a></li> }}
   let html : Verso.Output.Html := {{
     <details class="problems-toc">
@@ -135,7 +139,7 @@ private def introParagraphTerms : TermElabM (Array (TSyntax `term)) := do
     ]),
     ← `(paragraph #[
       textInline "Authors are encouraged to submit new problems via PRs to that repository, for inclusion in future benchmark releases. See ",
-      linkInline "Submit" "../submit/",
+      linkInline "Submit" "submit/",
       textInline " for details on submitting solutions."
     ])
   ]

--- a/SiteTheme.lean
+++ b/SiteTheme.lean
@@ -12,6 +12,9 @@ def theme (name : String) (siteName : String) : Theme := {
     let path := (← read).path
     let isHome := path.isEmpty
     let pageClass := if isHome then "home-page" else "inner-page"
+    -- Verso emits a `<base href>` tag pointing at the site root, so all
+    -- relative URLs in the page resolve against that base. Asset and nav
+    -- hrefs below use plain relative paths (no leading `/` or `../`).
     -- The home page emits its own wrappers (a full-width
     -- `.leaderboard-root` for the hero/leaderboard plus a
     -- `.wrap.prose.page-copy` for the intro prose), so the theme just
@@ -51,7 +54,12 @@ def theme (name : String) (siteName : String) : Theme := {
                   <span class="wordmark-mark">"⊢"</span>
                   <span class="wordmark-text">"lean-eval"</span>
                 </a>
-                {{ ← topNav (homeLink := name) }}
+                <nav class="top">
+                  <ol>
+                    <li><a href="problems/">"Problems"</a></li>
+                    <li><a href="submit/">"Submit"</a></li>
+                  </ol>
+                </nav>
               </div>
             </header>
             <main class="page" role="main">

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Check that every internal href/src in _site/ resolves to an actual file
+under the deployed GitHub Pages base path.
+
+GitHub Pages serves this site at `/lean-eval-leaderboard/`, so a link like
+`/foo` (root-absolute) or `../foo` (popping past the base) silently passes
+a flat `linkchecker _site/` check but 404s in production. We catch this by
+mounting `_site/` under that prefix and validating that every internal
+URL falls inside the base path AND points at a real file.
+
+Usage: scripts/check_links.py [--site-dir _site] [--prefix lean-eval-leaderboard]
+
+Exits 0 with no broken links, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+from html.parser import HTMLParser
+from urllib.parse import urlsplit, urljoin
+
+
+ATTR_HOSTING_LINKS = {
+    "a": "href",
+    "link": "href",
+    "script": "src",
+    "img": "src",
+    "iframe": "src",
+}
+
+
+class LinkExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.base: str | None = None
+        self.links: list[tuple[str, int]] = []  # (href, line)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        a = dict(attrs)
+        if tag == "base" and "href" in a and a["href"]:
+            self.base = a["href"]
+            return
+        attr = ATTR_HOSTING_LINKS.get(tag)
+        if not attr:
+            return
+        v = a.get(attr)
+        if not v:
+            return
+        line = self.getpos()[0]
+        self.links.append((v, line))
+
+
+def extract_links(html: str) -> tuple[str | None, list[tuple[str, int]]]:
+    p = LinkExtractor()
+    p.feed(html)
+    return p.base, p.links
+
+
+def is_external(url: str) -> bool:
+    s = urlsplit(url)
+    return bool(s.scheme) and s.scheme not in ("", "file")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--site-dir", default="_site")
+    ap.add_argument("--prefix", default="lean-eval-leaderboard")
+    args = ap.parse_args()
+
+    site = pathlib.Path(args.site_dir).resolve()
+    if not site.is_dir():
+        print(f"site dir not found: {site}", file=sys.stderr)
+        return 2
+
+    prefix = "/" + args.prefix.strip("/") + "/"
+
+    # Gather every HTML file in _site and the page URL it would be served at.
+    pages: list[tuple[pathlib.Path, str]] = []
+    for path in site.rglob("*.html"):
+        rel = path.relative_to(site).as_posix()
+        # Treat foo/index.html as foo/, otherwise foo/bar.html as the file.
+        if rel.endswith("/index.html"):
+            url_path = prefix + rel[: -len("index.html")]
+        elif rel == "index.html":
+            url_path = prefix
+        else:
+            url_path = prefix + rel
+        pages.append((path, url_path))
+
+    issues: list[str] = []
+    checked = 0
+
+    for path, url_path in pages:
+        try:
+            html = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:
+            issues.append(f"{path}: read error: {e}")
+            continue
+        base_href, links = extract_links(html)
+        # Resolve <base href> against the page URL.
+        page_url = "http://example.com" + url_path
+        base_url = urljoin(page_url, base_href) if base_href else page_url
+        for href, line in links:
+            checked += 1
+            if href.startswith(("mailto:", "javascript:", "data:", "#")):
+                continue
+            if is_external(href):
+                # http(s):// URLs to other hosts: skip — out of scope here.
+                if not href.startswith("http://example.com"):
+                    continue
+                target = href
+            else:
+                target = urljoin(base_url, href)
+            ts = urlsplit(target)
+            if ts.netloc and ts.netloc != "example.com":
+                continue
+            tpath = ts.path or "/"
+            # Must be inside the GitHub Pages base path.
+            if not tpath.startswith(prefix):
+                issues.append(
+                    f"{path}:{line}: link `{href}` resolves to `{tpath}` "
+                    f"which is outside the base path `{prefix}`"
+                )
+                continue
+            # Must point at a real file/dir under _site/.
+            rel = tpath[len(prefix):]
+            if rel.endswith("/"):
+                candidates = [site / rel / "index.html", site / rel.rstrip("/")]
+            else:
+                candidates = [site / rel]
+                if not "." in rel.split("/")[-1]:
+                    candidates.append(site / rel / "index.html")
+            if not any(c.exists() for c in candidates):
+                issues.append(
+                    f"{path}:{line}: link `{href}` resolves to `{tpath}` "
+                    f"but no file exists under {site}"
+                )
+
+    if issues:
+        print(f"check_links: {len(issues)} broken link(s) in {checked} checked:", file=sys.stderr)
+        for i in issues:
+            print("  " + i, file=sys.stderr)
+        return 1
+    print(f"check_links: ok, {checked} links across {len(pages)} pages")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR fixes the cluster of broken internal links the previous PR #18 deployed
together with one pre-existing breakage from #13's per-problem detail pages.

`https://leanprover.github.io/problems/<id>/` is what the home-page TOC was
pointing at; the deployed site lives at `https://leanprover.github.io/lean-eval-leaderboard/`,
so any link starting with `/problems/...` drops the prefix and 404s. Verso
emits a `<base href>` pointing at the site root, so all internal hrefs need
to be base-relative — no leading `/`, no `..` segments that pop past the
prefix.

This PR

* changes the per-problem TOC link from `/problems/<id>/` to `problems/<id>/`,
* changes the home/Problems-page Submit reference from `../submit/` to `submit/`,
* changes the per-problem-detail "← All problems" back-link from `../` to `problems/`,
* replaces the topnav rendered by Verso's `topNav (homeLink := name)` with a hand-written nav using base-relative `problems/` and `submit/` hrefs, so deeper pages don't render a homeLink that points off-site,
* adds `scripts/check_links.py`, a small dependency-free checker that walks every `*.html` in `_site/`, mounts it under the GitHub Pages prefix, and fails on any href/src that escapes the prefix or doesn't point at a real file under `_site/`. The deploy workflow runs it in place of `linkchecker`, which silently passed all four bug classes above because it treats off-prefix URLs as filtered.

Verified end-to-end with a Playwright crawl of all 36 problem pages plus
the home/index/submit roots: 0 broken links across 851 internal links and
39 pages.

🤖 Prepared with [Claude Code](https://claude.com/claude-code)