### PR TITLE
style: fill footer background to mirror header

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -372,7 +372,11 @@ nav.top .home { display: none; }
 .footer {
   border-top: 1px solid var(--color-border);
   padding: var(--space-6) 0 var(--space-10);
-  background: transparent;
+  background-color: var(--color-bg-translucent);
+  backdrop-filter: blur(10px);
+  transition:
+    background-color var(--transition-base),
+    border-color var(--transition-base);
 }
 
 .footer-inner {


### PR DESCRIPTION
This PR fills the site footer with the same translucent background, blur, and transition treatment used by the topbar, so the footer matches the header instead of disappearing into the page background.

🤖 Prepared with Claude Code