### PR TITLE
refactor: adapt site-data generation to manifests/problems/ directory (lean-eval#317)

### DIFF
--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -15,8 +15,8 @@ structure BenchmarkInfo where
 deriving FromJson
 
 /-- One `@[eval_problem]`-annotated declaration. Multiple holes may belong
-to the same `manifests/problems.toml` entry; they are rendered together as
-a stack on the problems page and in home-page popovers. -/
+to the same `manifests/problems/<id>.toml` entry; they are rendered together
+as a stack on the problems page and in home-page popovers. -/
 structure Hole where
   /-- Fully-qualified declaration name (e.g. `LeanEval.Foo.bar`). -/
   name : String

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -111,10 +111,14 @@ def load_holes(benchmark_repo: pathlib.Path, problem_id: str) -> tuple[Hole, ...
     return tuple(holes)
 
 
-def load_manifest(manifest_path: pathlib.Path, benchmark_repo: pathlib.Path) -> list[Problem]:
-    data = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+def load_manifest(manifest_dir: pathlib.Path, benchmark_repo: pathlib.Path) -> list[Problem]:
+    """Load every `manifests/problems/<id>.toml` file as a `Problem`.
+
+    Files are walked in sorted filename order, which becomes `sort_index`.
+    """
     problems: list[Problem] = []
-    for index, raw in enumerate(data["problem"]):
+    for index, path in enumerate(sorted(manifest_dir.glob("*.toml"))):
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
         problem_id = str(raw["id"])
         holes = load_holes(benchmark_repo, problem_id)
         problems.append(
@@ -851,11 +855,11 @@ def main() -> int:
                 f"{hint}"
             )
 
-    manifest_path = benchmark_repo / "manifests" / "problems.toml"
-    if not manifest_path.is_file():
-        raise SystemExit(f"Benchmark manifest not found: {manifest_path}")
+    manifest_dir = benchmark_repo / "manifests" / "problems"
+    if not manifest_dir.is_dir():
+        raise SystemExit(f"Benchmark manifest directory not found: {manifest_dir}")
 
-    problems = load_manifest(manifest_path, benchmark_repo)
+    problems = load_manifest(manifest_dir, benchmark_repo)
     raw_results = load_results(results_root)
 
     write_json(output_dir / "problems.json", build_problem_payload(benchmark_repo, problems))


### PR DESCRIPTION
leanprover/lean-eval#317 splits the single `manifests/problems.toml`
into per-problem files at `manifests/problems/<id>.toml`. This PR
adapts the leaderboard's site-data generator to the new layout:

- **`scripts/generate_site_data.py::load_manifest`** now walks
  `manifests/problems/*.toml` in sorted filename order (which becomes
  `sort_index`), decoding each file as a single top-level entry.
  Previously it read the single old file's `[[problem]]` array.
- **`LeaderboardSite/Data.lean`** doc-comment updated to point at the
  new path on `Hole`.

This **must** merge at-or-shortly-after leanprover/lean-eval#317,
otherwise site-data generation breaks on the next leaderboard rebuild.

(Caught by a Codex review on the original doc-only version of this PR;
thanks to Codex for flagging the active script reference I missed.)

🤖 Prepared with Claude Code