### PR TITLE
refactor: extract user-facing copy into a single Copy module

### DIFF
--- a/LeaderboardSite.lean
+++ b/LeaderboardSite.lean
@@ -1,6 +1,7 @@
 import VersoBlog
 
 import SiteTheme
+import LeaderboardSite.Copy
 import LeaderboardSite.Pages.Front
 import LeaderboardSite.Pages.Problems
 import LeaderboardSite.Pages.ProblemDetail
@@ -31,4 +32,5 @@ def leaderboardSite : Site :=
   ]
 
 def main (args : List String) : IO UInt32 :=
-  blogMain (theme "Leaderboard" "Lean AI formalization leaderboard") leaderboardSite {} args
+  blogMain (theme LeaderboardSite.Copy.siteThemeName LeaderboardSite.Copy.siteTitle)
+    leaderboardSite {} args

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -1,0 +1,384 @@
+import VersoBlog
+
+/-!
+# Site copy
+
+Every reader-facing string on the site lives here. Page-layout files
+(Pages/*.lean, Leaderboard.lean, SiteTheme.lean) read these and have no
+prose literals of their own.
+
+Two flavours of content:
+
+* Plain `String` defs (and small formatter functions) for short labels
+  embedded in hand-rolled HTML — nav, footer, hero, panel headers,
+  ARIA labels, button text, fallback strings, glyphs.
+* `VersoDoc Page` markdown bodies for substantial prose — the Front-page
+  intro, the Problems-page intro, and each Submit-page sub-section.
+  Authored as Verso markdown (the `verso (Page) "title"` term form
+  defined at `.lake/packages/verso/src/verso/Verso/Doc/Concrete.lean:140`)
+  so inline links read as `[label](url)` and code spans use backticks.
+
+Layout files compose markdown bodies into Parts via `VersoDoc.toPart` and
+`Part.content` — the same shape `paragraph #[textInline ...]` chains used
+to produce, just authored as readable prose.
+
+Verso markdown fence-length notes (parser quirk in v4.30.0-rc2):
+
+* For bodies that contain a `:::name` directive (e.g. `:::htmlDiv`), the
+  outer fence must be at least 5 colons. 4-colon outer + 3-colon inner
+  directive trips the parser.
+* For bodies with no nested directives, plain 3-colon fences are fine.
+* The opening fence must be on its own line *after* the title; the
+  closing fence on its own line at the end of the body.
+-/
+
+namespace LeaderboardSite.Copy
+
+open Verso Doc Verso.Doc.Concrete Verso.Genre.Blog
+
+/-! ## Site title / theme name -/
+
+def siteTitle      : String := "Lean AI formalization leaderboard"
+def siteThemeName  : String := "Leaderboard"
+
+/-! ## Cross-page constants -/
+
+def unavailable : String := "Unavailable."
+def monthNames  : Array String :=
+  #["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+
+/-! ## Topbar / nav (used by SiteTheme.lean) -/
+
+def wordmarkMark         : String := "⊢"
+def wordmarkText         : String := "lean-eval"
+def navProblems          : String := "Problems"
+def navSubmit            : String := "Submit"
+def topbarGithubAria     : String := "View source on GitHub"
+def themeToggleAria      : String := "Toggle dark mode"
+def themeToggleSunGlyph  : String := "☀"
+def themeToggleMoonGlyph : String := "☾"
+
+/-! ## Footer (used by SiteTheme.lean) -/
+
+def footerTagline               : String := "Public results for lean-eval."
+def footerBenchmarkRepo         : String := "Benchmark repo"
+def footerResultsRepo           : String := "Results repo"
+def footerCommunityHeading      : String := "Community"
+def footerLinkLean              : String := "Lean"
+def footerLinkMathlibInitiative : String := "Mathlib Initiative"
+def footerLinkZulip             : String := "Zulip"
+
+/-! ## Page-title separator (SiteTheme.lean) -/
+
+def pageTitleSeparator : String := " | "
+
+/-! ## Hero panel (Leaderboard.lean) -/
+
+def heroKicker : String := "lean-eval"
+def heroTitle  : String := siteTitle
+def heroCopy   : String :=
+  "Public results on a benchmark of hard Lean formalization problems. \
+   Expand any row to inspect solved theorems, extracted statements, and \
+   links to public proofs when available."
+def heroSide   : String :=
+  "Problem statements and leaderboard results are generated from public \
+   benchmark data and submitted solution artifacts. This is a \
+   submission-based leaderboard: rankings reflect accepted submitted \
+   solutions, not an automatic evaluation of every model on every \
+   problem by the Lean FRO or benchmark organisers."
+
+def heroBenchmarkBreakdownLabel : String := "Benchmark breakdown"
+def heroMainProblemsLabel       : String := "Main problems"
+def heroTestProblemsLabel       : String := "Test problems"
+def heroModelsLabel             : String := "models"
+def heroProblemsLabel           : String := "problems"
+def heroSubmitterSingular       : String := "submitter"
+def heroSubmitterPlural         : String := "submitters"
+def heroProblemAuthorSingular   : String := "problem author"
+def heroProblemAuthorPlural     : String := "problem authors"
+
+/-! ## Leaderboard panel header -/
+
+def panelKicker  : String := "Leaderboard"
+def panelHeading : String := "Model rankings"
+def panelNote    : String :=
+  "Ranked by solved problems, with main benchmark problems weighted first."
+
+/-! ## Empty-showcase state -/
+
+def emptyShowcaseLabel : String := "No public solves yet"
+def emptyShowcaseCopy  : String :=
+  "The benchmark catalog is public, and leaderboard rows will appear here \
+   as successful submissions are recorded."
+
+/-! ## Coverage matrix -/
+
+def coverageKicker        : String := "Coverage"
+def coverageHeading       : String := "Per-problem coverage"
+def coverageNote          : String :=
+  "Which problems each model has solved. Hidden on narrow screens."
+def coverageHeaderProblem : String := "Problem"
+def coverageCellSolved    : String := "✓"
+def coverageCellUnsolved  : String := "—"
+def coverageKindMain      : String := "main"
+def coverageKindTest      : String := "test"
+
+/-- ARIA label for a coverage cell, e.g. `"Some title: solved"`. -/
+def coverageCellAria (title : String) (solved : Bool) : String :=
+  let state := if solved then "solved" else "not solved"
+  s!"{title}: {state}"
+
+/-! ## Problem chips / theorem cards -/
+
+def proofWord                   : String := "proof"
+def howProducedSummary          : String := "How produced"
+def theoremStatementUnavailable : String := "Theorem statement unavailable."
+def versoTheoremPreviewLabel    : String := "Verso theorem preview"
+def leanTheoremStatementLabel   : String := "Lean theorem statement"
+
+/-- ARIA label for the problem-id chip that opens the theorem-statement popover. -/
+def theoremDisclosureAria (problemId : String) : String :=
+  s!"Show theorem statement for {problemId}"
+
+/-! ## Score pills -/
+
+def scoreSolvedSuffix : String := " solved"
+def scoreMainSuffix   : String := " main"
+def scoreTestSuffix   : String := " test"
+
+/-! ## Per-row entry section labels -/
+
+def submissionHistoryLabel : String := "Submission history"
+def firstSubmissionLabel   : String := "First submission"
+def lastSubmissionLabel    : String := "Last submission"
+def contributorsLabel      : String := "Contributors"
+def uniqueSolvesLabel      : String := "Problems uniquely solved by this model"
+def otherSolvesLabel       : String := "Other solved problems"
+def submittersEmpty        : String := "None"
+
+/-! ## Problems page -/
+
+def problemsTitle                 : String := "Problems"
+def filterBoxIcon                 : String := "⌕"
+def filterBoxLabel                : String := "Filter problems"
+def filterBoxPlaceholder          : String := "title, id, notes, source, or Lean source"
+def tocAllProblemsLabel           : String := "All problems"
+def mainBenchmarkSection          : String := "Main benchmark problems"
+def testProblemsSection           : String := "Test problems"
+def problemsNotesLabel            : String := "Notes"
+def problemsInformalSolutionLabel : String := "Informal solution"
+def problemsSourcePrefix          : String := "Source: "
+
+/-- "Submitter: GitHubUser." line shown on Problems and ProblemDetail. -/
+def problemsSubmitterSentence (submitter : String) : String :=
+  s!"Submitter: {submitter}."
+
+/-- Three-paragraph intro for the Problems page. The third paragraph
+links to `submit/` (site-relative — the leaderboard is served under a
+GitHub-Pages base path, so absolute `/submit` would 404). -/
+def problemsIntro : VersoDoc Page :=
+  verso (Page) "problemsIntro"
+  :::
+  The benchmark catalog consists of carefully curated problems across
+  mathematics, chosen so that their statements are mostly accessible
+  using existing Mathlib definitions, but their solutions are difficult
+  for current publicly available frontier models.
+
+  The problem statements below are automatically extracted from the
+  [lean-eval](https://github.com/leanprover/lean-eval) repository.
+
+  Authors are encouraged to submit new problems via PRs to that
+  repository, for inclusion in future benchmark releases. See
+  [Submit](submit/) for details on submitting solutions.
+  :::
+
+/-! ## ProblemDetail page -/
+
+def solvedByLabel    : String := "Solved by"
+def notYetSolvedText : String := "Not yet solved."
+def backToProblems   : String := "← All problems"
+
+/-- Solver-row sentence fragment: e.g. `" with GPT-5 on Apr 12, 2026"`. -/
+def solverWithModelOnDate (modelName formattedDate : String) : String :=
+  s!" with {modelName} on {formattedDate}"
+
+/-! ## Front page intro
+
+Wrapped in the existing `wrap prose page-copy` div so the home page's
+full-width layout (which bypasses the theme's default prose container)
+still gets the readable column. Outer fence is `:::::` because Verso
+v4.30.0-rc2's parser doesn't accept a 4-colon outer with a 3-colon
+inner directive. -/
+
+def frontIntro : VersoDoc Page :=
+  verso (Page) "frontIntro"
+  :::::
+  :::htmlDiv (class := "wrap prose page-copy")
+  Welcome to `lean-eval`, a Lean formalization benchmark and public
+  leaderboard.
+
+  You can submit new problems for review, and solutions for existing
+  problems. New problems will be carefully reviewed and added to future
+  benchmark releases if they are accepted. Solutions are automatically
+  verified using
+  [comparator](https://github.com/leanprover/comparator)
+  and added to the public leaderboard.
+
+  This benchmark intends to capture hard Lean formalization problems,
+  consisting of mathematical problems that are currently stateable mostly
+  using existing
+  [Mathlib](https://github.com/leanprover-community/mathlib4)
+  definitions, perhaps with a page or so of additional setup. They should
+  be hard, but usually not open problems: in fact, it's preferred if the
+  problem has a known informal solution which is publicly available.
+
+  Our hope is that at launch, the problem set will be mostly, but not
+  entirely, out of reach for current publicly available frontier models,
+  or simple orchestration layers built on top of these. So some genuine
+  mathematical subtlety is required!
+
+  It's also important to say what this benchmark is not: we are not
+  trying to capture the ability to write readable or reusable code, or to
+  follow best practices in Lean. In particular, the only requirement for
+  a solution to be accepted is that it is correct and passes the
+  comparator tests.
+  :::
+  :::::
+
+/-! ## Submit page
+
+The Submit page composes a top-level Part with named sub-Parts whose
+`htmlId`s (`step-1`, `step-2`, `step-3`, `what-becomes-public`) are
+referenced from CSS / anchors. We keep that Part composition in
+`Submit.lean` and only export the per-section *bodies* here, so the ids
+can't drift from markdown heading-id generation. -/
+
+def submitTitle : String := "Submit"
+
+/-- Lead paragraph above the step sub-sections. -/
+def submitLeadBody : VersoDoc Page :=
+  verso (Page) "submitLead"
+  :::
+  Submissions are made by opening a GitHub issue on the
+  [lean-eval benchmark repository](https://github.com/leanprover/lean-eval).
+  :::
+
+def submitStep1Title  : String :=
+  "1. Put your proof somewhere the lean-eval CI can fetch it"
+def submitStep1HtmlId : String := "step-1"
+
+def submitStep1Body : VersoDoc Page :=
+  verso (Page) "submitStep1"
+  :::
+  Accepted submission sources are URLs of one of these shapes:
+
+  - a GitHub repository: `https://github.com/<owner>/<repo>`
+  - a GitHub repository pinned to a branch, tag, or commit:
+    `https://github.com/<owner>/<repo>/tree/<ref>` or
+    `https://github.com/<owner>/<repo>/commit/<sha>`
+  - a public gist: `https://gist.github.com/<user>/<gist-id>`
+    (optionally with a revision suffix)
+
+  Private GitHub repositories are supported. To use one,
+  [install the lean-eval-bot GitHub App](https://github.com/apps/lean-eval-bot)
+  on the repository first, so that the CI can clone it.
+
+  Secret (unlisted) gists are not supported in v1. Make your gist public,
+  or host the proof in a repository.
+  :::
+
+def submitStep2Title  : String := "2. Lay out the proof so CI can find it"
+def submitStep2HtmlId : String := "step-2"
+
+def submitStep2Body : VersoDoc Page :=
+  verso (Page) "submitStep2"
+  :::
+  The CI walks whatever you submit and tries every directory containing a
+  `lakefile.toml` whose `name` field matches a benchmark problem id, and
+  which has a `Submission.lean` next to it. For example:
+
+  - a clone of a single generated workspace from
+    [leanprover/lean-eval/generated/](https://github.com/leanprover/lean-eval/tree/main/generated)
+  - a fork of leanprover/lean-eval itself with your proofs under the
+    relevant `generated/<problem_id>/` directories
+  - a custom repository containing several benchmark workspaces side by
+    side
+  - a gist containing a two-file minimum: a `lakefile.toml` with
+    `name = "<problem_id>"` and a `Submission.lean`
+
+  For each matched directory the CI overlays only your `Submission.lean`
+  and any files under `Submission/**/*.lean` onto a pristine copy of the
+  benchmark's workspace for that problem. Every other file in your
+  submission is ignored, including `Solution.lean`, `Challenge.lean`, or
+  any modified `lakefile.toml`. The CI then runs
+  [comparator](https://github.com/leanprover/comparator) to check the
+  proof.
+  :::
+
+def submitStep3Title  : String := "3. Open a submission issue"
+def submitStep3HtmlId : String := "step-3"
+
+def submitStep3Body : VersoDoc Page :=
+  verso (Page) "submitStep3"
+  :::
+  Click [Submit benchmark solution](https://github.com/leanprover/lean-eval/issues/new?template=submit.yml)
+  to open a pre-filled issue. The form asks for two things:
+
+  - a submission URL in one of the shapes above
+  - a free-form model identifier that identifies the model or system that
+    produced the proof
+
+  When you submit the issue, the lean-eval CI takes over. It clones your
+  content, scans for benchmark workspaces, runs comparator on every
+  match, and records any newly-solved problems in the leaderboard
+  repository. The CI comments on your issue with a per-problem pass/fail
+  summary and closes it when done. Any problem that passes is added to
+  your `results/<your-github-login>.json` record.
+
+  Submissions are cumulative. Every success is sticky, and there is no
+  limit on how many times you can submit. Resubmit whenever you have new
+  proofs.
+  :::
+
+def submitWhatPublicTitle  : String := "What becomes public"
+def submitWhatPublicHtmlId : String := "what-becomes-public"
+
+def submitWhatPublicBody : VersoDoc Page :=
+  verso (Page) "submitWhatPublic"
+  :::
+  Only the information you enter on the submission form, plus the list of
+  problems your submission solved, becomes public. Your proof is never
+  copied out of the ephemeral workflow runner into any public artifact.
+  The leaderboard only stores identifiers and timestamps.
+
+  If your submission source was a public repository or a public gist, the
+  leaderboard may link to it so that others can inspect your solution. If
+  the source was private, no link is published.
+  :::
+
+/-! ### Submit-page CTA + TL;DR widgets
+
+`Submit.lean` keeps the bespoke HTML wrappers (`<a class="cta-button">`,
+`<p class="submit-tldr">`) and reads its labels from here. The TL;DR
+paragraph splices a `<code>` and an `<a>` mid-sentence, so its prose is
+broken into chunks rather than authored as a single string. -/
+
+def submitCtaUrl    : String :=
+  "https://github.com/leanprover/lean-eval/issues/new?template=submit.yml"
+def submitCtaLabel  : String := "Submit benchmark solution"
+def submitCtaArrow  : String := " →"
+
+def submitTldrPart1 : String :=
+  "Three steps: host your proof on GitHub or in a public gist, lay it \
+   out so CI can match each "
+def submitTldrCode1 : String := "Submission.lean"
+def submitTldrPart2 : String :=
+  " to a problem id, and open a pre-filled issue. CI runs the proof \
+   through "
+def submitTldrComparatorLabel : String := "comparator"
+def submitTldrComparatorUrl   : String :=
+  "https://github.com/leanprover/comparator"
+def submitTldrPart3 : String :=
+  " and updates the leaderboard automatically."
+
+end LeaderboardSite.Copy

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -2,6 +2,7 @@ import Lean.Data.Json
 import VersoBlog
 import LeaderboardSite.Data
 import LeaderboardSite.AnchorRegistry
+import LeaderboardSite.Copy
 
 open Lean
 open Lean.Elab Term
@@ -12,6 +13,7 @@ open Verso.Output Html
 namespace LeaderboardSite.Leaderboard
 
 open LeaderboardSite.Data
+open LeaderboardSite.Copy
 
 /-! ## Helpers for building Verso `Block Page` / `Inline Page` values via syntax.
 
@@ -78,8 +80,6 @@ private def formatDate (iso : String) : String :=
   | date :: _ =>
     match date.splitOn "-" with
     | [yyyy, mm, dd] =>
-      let monthNames := #["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
       match mm.toNat? with
       | some m =>
         if 1 ≤ m ∧ m ≤ 12 then
@@ -92,12 +92,12 @@ private def formatDate (iso : String) : String :=
   | [] => iso
 
 private def scoreLineHtml (score : LeaderboardScore) : Html :=
-  let solved : String := s!"{score.display} solved"
+  let solved : String := s!"{score.display}{scoreSolvedSuffix}"
   {{
     <span class="entry-score-line">
       <span class="entry-score-primary">{{textHtml solved}}</span>
-      <span class="entry-score-pill entry-score-pill--main">{{textHtml s!"{score.solvedMain} main"}}</span>
-      <span class="entry-score-pill entry-score-pill--test">{{textHtml s!"{score.solvedTest} test"}}</span>
+      <span class="entry-score-pill entry-score-pill--main">{{textHtml s!"{score.solvedMain}{scoreMainSuffix}"}}</span>
+      <span class="entry-score-pill entry-score-pill--test">{{textHtml s!"{score.solvedTest}{scoreTestSuffix}"}}</span>
     </span>
   }}
 
@@ -128,35 +128,28 @@ private def heroBlock (summary : LeaderboardSummary) : Block Page :=
   let problemsHref := "problems/"
   let mainProblemsHref := s!"{problemsHref}#main-problems"
   let testProblemsHref := s!"{problemsHref}#test-problems"
-  let heroCopy :=
-    "Public results on a benchmark of hard Lean formalization problems. "
-    ++ "Expand any row to inspect solved theorems, extracted statements, and "
-    ++ "links to public proofs when available."
-  let heroSideCopy :=
-    "Problem statements and leaderboard results are generated from public "
-    ++ "benchmark data and submission artifacts."
   let heroMain := divBlock "hero-main" #[
-    divBlock "hero-kicker" #[paragraph #[textInline "lean-eval"]],
-    htmlBlobBlock {{ <h1 class="hero-title">"Lean AI formalization leaderboard"</h1> }},
+    divBlock "hero-kicker" #[paragraph #[textInline heroKicker]],
+    htmlBlobBlock {{ <h1 class="hero-title">{{textHtml heroTitle}}</h1> }},
     htmlBlobBlock {{ <p class="hero-copy">{{textHtml heroCopy}}</p> }},
     divBlock "hero-stats hero-stat-strip" #[
-      heroStat summary.models "models",
-      heroStat summary.submitters (pluralize summary.submitters "submitter" "submitters"),
+      heroStat summary.models heroModelsLabel,
+      heroStat summary.submitters (pluralize summary.submitters heroSubmitterSingular heroSubmitterPlural),
       heroStat summary.problemAuthors
-        (pluralize summary.problemAuthors "problem author" "problem authors"),
-      heroStatLink summary.problems "problems" problemsHref
+        (pluralize summary.problemAuthors heroProblemAuthorSingular heroProblemAuthorPlural),
+      heroStatLink summary.problems heroProblemsLabel problemsHref
     ]
   ]
-  let heroSide := htmlWrapperBlock "aside" #[("class", "hero-side")] #[
-    sectionLabel "Benchmark breakdown",
+  let heroSideAside := htmlWrapperBlock "aside" #[("class", "hero-side")] #[
+    sectionLabel heroBenchmarkBreakdownLabel,
     divBlock "hero-side-metrics" #[
-      statPairLink "Main problems" mainProblemsHref summary.mainProblems,
-      statPairLink "Test problems" testProblemsHref summary.testProblems
+      statPairLink heroMainProblemsLabel mainProblemsHref summary.mainProblems,
+      statPairLink heroTestProblemsLabel testProblemsHref summary.testProblems
     ],
-    htmlBlobBlock {{ <p class="hero-side-copy">{{textHtml heroSideCopy}}</p> }}
+    htmlBlobBlock {{ <p class="hero-side-copy">{{textHtml heroSide}}</p> }}
   ]
   sectionBlock "hero-panel" #[
-    divBlock "hero-grid" #[heroMain, heroSide]
+    divBlock "hero-grid" #[heroMain, heroSideAside]
   ]
 
 /-! ## Problem rows inside an entry -/
@@ -174,11 +167,11 @@ private def theoremCard
     let holeBlocks : Array (Block Page) :=
       rendered.map fun blk => divBlock "hole" #[blk]
     divBlock "theorem-card theorem-card-rendered" <|
-      #[divBlock "theorem-card-label" #[paragraph #[textInline "Verso theorem preview"]]]
+      #[divBlock "theorem-card-label" #[paragraph #[textInline versoTheoremPreviewLabel]]]
       ++ holeBlocks
   | none =>
     divBlock "theorem-card theorem-card-static" #[
-      divBlock "theorem-card-label" #[paragraph #[textInline "Lean theorem statement"]],
+      divBlock "theorem-card-label" #[paragraph #[textInline leanTheoremStatementLabel]],
       htmlBlobBlock {{ <pre>{{textHtml statement}}</pre> }}
     ]
 
@@ -200,7 +193,7 @@ private def problemItem
   let proofLink := match proofUrl? with
     | some url => htmlBlobBlock {{
         <a class="problem-proof-link" href={{url}}>
-          <span>"proof"</span>
+          <span>{{textHtml proofWord}}</span>
           <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M9 1v1.5h3.44L6.97 7.97l1.06 1.06L13.5 3.56V7H15V1H9zM2 3v11h11V8.5h-1.5V12.5h-8v-8H6.5V3H2z"/>
           </svg>
@@ -220,7 +213,7 @@ private def problemItem
       else
         htmlBlobBlock {{
           <details class="production-note">
-            <summary>"How produced"</summary>
+            <summary>{{textHtml howProducedSummary}}</summary>
             <p>{{textHtml trimmed.toString}}</p>
           </details>
         }}
@@ -232,7 +225,7 @@ private def problemItem
         htmlBlobBlock {{
           <span class="problem-id-trigger" role="button" tabindex="0"
                 aria-haspopup="true"
-                aria-label={{s!"Show theorem statement for {problemId}"}}>
+                aria-label={{theoremDisclosureAria problemId}}>
             {{textHtml problemId}}
           </span>
         }},
@@ -250,7 +243,7 @@ private def problemItem
 private def problemTitleAndStatement
     (problems : Std.HashMap String (String × String))
     (problemId : String) : (String × String) :=
-  problems.getD problemId (problemId, "Theorem statement unavailable.")
+  problems.getD problemId (problemId, theoremStatementUnavailable)
 
 /-- Render the `<summary>` row for an entry. -/
 private def entrySummary (entry : LeaderboardEntry) : Html :=
@@ -283,28 +276,28 @@ private def entryBody
   let uniqueIds : Std.HashSet String :=
     entry.uniqueProblemIds.foldl (init := ({} : Std.HashSet String)) (·.insert ·)
   let shared := entry.solvedProblems.filter fun s => ! uniqueIds.contains s.problemId
-  let uniqueSection := renderSection "Problems uniquely solved by this model" unique
-  let sharedSection := renderSection "Other solved problems" shared
+  let uniqueSection := renderSection uniqueSolvesLabel unique
+  let sharedSection := renderSection otherSolvesLabel shared
   let submitters : Html :=
     if entry.submitters.isEmpty then
-      {{ <span class="empty-inline">"None"</span> }}
+      {{ <span class="empty-inline">{{textHtml submittersEmpty}}</span> }}
     else
       Html.fromArray (entry.submitters.map fun s =>
         {{ <span class="submitter-chip">{{textHtml s.user}} <span>{{textHtml (toString s.solvedTotal)}}</span></span> }})
   let provenanceSection : Block Page :=
     divBlock "entry-section entry-side" #[
-      sectionLabel "Submission history",
+      sectionLabel submissionHistoryLabel,
       htmlBlobBlock {{
         <div class="stat-pair">
-          <span>"First submission"</span>
+          <span>{{textHtml firstSubmissionLabel}}</span>
           <span>{{textHtml (formatDate entry.firstSolvedAt)}}</span>
         </div>
         <div class="stat-pair">
-          <span>"Last submission"</span>
+          <span>{{textHtml lastSubmissionLabel}}</span>
           <span>{{textHtml (formatDate entry.lastSolvedAt)}}</span>
         </div>
       }},
-      sectionLabel "Contributors",
+      sectionLabel contributorsLabel,
       htmlBlobBlock {{ <div class="submitter-list">{{submitters}}</div> }}
     ]
   uniqueSection ++ sharedSection |>.push provenanceSection
@@ -318,11 +311,10 @@ private def entryBlock
 private def panelHeader : Block Page :=
   divBlock "panel-header" #[
     divBlock "" #[
-      divBlock "panel-kicker" #[paragraph #[textInline "Leaderboard"]],
-      htmlBlobBlock {{ <h2>"Model rankings"</h2> }}
+      divBlock "panel-kicker" #[paragraph #[textInline panelKicker]],
+      htmlBlobBlock {{ <h2>{{textHtml panelHeading}}</h2> }}
     ],
-    divBlock "panel-note" #[paragraph #[textInline
-      "Ranked by solved problems, with main benchmark problems weighted first."]]
+    divBlock "panel-note" #[paragraph #[textInline panelNote]]
   ]
 
 /-! ## Empty / placeholder leaderboard panel
@@ -340,12 +332,8 @@ private def emptyShowcase
     problemItem anchorMap id title statement none none none
   divBlock "empty-showcase" #[
     divBlock "empty-copy" #[
-      sectionLabel "No public solves yet",
-      htmlBlobBlock {{
-        <p class="empty-lead">{{textHtml
-          ("The benchmark catalog is public, and leaderboard rows will appear "
-          ++ "here as successful submissions are recorded.")}}</p>
-      }}
+      sectionLabel emptyShowcaseLabel,
+      htmlBlobBlock {{ <p class="empty-lead">{{textHtml emptyShowcaseCopy}}</p> }}
     ],
     divBlock "empty-problem-list" previewItems
   ]
@@ -365,19 +353,19 @@ private def coverageMatrix
       e.solvedProblems.foldl (init := ({} : Std.HashSet String))
         (fun s p => s.insert p.problemId)
   let headerCells : Html := Html.fromArray <|
-    #[{{ <th scope="col">"Problem"</th> }}] ++
+    #[{{ <th scope="col">{{textHtml coverageHeaderProblem}}</th> }}] ++
     entries.map (fun e =>
       {{ <th scope="col">{{textHtml e.modelName}}</th> }})
   let rows : Array Html := problemMeta.map fun (id, title, isTest) =>
     let kindClass := if isTest then "coverage-kind coverage-kind--test"
                                 else "coverage-kind coverage-kind--main"
-    let kindLabel := if isTest then "test" else "main"
+    let kindLabel := if isTest then coverageKindTest else coverageKindMain
     let cells : Array Html := entries.zipIdx.map fun (_, i) =>
       let solved := (solverSets[i]!).contains id
       if solved then
-        {{ <td class="coverage-cell coverage-cell--solved" aria-label={{s!"{title}: solved"}}>"✓"</td> }}
+        {{ <td class="coverage-cell coverage-cell--solved" aria-label={{coverageCellAria title true}}>{{textHtml coverageCellSolved}}</td> }}
       else
-        {{ <td class="coverage-cell coverage-cell--unsolved" aria-label={{s!"{title}: not solved"}}>"—"</td> }}
+        {{ <td class="coverage-cell coverage-cell--unsolved" aria-label={{coverageCellAria title false}}>{{textHtml coverageCellUnsolved}}</td> }}
     let cellsHtml : Html := Html.fromArray cells
     {{
       <tr>
@@ -391,9 +379,9 @@ private def coverageMatrix
   let body : Html := Html.fromArray rows
   htmlBlobBlock {{
     <section class="coverage-panel" aria-labelledby="coverage-heading">
-      <div class="panel-kicker">"Coverage"</div>
-      <h2 id="coverage-heading">"Per-problem coverage"</h2>
-      <p class="panel-note">"Which problems each model has solved. Hidden on narrow screens."</p>
+      <div class="panel-kicker">{{textHtml coverageKicker}}</div>
+      <h2 id="coverage-heading">{{textHtml coverageHeading}}</h2>
+      <p class="panel-note">{{textHtml coverageNote}}</p>
       <div class="coverage-table-wrap">
         <table class="coverage-table">
           <thead>

--- a/LeaderboardSite/Pages/Front.lean
+++ b/LeaderboardSite/Pages/Front.lean
@@ -1,27 +1,20 @@
 import VersoBlog
 import LeaderboardSite.Leaderboard
+import LeaderboardSite.Copy
 
 set_option verso.exampleProject "benchmark-snapshot"
 set_option maxHeartbeats 1000000
 
 open Lean
-open Lean.Elab Term
 open Verso Doc
 open Verso.Genre.Blog
 
 namespace LeaderboardSite.Pages
 
 open LeaderboardSite.Leaderboard
+open LeaderboardSite.Copy
 
 private def textInline (text : String) : Inline Page := .text text
-
-private def linkInline (label url : String) : Inline Page :=
-  .link #[.text label] url
-
-private def codeInline (text : String) : Inline Page := .code text
-
-private def paragraph (contents : Array (Inline Page)) : Block Page :=
-  .para contents
 
 private def pagePart
     (title : String)
@@ -30,44 +23,16 @@ private def pagePart
     Part Page :=
   .mk #[textInline title] title none content subParts
 
-private def divBlock (classes : String) (contents : Array (Block Page)) : Block Page :=
-  .other (BlockExt.htmlDiv classes) contents
-
-/-- Intro prose displayed after the leaderboard widget. Wrapped in
-`.wrap.prose.page-copy` so it gets the standard readable column. -/
-private def introProse : Block Page :=
-  divBlock "wrap prose page-copy" #[
-    paragraph #[
-      textInline "Welcome to ",
-      codeInline "lean-eval",
-      textInline ", a Lean formalization benchmark and public leaderboard."
-    ],
-    paragraph #[
-      textInline "You can submit new problems for review, and solutions for existing problems. New problems will be carefully reviewed and added to future benchmark releases if they are accepted. Solutions are automatically verified using ",
-      linkInline "comparator" "https://github.com/leanprover/comparator",
-      textInline " and added to the public leaderboard."
-    ],
-    paragraph #[
-      textInline "This benchmark intends to capture hard Lean formalization problems, consisting of mathematical problems that are currently stateable mostly using existing ",
-      linkInline "Mathlib" "https://github.com/leanprover-community/mathlib4",
-      textInline " definitions, perhaps with a page or so of additional setup. They should be hard, but usually not open problems: in fact, it's preferred if the problem has a known informal solution which is publicly available."
-    ],
-    paragraph #[
-      textInline "Our hope is that at launch, the problem set will be mostly, but not entirely, out of reach for current publicly available frontier models, or simple orchestration layers built on top of these. So some genuine mathematical subtlety is required!"
-    ],
-    paragraph #[
-      textInline "It's also important to say what this benchmark is not: we are not trying to capture the ability to write readable or reusable code, or to follow best practices in Lean. In particular, the only requirement for a solution to be accepted is that it is correct and passes the comparator tests."
-    ]
-  ]
-
 /-- The home page: leaderboard widget (full-width) on top, intro prose
-(constrained-width) below. The page does its own wrapping; the theme
-does not impose a prose container on this page.
+(constrained-width) below. The prose lives in `Copy.frontIntro`,
+authored as Verso markdown wrapped in the existing `wrap prose
+page-copy` div so the home page's full-width layout (which bypasses the
+theme's default prose container) still gets the readable column.
 
 Wrapped as a `VersoDoc` so the `site` DSL's lookup of `Front.toPart`
 resolves to `VersoDoc.toPart` rather than the deprecated `Part.toPart`. -/
 def _root_.LeaderboardSite.Pages.Front : VersoDoc Page :=
-  .mk (fun _ => pagePart "Lean AI formalization leaderboard"
-    (leaderboard% ++ #[introProse])) "{}"
+  .mk (fun _ => pagePart siteTitle
+    (leaderboard% ++ frontIntro.toPart.content)) "{}"
 
 end LeaderboardSite.Pages

--- a/LeaderboardSite/Pages/ProblemDetail.lean
+++ b/LeaderboardSite/Pages/ProblemDetail.lean
@@ -1,6 +1,7 @@
 import VersoBlog
 import LeaderboardSite.Data
 import LeaderboardSite.AnchorRegistry
+import LeaderboardSite.Copy
 
 open Lean
 open Lean.Elab Term
@@ -15,6 +16,7 @@ set_option maxHeartbeats 1000000
 namespace LeaderboardSite.Pages.ProblemDetail
 
 open LeaderboardSite.Data
+open LeaderboardSite.Copy
 
 private def textInline (text : String) : Inline Page :=
   .text text
@@ -37,18 +39,16 @@ private def holeWrap (child : Block Page) : Block Page :=
 private def headingBlock (text : String) : Block Page :=
   .other (BlockExt.blob {{ <h2>{{Html.text true text}}</h2> }}) #[]
 
-/-- "2026-04-30T10:05:19Z" → "Apr 30, 2026". Matches `Leaderboard.formatDate`'s
-formatting; duplicated here to keep the module dependency local. -/
+/-- "2026-04-30T10:05:19Z" → "Apr 30, 2026". Mirrors
+`Leaderboard.formatDate`. -/
 private def formatDate (iso : String) : String :=
   match iso.splitOn "T" with
   | date :: _ =>
     match date.splitOn "-" with
     | [yyyy, mm, dd] =>
-      let monthNames := #["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
       match mm.toNat? with
       | some m =>
-        if h : 1 ≤ m ∧ m ≤ 12 then
+        if 1 ≤ m ∧ m ≤ 12 then
           let name := monthNames[m - 1]!
           let dayNum := dd.toNat?.getD 0
           s!"{name} {dayNum}, {yyyy}"
@@ -87,48 +87,46 @@ private def solverParagraph (s : SolverRecord) : Block Page :=
   let baseInlines : Array (Inline Page) := #[
     textInline "• ",
     linkInline s!"@{s.user}" s!"https://github.com/{s.user}",
-    textInline s!" with {s.modelName} on {formatDate s.solvedAt}"
+    textInline (solverWithModelOnDate s.modelName (formatDate s.solvedAt))
   ]
   let inlines := match s.publicSolutionUrl with
     | some url =>
-      baseInlines ++ #[textInline " (", linkInline "proof" url, textInline ")"]
+      baseInlines ++ #[textInline " (", linkInline proofWord url, textInline ")"]
     | none => baseInlines
   paragraph inlines
 
 private def solversSection (solvers : Array SolverRecord) : Array (Block Page) :=
   if solvers.isEmpty then
-    #[headingBlock "Solved by", paragraph #[textInline "Not yet solved."]]
+    #[headingBlock solvedByLabel, paragraph #[textInline notYetSolvedText]]
   else
-    #[headingBlock "Solved by"] ++ solvers.map solverParagraph
+    #[headingBlock solvedByLabel] ++ solvers.map solverParagraph
 
 private def isUrl (text : String) : Bool :=
   text.startsWith "http://" || text.startsWith "https://"
 
-private def unavailableText : String := "Unavailable."
-
 private def optionalParagraph (label : String) (value : Option String) : Block Page :=
   let body :=
     match value.map (·.trimAscii.toString) with
-    | some s => if s.isEmpty then unavailableText else s
-    | none => unavailableText
+    | some s => if s.isEmpty then unavailable else s
+    | none => unavailable
   paragraph #[textInline s!"{label}: {body}"]
 
 private def sourceParagraph (value : Option String) : Block Page :=
   match value.map (·.trimAscii.toString) with
   | some s =>
     if s.isEmpty then
-      paragraph #[textInline s!"Source: {unavailableText}"]
+      paragraph #[textInline s!"{problemsSourcePrefix}{unavailable}"]
     else if isUrl s then
-      paragraph #[textInline "Source: ", linkInline s s]
+      paragraph #[textInline problemsSourcePrefix, linkInline s s]
     else
-      paragraph #[textInline s!"Source: {s}"]
-  | none => paragraph #[textInline s!"Source: {unavailableText}"]
+      paragraph #[textInline s!"{problemsSourcePrefix}{s}"]
+  | none => paragraph #[textInline s!"{problemsSourcePrefix}{unavailable}"]
 
 private def backLink : Block Page :=
   -- Verso emits a `<base href>` pointing at the site root, so a plain
   -- `problems/` href resolves to `<root>/problems/` rather than back up
   -- past the GitHub Pages base path.
-  paragraph #[linkInline "← All problems" "problems/"]
+  paragraph #[linkInline backToProblems "problems/"]
 
 /-- Assemble one detail page's `Part Page` at runtime from spliced anchor
 blocks plus the (already-flattened) solver list. Routing assembly through a
@@ -143,9 +141,9 @@ private def assembleDetailPart
     backLink,
     paragraph #[codeInline id],
     paragraph #[textInline submitterText],
-    optionalParagraph "Notes" notesText,
+    optionalParagraph problemsNotesLabel notesText,
     sourceParagraph sourceText,
-    optionalParagraph "Informal solution" informalSolution
+    optionalParagraph problemsInformalSolutionLabel informalSolution
   ]
   let body :=
     prelude
@@ -178,7 +176,7 @@ elab_rules : term
         let partTerm ← `(assembleDetailPart
             $(quote problem.title)
             $(quote problem.id)
-            $(quote s!"Submitter: {problem.submitter}.")
+            $(quote (problemsSubmitterSentence problem.submitter))
             $(quote problem.notesText)
             $(quote problem.sourceText)
             $(quote problem.informalSolution)

--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -1,6 +1,7 @@
 import VersoBlog
 import LeaderboardSite.Data
 import LeaderboardSite.AnchorRegistry
+import LeaderboardSite.Copy
 
 open Lean
 open Lean.Elab Term
@@ -14,6 +15,7 @@ set_option maxHeartbeats 1000000
 namespace LeaderboardSite.Pages
 
 open LeaderboardSite.Data
+open LeaderboardSite.Copy
 
 private def textInline (text : String) : Inline Page :=
   .text text
@@ -30,13 +32,10 @@ private def codeLinkInline (id url : String) : Inline Page :=
 private def paragraph (contents : Array (Inline Page)) : Block Page :=
   .para contents
 
-private def unavailableText : String :=
-  "Unavailable."
-
 private def valueOrUnavailable (value : Option String) : String :=
   match value.map (·.trimAscii.toString) with
-  | some text => if text.isEmpty then unavailableText else text
-  | none => unavailableText
+  | some text => if text.isEmpty then unavailable else text
+  | none => unavailable
 
 private def pageMeta (htmlId? : Option String := none) : Option Page.Meta :=
   htmlId?.map fun htmlId => { htmlId }
@@ -63,13 +62,13 @@ private def sourceParagraphTerm (problem : ProblemEntry) : TermElabM (TSyntax `t
   | some source =>
       if isUrl source then
         `(paragraph #[
-          textInline "Source: ",
+          textInline problemsSourcePrefix,
           linkInline $(quote source) $(quote source)
         ])
       else
-        `(paragraph #[textInline $(quote s!"Source: {source}")])
+        `(paragraph #[textInline $(quote s!"{problemsSourcePrefix}{source}")])
   | none =>
-      `(paragraph #[textInline $(quote s!"Source: {unavailableText}")])
+      `(paragraph #[textInline $(quote s!"{problemsSourcePrefix}{unavailable}")])
 
 private def holeWrap (child : Block Page) : Block Page :=
   .other (BlockExt.htmlDiv "hole") #[child]
@@ -83,11 +82,11 @@ private def filterBlock : Block Page :=
   let html : Verso.Output.Html := {{
     <div class="problems-filter" data-problems-filter="true">
       <label class="problems-filter-label" for="problems-filter-input">
-        <span class="problems-filter-icon" aria-hidden="true">"⌕"</span>
-        <span class="problems-filter-label-text">"Filter problems"</span>
+        <span class="problems-filter-icon" aria-hidden="true">{{Verso.Output.Html.text true filterBoxIcon}}</span>
+        <span class="problems-filter-label-text">{{Verso.Output.Html.text true filterBoxLabel}}</span>
       </label>
       <input id="problems-filter-input" type="search" class="problems-filter-input"
-             placeholder="title, id, notes, source, or Lean source"
+             placeholder={{filterBoxPlaceholder}}
              aria-describedby="problems-filter-count"
              autocomplete="off" spellcheck="false"/>
       <span id="problems-filter-count"
@@ -111,7 +110,7 @@ private def tocBlock (items : Array (String × String)) : Block Page :=
       {{ <li><a href={{href}}>{{Verso.Output.Html.text true title}}</a></li> }}
   let html : Verso.Output.Html := {{
     <details class="problems-toc">
-      <summary>"All problems"</summary>
+      <summary>{{Verso.Output.Html.text true tocAllProblemsLabel}}</summary>
       <ul class="problems-toc-list">{{lis}}</ul>
     </details>
   }}
@@ -169,14 +168,14 @@ private def filterHaystackText (problem : ProblemEntry) : String :=
   (String.intercalate " " parts.toList).toLower
 
 private def problemPartTerm (problem : ProblemEntry) : TermElabM (TSyntax `term) := do
-  let notesBlock ← optionalParagraphTerm "Notes" problem.notesText
+  let notesBlock ← optionalParagraphTerm problemsNotesLabel problem.notesText
   let sourceBlock ← sourceParagraphTerm problem
-  let solutionBlock ← optionalParagraphTerm "Informal solution" problem.informalSolution
+  let solutionBlock ← optionalParagraphTerm problemsInformalSolutionLabel problem.informalSolution
   let anchorsArr : TSyntaxArray `term := anchorBlockTerms problem
   `(assembleProblemPart
       $(quote problem.title)
       $(quote problem.id)
-      $(quote s!"Submitter: {problem.submitter}.")
+      $(quote (problemsSubmitterSentence problem.submitter))
       $(quote (filterHaystackText problem))
       $notesBlock
       $sourceBlock
@@ -201,42 +200,29 @@ private def sectionPartTerm (title : String) (htmlId : String)
   let subParts : TSyntaxArray `term := subParts
   `(pagePart $(quote title) #[groupHaystack] #[$subParts,*] (some $(quote htmlId)))
 
-private def introParagraphTerms : TermElabM (Array (TSyntax `term)) := do
-  pure #[
-    ← `(paragraph #[textInline "The benchmark catalog consists of carefully curated problems across mathematics, chosen so that their statements are mostly accessible using existing Mathlib definitions, but their solutions are difficult for current publicly available frontier models."]),
-    ← `(paragraph #[
-      textInline "The problem statements below are automatically extracted from the ",
-      linkInline "lean-eval" "https://github.com/leanprover/lean-eval",
-      textInline " repository."
-    ]),
-    ← `(paragraph #[
-      textInline "Authors are encouraged to submit new problems via PRs to that repository, for inclusion in future benchmark releases. See ",
-      linkInline "Submit" "submit/",
-      textInline " for details on submitting solutions."
-    ])
-  ]
-
 scoped syntax "problems_page%" : term
 
 elab_rules : term
   | `(problems_page%) => do
       let payload ← parseProblemsPayload
       let problems ← validateProblems payload
-      let introBlocks ← introParagraphTerms
       let mainProblems := Array.filter (fun problem => !problem.test) problems
       let starterProblems := Array.filter (·.test) problems
-      let mainSection ← sectionPartTerm "Main benchmark problems" "main-problems" mainProblems
+      let mainSection ← sectionPartTerm mainBenchmarkSection "main-problems" mainProblems
       let mut subParts := #[mainSection]
       if !starterProblems.isEmpty then
-        subParts := subParts.push (← sectionPartTerm "Test problems" "test-problems" starterProblems)
+        subParts := subParts.push (← sectionPartTerm testProblemsSection "test-problems" starterProblems)
       let tocItems : Array (String × String) :=
         (mainProblems ++ starterProblems).map fun p => (p.id, p.title)
       let tocTerm ← `(tocBlock $(quote tocItems))
       let filterTerm ← `(filterBlock)
-      let introBlocks' : TSyntaxArray `term :=
-        (introBlocks.push filterTerm).push tocTerm
       let subParts' : TSyntaxArray `term := subParts
-      let pageTerm ← `(pagePart "Problems" #[$introBlocks',*] #[$subParts',*])
+      -- Intro prose blocks come from `Copy.problemsIntro` (a Verso markdown
+      -- body). They're spliced as a runtime expression, then concatenated
+      -- with the elaborator-built filter and TOC blocks.
+      let pageTerm ← `(pagePart problemsTitle
+        (problemsIntro.toPart.content ++ #[$filterTerm, $tocTerm])
+        #[$subParts',*])
       let expectedType ← Lean.Elab.Term.elabTerm (← `(Part Page)) none
       Lean.Elab.Term.elabTerm pageTerm (some expectedType)
 

--- a/LeaderboardSite/Pages/Submit.lean
+++ b/LeaderboardSite/Pages/Submit.lean
@@ -1,4 +1,5 @@
 import VersoBlog
+import LeaderboardSite.Copy
 
 open Lean
 open Verso Doc
@@ -7,17 +8,11 @@ open Verso.Output Html
 
 namespace LeaderboardSite.Pages
 
+open LeaderboardSite.Copy
+
 private def textInline (text : String) : Inline Page := .text text
-private def codeInline (text : String) : Inline Page := .code text
-private def linkInline (label url : String) : Inline Page :=
-  .link #[.text label] url
-private def emInline (text : String) : Inline Page := .emph #[.text text]
 
-private def paragraph (contents : Array (Inline Page)) : Block Page :=
-  .para contents
-
-private def heading (text : String) (htmlId : String) (children : Array (Block Page)) : Part Page :=
-  Verso.Doc.Part.mk #[.text text] text (some { htmlId }) children #[]
+private def textHtml (s : String) : Verso.Output.Html := Verso.Output.Html.text true s
 
 private def pagePart
     (title : String)
@@ -26,131 +21,54 @@ private def pagePart
     Part Page :=
   .mk #[textInline title] title none content subParts
 
-private def bullets (items : Array (Array (Inline Page))) : Block Page :=
-  .ul (items.map fun is => ⟨#[.para is]⟩)
-
 private def htmlBlob (h : Verso.Output.Html) : Block Page :=
   Verso.Doc.Block.other (BlockExt.blob h) #[]
 
+/-- Big "Submit benchmark solution" button at the top of the page. -/
 private def ctaBlock : Block Page :=
   htmlBlob {{
-    <a class="cta-button"
-       href="https://github.com/leanprover/lean-eval/issues/new?template=submit.yml">
-      <span>"Submit benchmark solution"</span>
-      <span aria-hidden="true">" →"</span>
+    <a class="cta-button" href={{submitCtaUrl}}>
+      <span>{{textHtml submitCtaLabel}}</span>
+      <span aria-hidden="true">{{textHtml submitCtaArrow}}</span>
     </a>
   }}
 
+/-- Three-step TL;DR paragraph between the CTA and the lead. The HTML
+weaves a `<code>` and an `<a>` mid-sentence so its prose is broken
+into chunks rather than authored as a single string. -/
 private def tldrBlock : Block Page :=
   htmlBlob {{
     <p class="submit-tldr">
-      "Three steps: host your proof on GitHub or in a public gist, lay it out so CI can match each "
-      <code>"Submission.lean"</code>
-      " to a problem id, and open a pre-filled issue. CI runs the proof through "
-      <a href="https://github.com/leanprover/comparator">"comparator"</a>
-      " and updates the leaderboard automatically."
+      {{textHtml submitTldrPart1}}
+      <code>{{textHtml submitTldrCode1}}</code>
+      {{textHtml submitTldrPart2}}
+      <a href={{submitTldrComparatorUrl}}>{{textHtml submitTldrComparatorLabel}}</a>
+      {{textHtml submitTldrPart3}}
     </p>
   }}
 
+/-- Build a step sub-Part: title, explicit `htmlId` (referenced by CSS
+and anchors — must not drift), and body blocks pulled from a Verso
+markdown body in `Copy`. -/
+private def stepPart (title id : String) (body : VersoDoc Page) : Part Page :=
+  Verso.Doc.Part.mk #[textInline title] title (some { htmlId := id })
+    body.toPart.content #[]
+
 private def step1 : Part Page :=
-  heading "1. Put your proof somewhere the lean-eval CI can fetch it" "step-1" #[
-    paragraph #[textInline "Accepted submission sources are URLs of one of these shapes:"],
-    bullets #[
-      #[textInline "a GitHub repository: ",
-        codeInline "https://github.com/<owner>/<repo>"],
-      #[textInline "a GitHub repository pinned to a branch, tag, or commit: ",
-        codeInline "https://github.com/<owner>/<repo>/tree/<ref>",
-        textInline " or ",
-        codeInline "https://github.com/<owner>/<repo>/commit/<sha>"],
-      #[textInline "a public gist: ",
-        codeInline "https://gist.github.com/<user>/<gist-id>",
-        textInline " (optionally with a revision suffix)"]
-    ],
-    paragraph #[
-      textInline "Private GitHub repositories are supported. To use one, ",
-      linkInline "install the lean-eval-bot GitHub App" "https://github.com/apps/lean-eval-bot",
-      textInline " on the repository first, so that the CI can clone it."
-    ],
-    paragraph #[
-      textInline "Secret (unlisted) gists are not supported in v1. Make your gist public, or host the proof in a repository."
-    ]
-  ]
+  stepPart submitStep1Title submitStep1HtmlId submitStep1Body
 
 private def step2 : Part Page :=
-  heading "2. Lay out the proof so CI can find it" "step-2" #[
-    paragraph #[
-      textInline "The CI walks whatever you submit and tries every directory containing a ",
-      codeInline "lakefile.toml",
-      textInline " whose ",
-      codeInline "name",
-      textInline " field matches a benchmark problem id, and which has a ",
-      codeInline "Submission.lean",
-      textInline " next to it. For example:"
-    ],
-    bullets #[
-      #[textInline "a clone of a single generated workspace from ",
-        linkInline "leanprover/lean-eval/generated/" "https://github.com/leanprover/lean-eval/tree/main/generated"],
-      #[textInline "a fork of leanprover/lean-eval itself with your proofs under the relevant ",
-        codeInline "generated/<problem_id>/", textInline " directories"],
-      #[textInline "a custom repository containing several benchmark workspaces side by side"],
-      #[textInline "a gist containing a two-file minimum: a ",
-        codeInline "lakefile.toml", textInline " with ",
-        codeInline "name = \"<problem_id>\"", textInline " and a ",
-        codeInline "Submission.lean"]
-    ],
-    paragraph #[
-      textInline "For each matched directory the CI overlays only your ",
-      codeInline "Submission.lean",
-      textInline " and any files under ",
-      codeInline "Submission/**/*.lean",
-      textInline " onto a pristine copy of the benchmark's workspace for that problem. Every other file in your submission is ignored, including ",
-      codeInline "Solution.lean", textInline ", ",
-      codeInline "Challenge.lean", textInline ", or any modified ",
-      codeInline "lakefile.toml", textInline ". The CI then runs ",
-      linkInline "comparator" "https://github.com/leanprover/comparator",
-      textInline " to check the proof."
-    ]
-  ]
+  stepPart submitStep2Title submitStep2HtmlId submitStep2Body
 
 private def step3 : Part Page :=
-  heading "3. Open a submission issue" "step-3" #[
-    paragraph #[
-      textInline "Click ",
-      linkInline "Submit benchmark solution" "https://github.com/leanprover/lean-eval/issues/new?template=submit.yml",
-      textInline " to open a pre-filled issue. The form asks for two things:"
-    ],
-    bullets #[
-      #[textInline "a submission URL in one of the shapes above"],
-      #[textInline "a free-form model identifier that identifies the model or system that produced the proof"]
-    ],
-    paragraph #[
-      textInline "When you submit the issue, the lean-eval CI takes over. It clones your content, scans for benchmark workspaces, runs comparator on every match, and records any newly-solved problems in the leaderboard repository. The CI comments on your issue with a per-problem pass/fail summary and closes it when done. Any problem that passes is added to your ",
-      codeInline "results/<your-github-login>.json",
-      textInline " record."
-    ],
-    paragraph #[
-      textInline "Submissions are cumulative. Every success is sticky, and there is no limit on how many times you can submit. Resubmit whenever you have new proofs."
-    ]
-  ]
+  stepPart submitStep3Title submitStep3HtmlId submitStep3Body
 
 private def whatBecomesPublic : Part Page :=
-  heading "What becomes public" "what-becomes-public" #[
-    paragraph #[
-      textInline "Only the information you enter on the submission form, plus the list of problems your submission solved, becomes public. Your proof is never copied out of the ephemeral workflow runner into any public artifact. The leaderboard only stores identifiers and timestamps."
-    ],
-    paragraph #[
-      textInline "If your submission source was a public repository or a public gist, the leaderboard may link to it so that others can inspect your solution. If the source was private, no link is published."
-    ]
-  ]
+  stepPart submitWhatPublicTitle submitWhatPublicHtmlId submitWhatPublicBody
 
 def _root_.LeaderboardSite.Pages.Submit : VersoDoc Page :=
-  .mk (fun _ => pagePart "Submit"
-    #[ctaBlock, tldrBlock,
-      paragraph #[
-        textInline "Submissions are made by opening a GitHub issue on the ",
-        linkInline "lean-eval benchmark repository" "https://github.com/leanprover/lean-eval",
-        textInline "."
-      ]]
+  .mk (fun _ => pagePart submitTitle
+    (#[ctaBlock, tldrBlock] ++ submitLeadBody.toPart.content)
     #[step1, step2, step3, whatBecomesPublic]) "{}"
 
 end LeaderboardSite.Pages

--- a/SiteTheme.lean
+++ b/SiteTheme.lean
@@ -1,9 +1,13 @@
 import Verso.Doc.Html
 import VersoBlog
+import LeaderboardSite.Copy
 
 open Verso.Genre Blog Theme Template
 open Verso.Genre.Blog.Site.Syntax
 open Verso.Output Html
+open LeaderboardSite.Copy
+
+private def textHtml (s : String) : Html := Html.text true s
 
 /--
 Copied from VersoManual.Html. `addSlashJs` should likely be added to the
@@ -61,7 +65,7 @@ def theme (name : String) (siteName : String) : Theme := {
           </script>
           <meta charset="UTF-8"/>
           <meta name="viewport" content="width=device-width, initial-scale=1"/>
-          <title>{{ title }} s!" | {siteName}"</title>
+          <title>{{ title }}{{textHtml pageTitleSeparator}}{{textHtml siteName}}</title>
           <link rel="preconnect" href="https://fonts.googleapis.com"/>
           <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>
           <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Fira+Code:wght@400;500&display=swap"/>
@@ -77,22 +81,22 @@ def theme (name : String) (siteName : String) : Theme := {
             <header class="topbar">
               <div class="wrap topbar-inner">
                 <a class="wordmark" href=".">
-                  <span class="wordmark-mark">"⊢"</span>
-                  <span class="wordmark-text">"lean-eval"</span>
+                  <span class="wordmark-mark">{{textHtml wordmarkMark}}</span>
+                  <span class="wordmark-text">{{textHtml wordmarkText}}</span>
                 </a>
                 <div class="topbar-actions">
                   <nav class="top">
                     <ol>
-                      <li><a href="problems/">"Problems"</a></li>
-                      <li><a href="submit/">"Submit"</a></li>
+                      <li><a href="problems/">{{textHtml navProblems}}</a></li>
+                      <li><a href="submit/">{{textHtml navSubmit}}</a></li>
                     </ol>
                   </nav>
                   <a class="topbar-github" href="https://github.com/leanprover/lean-eval-leaderboard"
-                     aria-label="View source on GitHub"
+                     aria-label={{topbarGithubAria}}
                      target="_blank" rel="noopener">{{githubIcon}}</a>
-                  <button class="theme-toggle" type="button" aria-label="Toggle dark mode">
-                    <span class="icon-sun" aria-hidden="true">"☀"</span>
-                    <span class="icon-moon" aria-hidden="true">"☾"</span>
+                  <button class="theme-toggle" type="button" aria-label={{themeToggleAria}}>
+                    <span class="icon-sun" aria-hidden="true">{{textHtml themeToggleSunGlyph}}</span>
+                    <span class="icon-moon" aria-hidden="true">{{textHtml themeToggleMoonGlyph}}</span>
                   </button>
                 </div>
               </div>
@@ -103,15 +107,15 @@ def theme (name : String) (siteName : String) : Theme := {
             <footer class="footer">
               <div class="wrap footer-inner">
                 <div class="footer-row footer-row--repos">
-                  <span>"Public results for lean-eval."</span>
-                  <a href="https://github.com/leanprover/lean-eval">{{githubIcon}}<span>"Benchmark repo"</span></a>
-                  <a href="https://github.com/leanprover/lean-eval-leaderboard">{{githubIcon}}<span>"Results repo"</span></a>
+                  <span>{{textHtml footerTagline}}</span>
+                  <a href="https://github.com/leanprover/lean-eval">{{githubIcon}}<span>{{textHtml footerBenchmarkRepo}}</span></a>
+                  <a href="https://github.com/leanprover/lean-eval-leaderboard">{{githubIcon}}<span>{{textHtml footerResultsRepo}}</span></a>
                 </div>
                 <div class="footer-row footer-row--community">
-                  <span>"Community"</span>
-                  <a href="https://lean-lang.org/">"Lean"</a>
-                  <a href="https://mathlib-initiative.org/">"Mathlib Initiative"</a>
-                  <a href="https://leanprover.zulipchat.com/">"Zulip"</a>
+                  <span>{{textHtml footerCommunityHeading}}</span>
+                  <a href="https://lean-lang.org/">{{textHtml footerLinkLean}}</a>
+                  <a href="https://mathlib-initiative.org/">{{textHtml footerLinkMathlibInitiative}}</a>
+                  <a href="https://leanprover.zulipchat.com/">{{textHtml footerLinkZulip}}</a>
                 </div>
               </div>
             </footer>


### PR DESCRIPTION
This PR pulls every reader-facing string on the site — page bodies, hero copy, nav and footer text, ARIA labels, button labels, fallback strings — into a single `LeaderboardSite/Copy.lean` module. Page-layout files (`Pages/*.lean`, `Leaderboard.lean`, `SiteTheme.lean`) now hold layout and data binding only and reference `Copy.*` for any human-readable text. Editing a string no longer requires reading Lean macros: it's one place, clearly labelled as content.

Substantial prose (the Front-page intro, the Problems-page intro, and each Submit-page sub-section) lives in `Copy` as Verso markdown bodies authored via the `verso (Page) "title" ::: ... :::` term form, so inline links read as `[label](url)` and code spans use backticks. Pages splice these into hand-built Parts via `VersoDoc.toPart` and `Part.content`. Short labels embedded in hand-rolled HTML widgets stay as plain `String` defs.

`Submit.lean` keeps its top-level Part with named sub-Parts (`step-1`, `step-2`, `step-3`, `what-becomes-public`) so the `htmlId` metadata referenced by CSS / anchors is preserved verbatim — only the per-section bodies move to `Copy`.

One editorial change is folded in: `heroSide` is updated to clarify that this is a submission-based leaderboard, not an automatic evaluation of every model on every problem by the Lean FRO or benchmark organisers. Apart from that paragraph, the rendered HTML is byte-identical (after whitespace normalization) to the pre-refactor build — verified by diff against a baseline `_site/`, by `scripts/check_links.py` (1657 links across 55 pages), and by side-by-side screenshot comparison in light and dark mode of the Front, Problems, Submit, and a sample Detail page.

🤖 Prepared with Claude Code