### PR TITLE
drop isStarNormal_mul_of_commute from snapshot + site-data

### DIFF
--- a/benchmark-snapshot/BenchmarkProblems/Catalog.lean
+++ b/benchmark-snapshot/BenchmarkProblems/Catalog.lean
@@ -316,14 +316,6 @@ end ProblemExistsComplementaryPolynomialOnUnitCircle
 
 namespace ProblemIsStarNormalMulOfCommute
 
--- ANCHOR: isStarNormal_mul_of_commute__isStarNormal_mul_of_commute
-theorem isStarNormal_mul_of_commute {A : Type*} [NonUnitalCStarAlgebra A]
-    {a b : A} (ha : IsStarNormal a) (hb : IsStarNormal b)
-    (hab : Commute a b) :
-    IsStarNormal (a * b) := by
-  sorry
--- ANCHOR_END: isStarNormal_mul_of_commute__isStarNormal_mul_of_commute
-
 end ProblemIsStarNormalMulOfCommute
 
 namespace ProblemPosSemidefMapExp

--- a/site-data/problems.json
+++ b/site-data/problems.json
@@ -367,26 +367,6 @@
       "sort_index": 17
     },
     {
-      "id": "isStarNormal_mul_of_commute",
-      "title": "Product of commuting normal elements is normal",
-      "test": false,
-      "submitter": "Kim Morrison",
-      "module": "LeanEval.Algebra.NormalProduct",
-      "holes": [
-        {
-          "name": "LeanEval.Algebra.isStarNormal_mul_of_commute",
-          "basename": "isStarNormal_mul_of_commute",
-          "kind": "theorem",
-          "body": "theorem isStarNormal_mul_of_commute\n    {A : Type*} [NonUnitalCStarAlgebra A]\n    {a b : A} (ha : IsStarNormal a) (hb : IsStarNormal b)\n    (hab : Commute a b) :\n    IsStarNormal (a * b) := by\n  sorry"
-        }
-      ],
-      "notes": "Uses the Fuglede-Putnam-Rosenblum theorem to show all four of a, star a, b, star b pairwise commute, then verifies the normality condition by direct computation.",
-      "source": "B. Fuglede, A commutativity theorem for normal operators, 1950.",
-      "informal_solution": "From Commute a b and normality, apply Fuglede-Putnam twice to get Commute (star a) b and Commute (star a) (star b). Then star(ab)\u00b7(ab) = b*\u00b7a*\u00b7a\u00b7b = b*\u00b7a\u00b7a*\u00b7b (a normal) = a\u00b7b*\u00b7b\u00b7a* (all commute) = a\u00b7b\u00b7b*\u00b7a* (b normal) = (ab)\u00b7star(ab).",
-      "challenge_path": "generated/isStarNormal_mul_of_commute",
-      "sort_index": 18
-    },
-    {
       "id": "posSemidef_map_exp",
       "title": "Entrywise exponential of a PSD matrix is PSD",
       "test": false,


### PR DESCRIPTION
Pairs with https://github.com/leanprover/lean-eval/pull/53, which deletes the `isStarNormal_mul_of_commute` problem from the benchmark for being too easy (Aristotle's first attempt produced a 4-line direct computation using Mathlib's `Commute` API).

Removes the corresponding entry from:
- `benchmark-snapshot/BenchmarkProblems/Catalog.lean` (the ANCHOR-delimited theorem section the Verso build links into the site)
- `site-data/problems.json` (the generated problems list rendered on the home page and problems index)

Both files are normally regenerated from upstream lean-eval `main`, but `deploy.yml` here is only triggered by pushes/PRs on this repo and there is no automatic sync from lean-eval — so the snapshot needs an explicit follow-up commit to stay in sync. Order of merge isn't critical: the lean-eval PR is the source of truth, this PR just stops the leaderboard site from showing a deleted problem.

🤖 Prepared with Claude Code
