### PR TITLE
Avoid broken links for results missing from benchmark snapshot

### DIFF
--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -174,11 +174,18 @@ private def problemItem
     (problemId : String) (title : String) (statement : String)
     (proofUrl? : Option String)
     (rarityRank? : Option Nat)
-    (productionDescription? : Option String) : Block Page :=
+    (productionDescription? : Option String)
+    (hasProblemPage : Bool := true) : Block Page :=
   let problemHref := s!"problems/{problemId}/"
-  let titleLink := htmlBlobBlock {{
-    <a class="problem-title-link" href={{problemHref}}>{{textHtml title}}</a>
-  }}
+  let titleLink :=
+    if hasProblemPage then
+      htmlBlobBlock {{
+        <a class="problem-title-link" href={{problemHref}}>{{textHtml title}}</a>
+      }}
+    else
+      htmlBlobBlock {{
+        <span class="problem-title-link">{{textHtml title}}</span>
+      }}
   let proofLink := match proofUrl? with
     | some url => htmlBlobBlock {{
         <a class="problem-proof-link" href={{url}}>
@@ -261,9 +268,10 @@ private def entryBody
   let isTest := fun (pid : String) => kindMap.getD pid false
   let renderItem (item : SolvedProblem) : Block Page :=
     let (title, statement) := problemTitleAndStatement problems item.problemId
+    let hasProblemPage := (problems[item.problemId]?).isSome
     let proofUrl? := if item.publicSolution.available then item.publicSolution.url else none
     problemItem anchorMap item.problemId title statement proofUrl? (some item.rarityRank)
-      item.productionDescription
+      item.productionDescription hasProblemPage
   let renderSection (label : String) (items : Array SolvedProblem) : Array (Block Page) :=
     if items.isEmpty then #[] else
       #[divBlock "entry-section" #[


### PR DESCRIPTION
## Summary
- Render solved problem titles as plain text when a result references a problem id absent from the pinned benchmark snapshot.
- Keep known snapshot problems linked as before.
- Preserve counting/result visibility for out-of-snapshot records while avoiding deploy-blocking broken internal links.

## RCA
The leaderboard deploy is failing in `scripts/check_links.py` because current results include `variable_binder_example`, but the pinned benchmark snapshot has no generated page for that problem. The site rendered `problems/variable_binder_example/`, which does not exist under `_site`, so GitHub Pages deploy never publishes newer accepted results.

## Validation
- `python3 scripts/generate_site_data.py --no-write-snapshot --benchmark-repo lean-eval-benchmark --results-repo lean-eval-submissions` reproduced the warning: missing `variable_binder_example` in the snapshot catalog.
- `lake build LeaderboardSite.Data` passed.
- Full `lake build` was started but not completed locally because the benchmark snapshot highlighting path was doing a long local SubVerso extraction; CI should exercise the exact deploy path.
- `git diff --check -- .` passed before commit.