### PR TITLE
doc: point leaderboard link at lean-lang.org/eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lean-eval-leaderboard
 
-**[View the leaderboard →](https://leanprover.github.io/lean-eval-leaderboard/)**
+**[View the leaderboard →](https://lean-lang.org/eval/)**
 
 Results store and public website data source for the
 [lean-eval](https://github.com/leanprover/lean-eval) benchmark.


### PR DESCRIPTION
This PR updates the leaderboard link in the README to point at the new https://lean-lang.org/eval/ URL.

🤖 Prepared with Claude Code