### PR TITLE
style: drop unused Oranienbaum, stack footer rows vertically

### DIFF
--- a/SiteTheme.lean
+++ b/SiteTheme.lean
@@ -42,7 +42,7 @@ def theme (name : String) (siteName : String) : Theme := {
           <title>{{ title }} s!" | {siteName}"</title>
           <link rel="preconnect" href="https://fonts.googleapis.com"/>
           <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>
-          <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Oranienbaum&family=Fira+Code:wght@400;500&display=swap"/>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Fira+Code:wght@400;500&display=swap"/>
           {{← builtinHeader }}
           <link rel="icon" type="image/svg+xml" href="static/favicon.svg"/>
           <link rel="stylesheet" href="static/style.css"/>

--- a/static/style.css
+++ b/static/style.css
@@ -6,7 +6,7 @@
 :root {
   /* Typography */
   --font-primary: 'Open Sans', Arial, sans-serif;
-  --font-secondary: 'Oranienbaum', serif;
+  --font-secondary: var(--font-primary);
   --font-mono: 'Fira Code', 'IBM Plex Mono', 'SFMono-Regular', monospace;
 
   --fs-xs:   0.75rem;
@@ -377,8 +377,8 @@ nav.top .home { display: none; }
 
 .footer-inner {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-4);
+  flex-direction: column;
+  gap: var(--space-3);
   color: var(--color-text-light);
   font-size: 0.88rem;
 }


### PR DESCRIPTION
This PR drops the unused Oranienbaum display face from the leaderboard's typography and fixes the footer layout so its two rows stack vertically.

The hero/section titles used \`--font-secondary: 'Oranienbaum', serif\`, but although lean-lang.org defines \`--font-secondary\` identically, it never applies it anywhere — every visible heading on lean-lang.org is Open Sans (\`--font-primary\`). The leaderboard's serif display title was therefore the odd font out. Alias \`--font-secondary\` to \`--font-primary\` so the leaderboard's headings match what lean-lang.org actually renders, and drop \`family=Oranienbaum\` from the Google Fonts request to avoid the wasted download.

The footer's two rows (\`--repos\` / \`--community\`) were laid out inside \`.footer-inner\` with \`display: flex; flex-wrap: wrap\`, so on wide viewports they sat side-by-side as flex items. The \`--community\` row's \`border-top\` + \`padding-top\` then offset its baseline relative to \`--repos\`, which is what produced the visible "Community / Lean / Mathlib Initiative / Zulip" line sitting slightly lower than "Public results for lean-eval. / Benchmark repo / Results repo". Switch \`.footer-inner\` to \`flex-direction: column\` so the rows stack vertically — which is the layout the top border was designed for.

🤖 Prepared with Claude Code