### PR TITLE
feat(site): show problem-author count in hero stats

### DIFF
--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -94,6 +94,7 @@ instance : FromJson ProblemsPayload where
 structure LeaderboardSummary where
   models : Nat
   submitters : Nat
+  problemAuthors : Nat
   problems : Nat
   mainProblems : Nat
   testProblems : Nat
@@ -104,6 +105,7 @@ instance : FromJson LeaderboardSummary where
     return {
       models := ← json.getObjValAs? Nat "models"
       submitters := ← json.getObjValAs? Nat "submitters"
+      problemAuthors := ← json.getObjValAs? Nat "problem_authors"
       problems := ← json.getObjValAs? Nat "problems"
       mainProblems := ← json.getObjValAs? Nat "main_problems"
       testProblems := ← json.getObjValAs? Nat "test_problems"

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -142,6 +142,8 @@ private def heroBlock (summary : LeaderboardSummary) : Block Page :=
     divBlock "hero-stats hero-stat-strip" #[
       heroStat summary.models "models",
       heroStat summary.submitters (pluralize summary.submitters "submitter" "submitters"),
+      heroStat summary.problemAuthors
+        (pluralize summary.problemAuthors "problem author" "problem authors"),
       heroStatLink summary.problems "problems" problemsHref
     ]
   ]

--- a/docs/site-data-schema.md
+++ b/docs/site-data-schema.md
@@ -98,6 +98,7 @@ aggregated, ranked, and enriched with provenance and notability metadata.
   "summary": {
     "models": 3,
     "submitters": 5,
+    "problem_authors": 4,
     "problems": 17,
     "main_problems": 15,
     "test_problems": 2

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -705,6 +705,7 @@ def build_leaderboard_payload(
         "summary": {
             "models": len(entries),
             "submitters": len({str(record["user"]) for record in raw_results}),
+            "problem_authors": len({problem.submitter for problem in problems}),
             "problems": len(problems),
             "main_problems": sum(0 if problem.test else 1 for problem in problems),
             "test_problems": sum(1 if problem.test else 0 for problem in problems),


### PR DESCRIPTION
This PR adds a fourth hero stat next to "submitters" so the landing page distinguishes "people who have submitted accepted proofs" (the existing `submitters` count, drawn from `results/*.json`) from "people who have authored problems" (the new `problem_authors` count, drawn from distinct `submitter` strings in the benchmark manifest). Both numbers are correct in their own category — the site just wasn't showing the second one.

Context: came up on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/583341-Model-comparisons-for-Lean/topic/LeanEval/near/592651591) — Rado pointed out the dashboard reports "2 submitters" even though several other people have contributed problems via PRs to `leanprover/lean-eval`.

Touches:
- `scripts/generate_site_data.py` — emit `summary.problem_authors`
- `LeaderboardSite/Data.lean` — add `problemAuthors : Nat` to `LeaderboardSummary`
- `LeaderboardSite/Leaderboard.lean` — render the new hero stat
- `docs/site-data-schema.md` — schema example

Caveats: the hero strip now has 4 cells instead of 3; CSS may want a tweak on narrow viewports. I haven't run a `lake build` of the site locally — the Lean changes are mechanical (one field, one decoder line, two stat-strip lines), but worth eyeballing the rendered hero on a real build before merging.

🤖 Prepared with Claude Code