### PR TITLE
Fix theorem condition for exists_complementary_polynomial_on_unit_circle

### DIFF
--- a/benchmark-snapshot/BenchmarkProblems/Catalog.lean
+++ b/benchmark-snapshot/BenchmarkProblems/Catalog.lean
@@ -307,7 +307,7 @@ open Polynomial
 theorem exists_complementary_polynomial_on_unit_circle (P : ℂ[X])
     (hP : ∀ z : Circle, ‖P.eval (z : ℂ)‖ ≤ 1) :
     ∃ Q : ℂ[X],
-      Q.natDegree = P.natDegree ∧
+      Q.natDegree ≤ P.natDegree ∧
         ∀ z : Circle, ‖P.eval (z : ℂ)‖ ^ 2 + ‖Q.eval (z : ℂ)‖ ^ 2 = 1 := by
   sorry
 -- ANCHOR_END: exists_complementary_polynomial_on_unit_circle__exists_complementary_polynomial_on_unit_circle


### PR DESCRIPTION
Fix issue #34 (otherwise we have the counterexample `P=X` to the current written statement)