### PR TITLE
fix(workflow): check out lean-eval-submissions in bump-benchmark-snapshot

### DIFF
--- a/.github/workflows/bump-benchmark-snapshot.yml
+++ b/.github/workflows/bump-benchmark-snapshot.yml
@@ -58,6 +58,21 @@ jobs:
           path: lean-eval-benchmark
           fetch-depth: 0
 
+      - name: Checkout the results store
+        # generate_site_data.py calls build_leaderboard_payload(), which
+        # needs `git rev-parse HEAD` of the results repo even when we are
+        # only regenerating the benchmark-snapshot tree. Previously this
+        # step was missing — the script crashed on a non-existent
+        # `lean-eval-submissions/` path the moment it got past the
+        # manifest-loading stage. Latent bug; surfaced when lean-eval#317
+        # split the manifest and the script started successfully reaching
+        # the leaderboard-payload step.
+        if: steps.target.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: leanprover/lean-eval-submissions
+          path: lean-eval-submissions
+
       - name: Set up elan
         if: steps.target.outputs.skip != 'true'
         shell: bash


### PR DESCRIPTION
`generate_site_data.py` calls `build_leaderboard_payload()`, which
needs `git rev-parse HEAD` of the results repo. The
`bump-benchmark-snapshot.yml` workflow never checked
`lean-eval-submissions` out, so the script crashed on a non-existent
`lean-eval-submissions/` path the moment it got past manifest
loading.

Latent bug — masked previously by the fact that the earlier failure
mode (`manifests/problems.toml not found` before #45) crashed first.
Surfaced now that #45's manifest-directory fix landed: the script
reaches the leaderboard-payload step and falls over on the missing
checkout.

Fix: add the standard `actions/checkout@v4` step for
`leanprover/lean-eval-submissions`, mirroring the same pattern
`deploy.yml` uses.

🤖 Prepared with Claude Code