### PR TITLE
feat: read results from the lean-eval-submissions repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+  # leanprover/lean-eval-submissions fires this after recording a new
+  # result, so the site redeploys with it. Before the submission
+  # pipeline split out, a record commit landed in this repo and the
+  # `push` trigger covered it; results now live in a separate repo.
+  repository_dispatch:
+    types: [results-advanced]
 
 permissions:
   contents: read
@@ -29,15 +35,25 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout benchmark repo at the snapshot's pinned commit
-        # site-data/leaderboard.json is regenerated each deploy from results/.
-        # The generator needs the benchmark repo for problem metadata. We pin
-        # to the same commit benchmark-snapshot/ was built from so the
-        # snapshot's catalog and the regenerated site-data stay in lockstep.
+        # site-data/leaderboard.json is regenerated each deploy from the
+        # results store. The generator needs the benchmark repo for problem
+        # metadata. We pin to the same commit benchmark-snapshot/ was built
+        # from so the snapshot's catalog and the regenerated site-data stay
+        # in lockstep.
         uses: actions/checkout@v4
         with:
           repository: leanprover/lean-eval
           path: lean-eval-benchmark
           fetch-depth: 0
+
+      - name: Checkout the results store
+        # leanprover/lean-eval-submissions holds results/<login>.json.
+        # generate_site_data.py reads them via --results-repo. Always main
+        # HEAD: the results store is append-only and the site shows latest.
+        uses: actions/checkout@v4
+        with:
+          repository: leanprover/lean-eval-submissions
+          path: lean-eval-submissions
 
       - name: Pin benchmark checkout to snapshot commit
         run: |
@@ -91,14 +107,16 @@ jobs:
           )
           lake build BenchmarkProblems subverso-extract-mod $highlighted_targets
 
-      - name: Regenerate site-data from results/ and the pinned benchmark
-        # site-data/ is .gitignored — regenerated here so every record: push
-        # to results/ shows up on the next deploy. --no-write-snapshot keeps
-        # benchmark-snapshot/ untouched so its Lake cache stays warm.
+      - name: Regenerate site-data from the results store and the pinned benchmark
+        # site-data/ is .gitignored — regenerated here so every new result
+        # in leanprover/lean-eval-submissions shows up on the next deploy.
+        # --no-write-snapshot keeps benchmark-snapshot/ untouched so its
+        # Lake cache stays warm.
         run: |
           python3 scripts/generate_site_data.py \
             --no-write-snapshot \
-            --benchmark-repo lean-eval-benchmark
+            --benchmark-repo lean-eval-benchmark \
+            --results-repo lean-eval-submissions
 
       - name: Build site
         run: lake exe lean-eval-leaderboard --output _site

--- a/README.md
+++ b/README.md
@@ -2,21 +2,18 @@
 
 **[View the leaderboard →](https://lean-lang.org/eval/)**
 
-Results store and public website data source for the
+The public website for the
 [lean-eval](https://github.com/leanprover/lean-eval) benchmark.
 
-This repository holds machine-written artifacts produced by the lean-eval CI
-and by the leaderboard-site build pipeline.
+This repository builds the leaderboard site. It does **not** store the raw
+results: those live in the submissions repository,
+[`leanprover/lean-eval-submissions`](https://github.com/leanprover/lean-eval-submissions),
+under `results/<login>.json` — its README documents the record schema and
+write semantics. The deploy workflow checks that repo out and the site is
+regenerated from it.
 
-- `results/` is the append-only public success log written by lean-eval CI.
-- `site-data/` is the derived, presentation-oriented data consumed by the
-  public website.
-
-**Do not edit generated files here by hand.**
-
-Successes are **sticky**: once a problem is marked solved for a given user,
-that record is never modified or removed, even if a later submission from the
-same user no longer proves it.
+`site-data/` is the derived, presentation-oriented data consumed by the
+public website. **Do not edit generated files here by hand.**
 
 > Submitter-facing instructions live on the Verso website at
 > [`LeaderboardSite/Pages/Submit.lean`](LeaderboardSite/Pages/Submit.lean).
@@ -26,30 +23,42 @@ same user no longer proves it.
 ## File layout
 
 ```
-results/
-  <github-login>.json
-
 site-data/
   problems.json
   leaderboard.json
 ```
 
-One file per submitter. Users without any successful submission have no file.
-Filenames use the user's GitHub login, lowercased, since GitHub logins are
-case-insensitive.
+The `site-data/` directory is generated from the results store
+(`leanprover/lean-eval-submissions/results/`) together with benchmark metadata
+imported from the benchmark repository. Its schema is documented in
+[docs/site-data-schema.md](docs/site-data-schema.md). Its files are derived
+(`.gitignore`d) and produced by `scripts/generate_site_data.py`, which the
+deploy workflow runs before every site build, and which local developers
+invoke via `lake script run generate` (the `generate` script in
+`lakefile.lean` runs the generator and then builds the site).
 
-The `site-data/` directory is generated from the raw `results/` files together
-with benchmark metadata imported from the benchmark repository. Its schema is
-documented in [docs/site-data-schema.md](docs/site-data-schema.md). Its files
-are derived (`.gitignore`d) and produced by `scripts/generate_site_data.py`,
-which the deploy workflow runs before every site build, and which local
-developers invoke via `lake script run generate` (the `generate` script in
-`lakefile.lean` runs the generator and then builds the site). The deploy pins
-the benchmark sibling clone to the commit recorded in
-`benchmark-snapshot/.benchmark-commit`, so the regenerated site-data and the
-checked-in snapshot's catalog stay in lockstep.
+`generate_site_data.py` takes `--benchmark-repo` (a `leanprover/lean-eval`
+checkout) and `--results-repo` (a `leanprover/lean-eval-submissions`
+checkout); both default to sibling clones, or set `LEAN_EVAL_BENCHMARK_REPO` /
+`LEAN_EVAL_RESULTS_REPO`. The deploy pins the benchmark clone to the commit
+recorded in `benchmark-snapshot/.benchmark-commit`, so the regenerated
+site-data and the checked-in snapshot's catalog stay in lockstep; the results
+clone is always read at `main` HEAD.
 
-## Record schema (v2)
+## Results
+
+The results store and its record schema live in
+[`leanprover/lean-eval-submissions`](https://github.com/leanprover/lean-eval-submissions).
+Successes are **sticky**: once a `(user, model, problem)` triple is recorded
+it is never modified or removed.
+
+<details>
+<summary>Historical record-schema notes (superseded — see lean-eval-submissions)</summary>
+
+The text below is retained for reference; the authoritative schema is the
+one in the submissions repo's README.
+
+### Record schema (v2)
 
 ```json
 {
@@ -151,11 +160,13 @@ record: <login> solved <problem_id>[, <problem_id>...] using <model> @ <benchmar
 One commit per submission, grouping all newly-recorded problems for a
 single model together.
 
-## Schema evolution
+### Schema evolution
 
 Breaking changes bump `schema_version`. Consumers should refuse to parse a
 file whose `schema_version` they do not know. Non-breaking additive changes
 (new optional fields) keep the version number stable.
+
+</details>
 
 ## Website build direction
 

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -8,6 +8,7 @@ import pathlib
 import re
 import shutil
 import subprocess
+import sys
 import tomllib
 from collections import defaultdict
 from dataclasses import dataclass
@@ -16,12 +17,18 @@ from typing import Any
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
-RESULTS_ROOT = REPO_ROOT / "results"
 SITE_DATA_ROOT = REPO_ROOT / "site-data"
 BENCHMARK_SNAPSHOT_ROOT = REPO_ROOT / "benchmark-snapshot"
 DEFAULT_BENCHMARK_REPO = pathlib.Path(
     os.environ.get("LEAN_EVAL_BENCHMARK_REPO", str(REPO_ROOT.parent / "lean-eval"))
 )
+# The results store (`results/<login>.json`) lives in a sibling repo,
+# leanprover/lean-eval-submissions. The deploy workflow checks it out and
+# passes --results-repo; locally it defaults to a sibling clone.
+DEFAULT_RESULTS_REPO = pathlib.Path(
+    os.environ.get("LEAN_EVAL_RESULTS_REPO", str(REPO_ROOT.parent / "lean-eval-submissions"))
+)
+RESULTS_REPO_SLUG = "leanprover/lean-eval-submissions"
 # Path to the SHA pin file the deploy workflow already uses to know
 # which lean-eval commit benchmark-snapshot/ was built from. Single
 # line, 40 hex chars + trailing newline. Bumping this file is the
@@ -602,6 +609,27 @@ def build_leaderboard_payload(
                 if current is None or timestamp_key(candidate["solved_at"]) < timestamp_key(current["solved_at"]):
                     per_model_problem[model_id][problem_id] = candidate
 
+    # Snapshot-race tolerance: a result can be recorded against a
+    # leanprover/lean-eval commit slightly newer than the leaderboard's
+    # benchmark-snapshot, naming a problem the snapshot's catalog does
+    # not yet contain. Such records are kept in the leaderboard payload
+    # but counted only in solved_total (not solved_main/solved_test);
+    # warn so the gap is visible until the snapshot catches up.
+    unknown_problem_ids = sorted(
+        {
+            problem_id
+            for problems_for_model in per_model_problem.values()
+            for problem_id in problems_for_model
+            if problem_id not in problem_map
+        }
+    )
+    if unknown_problem_ids:
+        print(
+            "warning: results reference problem ids absent from the benchmark "
+            f"snapshot catalog: {', '.join(unknown_problem_ids)}",
+            file=sys.stderr,
+        )
+
     solving_model_counts: dict[str, int] = defaultdict(int)
     for problems_for_model in per_model_problem.values():
         for problem_id in problems_for_model:
@@ -695,7 +723,7 @@ def build_leaderboard_payload(
         "schema_version": 1,
         "generated_at": utc_now(),
         "results_repo": {
-            "repo": "leanprover/lean-eval-leaderboard",
+            "repo": RESULTS_REPO_SLUG,
             "commit": git_head(results_repo),
         },
         "benchmark": {
@@ -735,7 +763,17 @@ def _read_pinned_sha() -> str:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--benchmark-repo", default=str(DEFAULT_BENCHMARK_REPO))
-    parser.add_argument("--results-root", default=str(RESULTS_ROOT))
+    parser.add_argument(
+        "--results-repo",
+        default=str(DEFAULT_RESULTS_REPO),
+        help="Checkout of leanprover/lean-eval-submissions (the results store).",
+    )
+    parser.add_argument(
+        "--results-root",
+        default=None,
+        help="Directory of <login>.json result files. "
+        "Defaults to <results-repo>/results.",
+    )
     parser.add_argument("--output-dir", default=str(SITE_DATA_ROOT))
     parser.add_argument(
         "--no-write-snapshot",
@@ -761,7 +799,12 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     benchmark_repo = pathlib.Path(args.benchmark_repo).resolve()
-    results_root = pathlib.Path(args.results_root).resolve()
+    results_repo = pathlib.Path(args.results_repo).resolve()
+    results_root = (
+        pathlib.Path(args.results_root).resolve()
+        if args.results_root
+        else results_repo / "results"
+    )
     output_dir = pathlib.Path(args.output_dir).resolve()
 
     # Pin-check: assert that the lean-eval clone we're about to read from
@@ -815,7 +858,7 @@ def main() -> int:
     write_json(output_dir / "problems.json", build_problem_payload(benchmark_repo, problems))
     write_json(
         output_dir / "leaderboard.json",
-        build_leaderboard_payload(REPO_ROOT, benchmark_repo, problems, raw_results),
+        build_leaderboard_payload(results_repo, benchmark_repo, problems, raw_results),
     )
     if not args.no_write_snapshot:
         write_benchmark_snapshot(benchmark_repo, problems)


### PR DESCRIPTION
This PR points the leaderboard build at the new results store. The raw results (`results/<login>.json`) moved out of this repository into [`leanprover/lean-eval-submissions`](https://github.com/leanprover/lean-eval-submissions) along with the submission pipeline; this repository now only builds the public site.

- `generate_site_data.py` gains a `--results-repo` argument (env `LEAN_EVAL_RESULTS_REPO`), defaulting to a sibling `lean-eval-submissions` clone; `--results-root` derives from it. The leaderboard payload's `results_repo` field reports `leanprover/lean-eval-submissions`.
- It warns when a result names a problem id absent from the benchmark snapshot's catalog — a record evaluated against a `lean-eval` commit newer than the snapshot is kept rather than crashing the build.
- `deploy.yml` checks out `leanprover/lean-eval-submissions`, passes `--results-repo`, and gains a `repository_dispatch` (`results-advanced`) trigger so a newly-recorded result redeploys the site (the submission pipeline fires that dispatch after each `record`).

The repository's own `results/` directory is **left in place** by this PR — it is removed in a follow-up once a deploy reading from the new location has been verified green.

> [!IMPORTANT]
> Part of a three-repo split. Merge order: `leanprover/lean-eval-submissions` must be populated and reachable before this is merged, so the deploy can check it out.

🤖 Prepared with Claude Code