### PR TITLE
feat: deprioritize internal test problems on the leaderboard

### DIFF
--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -87,9 +87,6 @@ def heroSide   : String :=
    solutions, not an automatic evaluation of every model on every \
    problem by the Lean FRO or benchmark organisers."
 
-def heroBenchmarkBreakdownLabel : String := "Benchmark breakdown"
-def heroMainProblemsLabel       : String := "Main problems"
-def heroTestProblemsLabel       : String := "Test problems"
 def heroModelsLabel             : String := "models"
 def heroProblemsLabel           : String := "problems"
 def heroSubmitterSingular       : String := "submitter"
@@ -102,7 +99,8 @@ def heroProblemAuthorPlural     : String := "problem authors"
 def panelKicker  : String := "Leaderboard"
 def panelHeading : String := "Model rankings"
 def panelNote    : String :=
-  "Ranked by solved problems, with main benchmark problems weighted first."
+  "Ranked by main benchmark problems solved. Internal test problems do \
+   not count toward the score."
 
 /-! ## Empty-showcase state -/
 
@@ -140,11 +138,9 @@ def leanTheoremStatementLabel   : String := "Lean theorem statement"
 def theoremDisclosureAria (problemId : String) : String :=
   s!"Show theorem statement for {problemId}"
 
-/-! ## Score pills -/
+/-! ## Score line -/
 
 def scoreSolvedSuffix : String := " solved"
-def scoreMainSuffix   : String := " main"
-def scoreTestSuffix   : String := " test"
 
 /-! ## Per-row entry section labels -/
 
@@ -155,6 +151,12 @@ def contributorsLabel      : String := "Contributors"
 def uniqueSolvesLabel      : String := "Problems uniquely solved by this model"
 def otherSolvesLabel       : String := "Other solved problems"
 def submittersEmpty        : String := "None"
+
+/-- One muted line summarising test-problem solves inside an expanded
+entry, e.g. `"Test problems: two_plus_two, foo (2 / 5 solved)"`. Test
+problems are internal fixtures and are not counted toward the score. -/
+def testSolvesLine (ids : String) (solved total : Nat) : String :=
+  s!"Test problems: {ids} ({solved} / {total} solved)"
 
 /-! ## Problems page -/
 

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -91,13 +91,14 @@ private def formatDate (iso : String) : String :=
     | _ => iso
   | [] => iso
 
+/-- The summary-row score: the main-only solved count. Test-problem
+solves are internal fixtures and are reported separately, as a single
+muted line inside the expanded entry body. -/
 private def scoreLineHtml (score : LeaderboardScore) : Html :=
   let solved : String := s!"{score.display}{scoreSolvedSuffix}"
   {{
     <span class="entry-score-line">
       <span class="entry-score-primary">{{textHtml solved}}</span>
-      <span class="entry-score-pill entry-score-pill--main">{{textHtml s!"{score.solvedMain}{scoreMainSuffix}"}}</span>
-      <span class="entry-score-pill entry-score-pill--test">{{textHtml s!"{score.solvedTest}{scoreTestSuffix}"}}</span>
     </span>
   }}
 
@@ -114,20 +115,13 @@ private def heroStatLink (number : Nat) (label href : String) : Block Page :=
     htmlBlobBlock (heroStatBody number label)
   ]
 
-private def statPairLink (label href : String) (value : Nat) : Block Page :=
-  htmlWrapperBlock "a" #[("class", "stat-pair stat-pair-link"), ("href", href)] #[
-    htmlBlobBlock {{
-      <span>{{textHtml label}}</span><span>{{textHtml (toString value)}}</span>
-    }}
-  ]
-
 private def sectionLabel (text : String) : Block Page :=
   divBlock "section-label" #[paragraph #[textInline text]]
 
 private def heroBlock (summary : LeaderboardSummary) : Block Page :=
   let problemsHref := "problems/"
-  let mainProblemsHref := s!"{problemsHref}#main-problems"
-  let testProblemsHref := s!"{problemsHref}#test-problems"
+  -- The headline problem count is main-only; the five internal test
+  -- problems are deliberately not advertised in the hero.
   let heroMain := divBlock "hero-main" #[
     divBlock "hero-kicker" #[paragraph #[textInline heroKicker]],
     htmlBlobBlock {{ <h1 class="hero-title">{{textHtml heroTitle}}</h1> }},
@@ -137,15 +131,10 @@ private def heroBlock (summary : LeaderboardSummary) : Block Page :=
       heroStat summary.submitters (pluralize summary.submitters heroSubmitterSingular heroSubmitterPlural),
       heroStat summary.problemAuthors
         (pluralize summary.problemAuthors heroProblemAuthorSingular heroProblemAuthorPlural),
-      heroStatLink summary.problems heroProblemsLabel problemsHref
+      heroStatLink summary.mainProblems heroProblemsLabel problemsHref
     ]
   ]
   let heroSideAside := htmlWrapperBlock "aside" #[("class", "hero-side")] #[
-    sectionLabel heroBenchmarkBreakdownLabel,
-    divBlock "hero-side-metrics" #[
-      statPairLink heroMainProblemsLabel mainProblemsHref summary.mainProblems,
-      statPairLink heroTestProblemsLabel testProblemsHref summary.testProblems
-    ],
     htmlBlobBlock {{ <p class="hero-side-copy">{{textHtml heroSide}}</p> }}
   ]
   sectionBlock "hero-panel" #[
@@ -255,11 +244,21 @@ private def entrySummary (entry : LeaderboardEntry) : Html :=
     <span class="entry-score">{{scoreLineHtml entry.score}}</span>
   }}
 
-/-- Render the body of a `<details>` row: solved-by-this-model + provenance. -/
+/-- Render the body of a `<details>` row: solved-by-this-model + provenance.
+
+Test-problem solves are kept out of the unique/other problem grids and
+collapsed into a single muted line (`testSolvesLine`) at the end of the
+solve sections — they are internal fixtures and should not compete for
+attention with real benchmark solves. `kindMap` maps a problem id to its
+`test` flag; `testTotal` is the total number of test problems in the
+catalog, used for the `solved / total` count. -/
 private def entryBody
     (problems : Std.HashMap String (String × String))
+    (kindMap : Std.HashMap String Bool)
+    (testTotal : Nat)
     (anchorMap : Std.HashMap String (Array (Block Page)))
     (entry : LeaderboardEntry) : Array (Block Page) :=
+  let isTest := fun (pid : String) => kindMap.getD pid false
   let renderItem (item : SolvedProblem) : Block Page :=
     let (title, statement) := problemTitleAndStatement problems item.problemId
     let proofUrl? := if item.publicSolution.available then item.publicSolution.url else none
@@ -271,13 +270,24 @@ private def entryBody
           sectionLabel label,
           divBlock "problem-grid" (items.map renderItem)
         ]]
-  let unique := entry.uniqueProblemIds.filterMap fun pid =>
-    entry.solvedProblems.find? (·.problemId == pid)
+  -- Split the model's solves into real (main) benchmark problems and
+  -- internal test fixtures.
+  let mainSolved := entry.solvedProblems.filter fun s => ! isTest s.problemId
+  let testSolved := entry.solvedProblems.filter fun s => isTest s.problemId
   let uniqueIds : Std.HashSet String :=
-    entry.uniqueProblemIds.foldl (init := ({} : Std.HashSet String)) (·.insert ·)
-  let shared := entry.solvedProblems.filter fun s => ! uniqueIds.contains s.problemId
+    entry.uniqueProblemIds.foldl (init := ({} : Std.HashSet String)) fun s pid =>
+      if isTest pid then s else s.insert pid
+  let unique := entry.uniqueProblemIds.filterMap fun pid =>
+    if isTest pid then none else mainSolved.find? (·.problemId == pid)
+  let shared := mainSolved.filter fun s => ! uniqueIds.contains s.problemId
   let uniqueSection := renderSection uniqueSolvesLabel unique
   let sharedSection := renderSection otherSolvesLabel shared
+  -- One muted line summarising test-problem solves, only when there are any.
+  let testSection : Array (Block Page) :=
+    if testSolved.isEmpty then #[] else
+      let ids := String.intercalate ", " (testSolved.map (·.problemId)).toList
+      #[divBlock "entry-test-note"
+          #[paragraph #[textInline (testSolvesLine ids testSolved.size testTotal)]]]
   let submitters : Html :=
     if entry.submitters.isEmpty then
       {{ <span class="empty-inline">{{textHtml submittersEmpty}}</span> }}
@@ -300,13 +310,16 @@ private def entryBody
       sectionLabel contributorsLabel,
       htmlBlobBlock {{ <div class="submitter-list">{{submitters}}</div> }}
     ]
-  uniqueSection ++ sharedSection |>.push provenanceSection
+  uniqueSection ++ sharedSection ++ testSection |>.push provenanceSection
 
 private def entryBlock
     (problems : Std.HashMap String (String × String))
+    (kindMap : Std.HashMap String Bool)
+    (testTotal : Nat)
     (anchorMap : Std.HashMap String (Array (Block Page)))
     (entry : LeaderboardEntry) : Block Page :=
-  detailsBlock "entry" (entrySummary entry) (entryBody problems anchorMap entry)
+  detailsBlock "entry" (entrySummary entry)
+    (entryBody problems kindMap testTotal anchorMap entry)
 
 private def panelHeader : Block Page :=
   divBlock "panel-header" #[
@@ -348,6 +361,12 @@ mobile/tablet keep the existing list view. -/
 private def coverageMatrix
     (problemMeta : Array (String × String × Bool))
     (entries : Array LeaderboardEntry) : Block Page :=
+  -- Test problems are kept in the matrix but sunk below every main
+  -- benchmark problem; the partition is stable so catalog order is
+  -- preserved within each group.
+  let problemMeta : Array (String × String × Bool) :=
+    problemMeta.filter (fun (_, _, isTest) => ! isTest)
+      ++ problemMeta.filter (fun (_, _, isTest) => isTest)
   let solverSets : Array (Std.HashSet String) :=
     entries.map fun e =>
       e.solvedProblems.foldl (init := ({} : Std.HashSet String))
@@ -397,6 +416,8 @@ private def coverageMatrix
 empty showcase with a 4-problem catalog preview. -/
 private def leaderboardPanel
     (problems : Std.HashMap String (String × String))
+    (kindMap : Std.HashMap String Bool)
+    (testTotal : Nat)
     (anchorMap : Std.HashMap String (Array (Block Page)))
     (preview : Array (String × String × String))
     (entries : Array LeaderboardEntry) : Block Page :=
@@ -404,7 +425,7 @@ private def leaderboardPanel
     if entries.isEmpty then
       #[emptyShowcase anchorMap preview]
     else
-      entries.map (entryBlock problems anchorMap)
+      entries.map (entryBlock problems kindMap testTotal anchorMap)
   sectionBlock "leaderboard-panel" #[
     panelHeader,
     divBlock "entry-list" body
@@ -452,7 +473,10 @@ def leaderboardBlocks
       problemMap[id]?.map fun (title, statement) => (id, title, statement)
   let problemMeta : Array (String × String × Bool) := problemEntries.map
     fun (id, title, _) => (id, title, kindMap.getD id false)
-  let leaderboard := leaderboardPanel problemMap anchorMap preview entries
+  let testTotal : Nat := problemMeta.foldl (init := 0)
+    fun n (_, _, isTest) => if isTest then n + 1 else n
+  let leaderboard :=
+    leaderboardPanel problemMap kindMap testTotal anchorMap preview entries
   let coverage :=
     if entries.isEmpty then htmlBlobBlock {{ <span></span> }}
     else coverageMatrix problemMeta entries

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -643,7 +643,9 @@ def build_leaderboard_payload(
                     "solved_total": solved_total,
                     "solved_main": solved_main,
                     "solved_test": solved_test,
-                    "display": str(solved_total),
+                    # Headline number is main-only: test problems are
+                    # internal fixtures and must not inflate the score.
+                    "display": str(solved_main),
                 },
                 "first_solved_at": first_solved_at,
                 "last_solved_at": last_solved_at,
@@ -680,9 +682,10 @@ def build_leaderboard_payload(
             }
         )
 
+    # Rank by main benchmark solves only; test-problem solves never move a
+    # model up the board.
     entries.sort(
         key=lambda entry: (
-            -entry["score"]["solved_total"],
             -entry["score"]["solved_main"],
             timestamp_key(entry["last_solved_at"]),
             entry["model_name"].lower(),

--- a/static/style.css
+++ b/static/style.css
@@ -945,22 +945,6 @@ nav.top .home { display: none; }
   border-bottom: 1px solid var(--color-border);
 }
 
-.stat-pair-link {
-  text-decoration: none;
-  color: inherit;
-  transition: color var(--transition-fast);
-}
-
-.stat-pair-link:hover,
-.stat-pair-link:focus-visible {
-  color: var(--color-primary);
-}
-
-.stat-pair-link:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
 .submitter-list {
   display: flex;
   flex-wrap: wrap;
@@ -1269,7 +1253,7 @@ input.tactic-toggle,
   display: none;
 }
 
-/* Score pills in the leaderboard summary row. */
+/* Score line in the leaderboard summary row. */
 .entry-score-line {
   display: inline-flex;
   align-items: center;
@@ -1285,38 +1269,18 @@ input.tactic-toggle,
   font-weight: 600;
 }
 
-.entry-score-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 9px;
-  border-radius: var(--radius-pill);
+/* Muted single-line summary of test-problem solves inside an expanded
+   entry. Test problems are internal fixtures, so they get one quiet
+   line rather than a grid of problem chips. */
+.entry-test-note {
+  color: var(--color-text-light);
+  font-size: 0.82rem;
   font-family: var(--font-mono);
-  font-size: 0.74rem;
-  border: 1px solid transparent;
+  margin-top: var(--space-2);
 }
 
-.entry-score-pill--main {
-  color: var(--color-primary);
-  border-color: rgba(56, 110, 224, 0.28);
-  background: rgba(56, 110, 224, 0.08);
-}
-
-.entry-score-pill--test {
-  color: #7c4dcc;
-  border-color: rgba(124, 77, 204, 0.28);
-  background: rgba(124, 77, 204, 0.08);
-}
-
-.dark-theme .entry-score-pill--main {
-  color: var(--color-primary);
-  border-color: rgba(59, 148, 255, 0.32);
-  background: rgba(59, 148, 255, 0.10);
-}
-
-.dark-theme .entry-score-pill--test {
-  color: #c5a5ff;
-  border-color: rgba(197, 165, 255, 0.32);
-  background: rgba(197, 165, 255, 0.10);
+.entry-test-note p {
+  margin: 0;
 }
 
 /* Hero stat strip: pill-shaped inline strip wrapping the home-page stats. */


### PR DESCRIPTION
This PR deprioritizes the five internal `test = true` problems so they no longer compete with real benchmark solves for attention. The headline number on each leaderboard row, and the ranking, become main-only: `score.display` is now `solved_main` and entries sort by `-solved_main`, so a test-problem solve can never move a model up the board. The always-visible summary row drops the `main` and `test` score pills, leaving just the main solved count.

Inside the expanded per-model drop-down, test-problem solves are filtered out of the "uniquely solved" / "other solved" grids and collapsed into a single muted line — e.g. `Test problems: two_plus_two, list_append_singleton_length, … (5 / 5 solved)`. The line only appears when the model solved at least one test problem.

In the coverage matrix, test rows are kept but sunk below every main benchmark problem; the partition is stable, so catalog order is preserved within each group.

The hero panel no longer advertises the test problems: the "Benchmark breakdown" aside (which existed only to split the catalog into main + test) is dropped, leaving the aside with just its explanatory paragraph, and the prominent hero problem count is now main-only.

Verified by regenerating `site-data/`, building `LeaderboardSite`, and rendering `_site/`: no `entry-score-pill` in the output, the test-note line and main-only headline render correctly, the hero shows `55 problems` with no breakdown aside, and the coverage matrix lists all 55 main rows before the 5 test rows.

🤖 Prepared with Claude Code