### PR TITLE
schema v2: key sticky records on (user, model, problem)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,30 +42,40 @@ The `site-data/` directory is generated from the raw `results/` files together
 with benchmark metadata imported from the benchmark repository. Its schema is
 documented in [docs/site-data-schema.md](docs/site-data-schema.md).
 
-## Record schema (v1)
+## Record schema (v2)
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "user": "kim-em",
   "solved": {
-    "two_plus_two": {
-      "solved_at": "2026-04-11T10:45:00Z",
-      "benchmark_commit": "8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f",
-      "submission_repo": "kim-em/my-lean-eval-proofs",
-      "submission_ref": "deadbeefcafef00dbaadc0de1234567890abcdef",
-      "submission_public": true,
-      "model": "Claude Opus 4.6",
-      "issue_number": 42
+    "Claude Opus 4.6": {
+      "two_plus_two": {
+        "solved_at": "2026-04-11T10:45:00Z",
+        "benchmark_commit": "8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f",
+        "submission_repo": "kim-em/my-lean-eval-proofs",
+        "submission_ref": "deadbeefcafef00dbaadc0de1234567890abcdef",
+        "submission_public": true,
+        "issue_number": 42
+      },
+      "list_append_singleton_length": {
+        "solved_at": "2026-04-12T08:15:30Z",
+        "benchmark_commit": "8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f",
+        "submission_repo": "kim-em/my-lean-eval-proofs",
+        "submission_ref": "deadbeefcafef00dbaadc0de1234567890abcdef",
+        "submission_public": false,
+        "issue_number": 43
+      }
     },
-    "list_append_singleton_length": {
-      "solved_at": "2026-04-12T08:15:30Z",
-      "benchmark_commit": "8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f",
-      "submission_repo": "kim-em/my-lean-eval-proofs",
-      "submission_ref": "deadbeefcafef00dbaadc0de1234567890abcdef",
-      "submission_public": false,
-      "model": "Claude Opus 4.6",
-      "issue_number": 43
+    "GPT-5.5": {
+      "two_plus_two": {
+        "solved_at": "2026-04-12T11:00:00Z",
+        "benchmark_commit": "8e1b9cf5e1d3c2b1a0f9e8d7c6b5a4938271605f",
+        "submission_repo": "kim-em/another-gist",
+        "submission_ref": "0123456789abcdef0123456789abcdef01234567",
+        "submission_public": true,
+        "issue_number": 44
+      }
     }
   }
 }
@@ -75,9 +85,15 @@ documented in [docs/site-data-schema.md](docs/site-data-schema.md).
 
 | Field            | Type    | Description                                              |
 | ---------------- | ------- | -------------------------------------------------------- |
-| `schema_version` | integer | Currently `1`.                                           |
-| `user`           | string  | GitHub login with original case preserved.              |
-| `solved`         | object  | Map from problem id to solution record. Never empty.    |
+| `schema_version` | integer | Currently `2`.                                           |
+| `user`           | string  | GitHub login with original case preserved.               |
+| `solved`         | object  | Map from model name to per-problem solution records. Never empty. |
+
+### Per-model bucket
+
+The keys of `solved` are free-form model identifiers as supplied on the
+submission form (e.g. `"Claude Opus 4.7"`, `"GPT-5.5"`, `"Aristotle (Harmonic)"`).
+Each value is an object mapping `<problem_id>` to a solution record.
 
 ### Per-problem solution record
 
@@ -88,33 +104,45 @@ documented in [docs/site-data-schema.md](docs/site-data-schema.md).
 | `submission_repo`  | string  | Identifier of the submission source: `owner/repo` for a GitHub repository, or `user/gist-id` for a gist. |
 | `submission_ref`   | string  | 40-character SHA pinning the submission at evaluation time. For repositories this is a commit SHA; for gists this is the gist revision SHA. |
 | `submission_public`| boolean | `true` if the submission source was public at evaluation time, `false` otherwise. The leaderboard site uses this to decide whether to link to the solution. |
-| `model`            | string  | Free-form model identifier supplied by the submitter on the submission form.           |
 | `issue_number`     | integer | Issue number in `leanprover/lean-eval` that triggered the evaluation.                  |
+| `production_description` | string \| absent | Optional free-form description of how the solution was produced. |
+
+The `model` field has moved out of the per-problem record and become the
+key of the surrounding bucket.
 
 ## Write semantics
 
 When the lean-eval CI records a successful submission:
 
 1. It reads `results/<login>.json`, or starts from an empty `solved` map.
-2. For each problem that passed in the submission:
-   - If `solved[<problem_id>]` already exists, **do nothing** (sticky no-op).
-   - Otherwise, add a new record with the fields above.
-3. If at least one new record was added, the CI commits and pushes the updated
-   file. If no new records were added, it makes no commit.
+2. The submission carries one model name (the value of the issue form's
+   `Model` field). The CI uses that as the bucket key.
+3. For each problem that passed in the submission:
+   - If `solved[<model>][<problem_id>]` already exists, **do nothing** (sticky no-op).
+   - Otherwise, create the model bucket if needed, and add a new record with
+     the fields above.
+4. If at least one new record was added, the CI commits and pushes the
+   updated file. If no new records were added, it makes no commit.
 
-The `solved` map only ever grows. The original `solved_at` timestamp is
-preserved, and the audit trail (`benchmark_commit`, `submission_ref`,
-`issue_number`) always refers to the run that first established the success.
+The map only ever grows: existing buckets keep their problems, and existing
+problem records keep their original `solved_at` timestamps and audit trail
+(`benchmark_commit`, `submission_ref`, `issue_number`).
+
+A single user can therefore claim the same problem under several model
+names — one record per `(user, model, problem)` triple. This is the change
+from v1, which keyed sticky records on `(user, problem)` only and so could
+record at most one model per problem per user.
 
 ## Commit convention
 
 Commits by the lean-eval CI use the message form:
 
 ```
-record: <login> solved <problem_id>[, <problem_id>...] @ <benchmark_short_sha>
+record: <login> solved <problem_id>[, <problem_id>...] using <model> @ <benchmark_short_sha>
 ```
 
-One commit per submission, grouping all newly-recorded problems together.
+One commit per submission, grouping all newly-recorded problems for a
+single model together.
 
 ## Schema evolution
 

--- a/results/kim-em.json
+++ b/results/kim-em.json
@@ -1,25 +1,25 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "solved": {
-    "list_append_singleton_length": {
-      "benchmark_commit": "153074273553d2bb085dad121e56ff4908922159",
-      "issue_number": 39,
-      "model": "dogfood",
-      "production_description": "Hand-written starter proof for the lean-eval test problem `list_append_singleton_length`. The proof is a one-line `rfl` after importing the benchmark helper module. Human time: under a minute. AI time, tokens, and cost: none.",
-      "solved_at": "2026-05-01T00:59:23Z",
-      "submission_public": true,
-      "submission_ref": "4ddea908fe0b67b1fbeace49b23f5d688eeeecf4",
-      "submission_repo": "kim-em/65d3c6ed853ea74dc2e1d1088bc4b323"
-    },
-    "two_plus_two": {
-      "benchmark_commit": "48b8530beb9ff567d8932326aaec1e1acb67b749",
-      "issue_number": 30,
-      "model": "dogfood",
-      "production_description": "Hand-written dogfood proof to populate the leaderboard end-to-end during development. The two_plus_two problem reduces to decide / definitional reduction on 2 + 2 = 4 : \u2115, so the \"solution\" is essentially a one-liner with no model or orchestrator involved. Human time: a few seconds. AI time, tokens, and cost: zero \u2014 no LLM was invoked. This entry exists to demonstrate the new \"How produced\" field on the leaderboard, not as a real benchmark result.",
-      "solved_at": "2026-04-30T10:01:20Z",
-      "submission_public": false,
-      "submission_ref": "d4f2f309e180037f352f8e6086dd4063ccbdce00",
-      "submission_repo": "kim-em/lean-eval-dogfood"
+    "dogfood": {
+      "list_append_singleton_length": {
+        "benchmark_commit": "153074273553d2bb085dad121e56ff4908922159",
+        "issue_number": 39,
+        "production_description": "Hand-written starter proof for the lean-eval test problem `list_append_singleton_length`. The proof is a one-line `rfl` after importing the benchmark helper module. Human time: under a minute. AI time, tokens, and cost: none.",
+        "solved_at": "2026-05-01T00:59:23Z",
+        "submission_public": true,
+        "submission_ref": "4ddea908fe0b67b1fbeace49b23f5d688eeeecf4",
+        "submission_repo": "kim-em/65d3c6ed853ea74dc2e1d1088bc4b323"
+      },
+      "two_plus_two": {
+        "benchmark_commit": "48b8530beb9ff567d8932326aaec1e1acb67b749",
+        "issue_number": 30,
+        "production_description": "Hand-written dogfood proof to populate the leaderboard end-to-end during development. The two_plus_two problem reduces to decide / definitional reduction on 2 + 2 = 4 : \u2115, so the \"solution\" is essentially a one-liner with no model or orchestrator involved. Human time: a few seconds. AI time, tokens, and cost: zero \u2014 no LLM was invoked. This entry exists to demonstrate the new \"How produced\" field on the leaderboard, not as a real benchmark result.",
+        "solved_at": "2026-04-30T10:01:20Z",
+        "submission_public": false,
+        "submission_ref": "d4f2f309e180037f352f8e6086dd4063ccbdce00",
+        "submission_repo": "kim-em/lean-eval-dogfood"
+      }
     }
   },
   "user": "kim-em"

--- a/results/rkirov.json
+++ b/results/rkirov.json
@@ -1,32 +1,31 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "solved": {
-    "finite_graph_ramsey_theorem": {
-      "benchmark_commit": "48b8530beb9ff567d8932326aaec1e1acb67b749",
-      "issue_number": 21,
-      "model": "Claude Opus 4.7 with 1M context",
-      "solved_at": "2026-04-30T10:05:19Z",
-      "submission_public": true,
-      "submission_ref": "212bebf172ea4a345071d0b3fc40a978515d09c6",
-      "submission_repo": "rkirov/lean-eval"
-    },
-    "list_append_singleton_length": {
-      "benchmark_commit": "48b8530beb9ff567d8932326aaec1e1acb67b749",
-      "issue_number": 21,
-      "model": "Claude Opus 4.7 with 1M context",
-      "solved_at": "2026-04-30T10:05:19Z",
-      "submission_public": true,
-      "submission_ref": "212bebf172ea4a345071d0b3fc40a978515d09c6",
-      "submission_repo": "rkirov/lean-eval"
-    },
-    "two_plus_two": {
-      "benchmark_commit": "48b8530beb9ff567d8932326aaec1e1acb67b749",
-      "issue_number": 21,
-      "model": "Claude Opus 4.7 with 1M context",
-      "solved_at": "2026-04-30T10:05:19Z",
-      "submission_public": true,
-      "submission_ref": "212bebf172ea4a345071d0b3fc40a978515d09c6",
-      "submission_repo": "rkirov/lean-eval"
+    "Claude Opus 4.7 with 1M context": {
+      "finite_graph_ramsey_theorem": {
+        "benchmark_commit": "48b8530beb9ff567d8932326aaec1e1acb67b749",
+        "issue_number": 21,
+        "solved_at": "2026-04-30T10:05:19Z",
+        "submission_public": true,
+        "submission_ref": "212bebf172ea4a345071d0b3fc40a978515d09c6",
+        "submission_repo": "rkirov/lean-eval"
+      },
+      "list_append_singleton_length": {
+        "benchmark_commit": "48b8530beb9ff567d8932326aaec1e1acb67b749",
+        "issue_number": 21,
+        "solved_at": "2026-04-30T10:05:19Z",
+        "submission_public": true,
+        "submission_ref": "212bebf172ea4a345071d0b3fc40a978515d09c6",
+        "submission_repo": "rkirov/lean-eval"
+      },
+      "two_plus_two": {
+        "benchmark_commit": "48b8530beb9ff567d8932326aaec1e1acb67b749",
+        "issue_number": 21,
+        "solved_at": "2026-04-30T10:05:19Z",
+        "submission_public": true,
+        "submission_ref": "212bebf172ea4a345071d0b3fc40a978515d09c6",
+        "submission_repo": "rkirov/lean-eval"
+      }
     }
   },
   "user": "rkirov"

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -461,44 +461,52 @@ def build_leaderboard_payload(
 
     for user_record in raw_results:
         user = str(user_record["user"])
-        solved = user_record.get("solved", {})
-        for problem_id, record in solved.items():
-            model_name = normalize_model_name(str(record.get("model", "Unknown model")))
+        schema_version = user_record.get("schema_version")
+        if schema_version != 2:
+            raise SystemExit(
+                f"results file for user {user!r} has schema_version "
+                f"{schema_version!r}; this generator only knows version 2. "
+                "Run scripts/migrate_v1_to_v2.py if it is still v1."
+            )
+        solved_per_model = user_record.get("solved", {})
+        for raw_model_name, problems_for_model in solved_per_model.items():
+            model_name = normalize_model_name(str(raw_model_name))
             model_id = slugify(model_name)
             model_display.setdefault(model_id, model_name)
-            per_model_submitters[model_id][user] += 1
-            current = per_model_problem[model_id].get(problem_id)
-            production_description_raw = record.get("production_description")
-            production_description = (
-                str(production_description_raw).strip()
-                if isinstance(production_description_raw, str) and str(production_description_raw).strip()
-                else None
-            )
-            candidate = {
-                "problem_id": problem_id,
-                "solved_at": str(record["solved_at"]),
-                "provenance": {
-                    "user": user,
-                    "issue_number": int(record["issue_number"]),
-                    "benchmark_commit": str(record["benchmark_commit"]),
-                    "submission_repo": str(record["submission_repo"]),
-                    "submission_ref": str(record["submission_ref"]),
-                },
-                "public_solution": {
-                    "available": bool(record["submission_public"]),
-                    "repo": str(record["submission_repo"]) if record["submission_public"] else None,
-                    "ref": str(record["submission_ref"]) if record["submission_public"] else None,
-                    "url": public_solution_url(
-                        str(record["submission_repo"]),
-                        str(record["submission_ref"]),
-                        problem_id,
-                        bool(record["submission_public"]),
-                    ),
-                },
-                "production_description": production_description,
-            }
-            if current is None or timestamp_key(candidate["solved_at"]) < timestamp_key(current["solved_at"]):
-                per_model_problem[model_id][problem_id] = candidate
+            for problem_id, record in problems_for_model.items():
+                per_model_submitters[model_id][user] += 1
+                current = per_model_problem[model_id].get(problem_id)
+                production_description_raw = record.get("production_description")
+                production_description = (
+                    str(production_description_raw).strip()
+                    if isinstance(production_description_raw, str) and str(production_description_raw).strip()
+                    else None
+                )
+                candidate = {
+                    "problem_id": problem_id,
+                    "solved_at": str(record["solved_at"]),
+                    "provenance": {
+                        "user": user,
+                        "issue_number": int(record["issue_number"]),
+                        "benchmark_commit": str(record["benchmark_commit"]),
+                        "submission_repo": str(record["submission_repo"]),
+                        "submission_ref": str(record["submission_ref"]),
+                    },
+                    "public_solution": {
+                        "available": bool(record["submission_public"]),
+                        "repo": str(record["submission_repo"]) if record["submission_public"] else None,
+                        "ref": str(record["submission_ref"]) if record["submission_public"] else None,
+                        "url": public_solution_url(
+                            str(record["submission_repo"]),
+                            str(record["submission_ref"]),
+                            problem_id,
+                            bool(record["submission_public"]),
+                        ),
+                    },
+                    "production_description": production_description,
+                }
+                if current is None or timestamp_key(candidate["solved_at"]) < timestamp_key(current["solved_at"]):
+                    per_model_problem[model_id][problem_id] = candidate
 
     solving_model_counts: dict[str, int] = defaultdict(int)
     for problems_for_model in per_model_problem.values():

--- a/scripts/migrate_v1_to_v2.py
+++ b/scripts/migrate_v1_to_v2.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""One-shot migration of `results/*.json` from schema_version 1 to 2.
+
+Schema v1 keyed sticky records on `(user, problem)`, with `model` stored
+inside each per-problem record. Schema v2 keys sticky records on
+`(user, model, problem)` by hoisting `model` up into a bucket layer:
+
+    v1:  solved[<problem_id>] = { "model": "...", ...other fields }
+    v2:  solved[<model>][<problem_id>] = { ...other fields, no "model" }
+
+The migration is mechanical, lossless, and idempotent: re-running on a
+v2 file is a no-op.
+
+Usage:
+    python3 scripts/migrate_v1_to_v2.py results/<login>.json [...]
+    python3 scripts/migrate_v1_to_v2.py --all          # walk results/
+    python3 scripts/migrate_v1_to_v2.py --check ...    # dry-run (exit 1 if change needed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+RESULTS_ROOT = REPO_ROOT / "results"
+
+
+class MigrationError(Exception):
+    pass
+
+
+def migrate(data: dict) -> dict:
+    version = data.get("schema_version")
+    if version == 2:
+        return data
+    if version != 1:
+        raise MigrationError(f"unexpected schema_version {version!r}; can only migrate v1 → v2")
+
+    user = data.get("user")
+    if not isinstance(user, str):
+        raise MigrationError("missing or non-string 'user'")
+    solved_v1 = data.get("solved")
+    if not isinstance(solved_v1, dict):
+        raise MigrationError("missing or non-object 'solved'")
+
+    solved_v2: dict[str, dict[str, dict]] = {}
+    for problem_id, record in solved_v1.items():
+        if not isinstance(record, dict):
+            raise MigrationError(f"record for problem {problem_id!r} is not an object")
+        record = dict(record)  # don't mutate input
+        model = record.pop("model", None)
+        if not isinstance(model, str) or not model.strip():
+            raise MigrationError(
+                f"record for problem {problem_id!r} is missing a non-empty 'model' string"
+            )
+        bucket = solved_v2.setdefault(model, {})
+        if problem_id in bucket:
+            # Two v1 records with the same model+problem can only happen if
+            # the v1 file was hand-edited; v1 sticky semantics prevent it
+            # via the writer. Fail loudly.
+            raise MigrationError(
+                f"duplicate (model, problem) = ({model!r}, {problem_id!r}) in v1 file"
+            )
+        bucket[problem_id] = record
+
+    return {"schema_version": 2, "user": user, "solved": solved_v2}
+
+
+def _format(data: dict) -> str:
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def _process(path: pathlib.Path, *, check: bool) -> bool:
+    """Returns True if the file changed (or would change in --check mode)."""
+    original = path.read_text(encoding="utf-8")
+    data = json.loads(original)
+    migrated = migrate(data)
+    new_text = _format(migrated)
+    if new_text == original:
+        return False
+    if check:
+        print(f"would migrate: {path}", file=sys.stderr)
+    else:
+        path.write_text(new_text, encoding="utf-8")
+        print(f"migrated: {path}", file=sys.stderr)
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=pathlib.Path)
+    parser.add_argument("--all", action="store_true", help="Migrate every file under results/.")
+    parser.add_argument("--check", action="store_true", help="Dry-run; exit 1 if any file would change.")
+    args = parser.parse_args(argv)
+
+    if args.all:
+        if args.paths:
+            parser.error("--all is incompatible with explicit paths")
+        args.paths = sorted(p for p in RESULTS_ROOT.glob("*.json"))
+    if not args.paths:
+        parser.error("nothing to do; pass file paths or --all")
+
+    any_changed = False
+    try:
+        for path in args.paths:
+            if not path.is_file():
+                raise MigrationError(f"not a file: {path}")
+            any_changed |= _process(path, check=args.check)
+    except (MigrationError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return (1 if (args.check and any_changed) else 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR migrates the results-file schema so a single user can claim the same problem under multiple model names. The bottleneck for adding new model rows to the leaderboard was that v1 keyed sticky records on `(user, problem)` only — once kim-em or any other user had a problem recorded, no future submission of that problem from the same user could attribute the solve to a different model. v2 hoists `model` from inside each per-problem record up into a bucket layer:

```
v1:  solved[<problem_id>] = { "model": "...", ...rest }
v2:  solved[<model>][<problem_id>] = { ...rest, no "model" }
```

Backwards compatibility: v1 and v2 are not interoperable; consumers refuse to parse the version they do not know. The `solved` map and the per-problem record fields keep their existing semantics. The site-data output schema (`site-data/leaderboard.json`) is unchanged, so the Verso site code does not need updates.

Changes:
- `README.md`: rewrite the schema section for v2
- `scripts/generate_site_data.py`: read v2 nested shape; reject non-v2
- `scripts/migrate_v1_to_v2.py`: one-shot, idempotent migration helper
- `results/{kim-em,rkirov}.json`: migrated to v2

Pairs with the writer change in https://github.com/leanprover/lean-eval (PR linked once opened). **Merge this PR first**, then the lean-eval writer PR; in between, new submissions will fail to record (writer is v1, data is v2). The gap should be brief.

🤖 Prepared with Claude Code
