### PR TITLE
fix(workflow): pass --results-repo to bump-benchmark-snapshot script

### DIFF
--- a/.github/workflows/bump-benchmark-snapshot.yml
+++ b/.github/workflows/bump-benchmark-snapshot.yml
@@ -83,7 +83,9 @@ jobs:
       - name: Regenerate benchmark-snapshot from target lean-eval
         if: steps.target.outputs.skip != 'true'
         run: |
-          python3 scripts/generate_site_data.py --benchmark-repo lean-eval-benchmark
+          python3 scripts/generate_site_data.py \
+            --benchmark-repo lean-eval-benchmark \
+            --results-repo lean-eval-submissions
 
       - name: Verify the new snapshot compiles
         # In-workflow `lake build` replaces the build-check we'd otherwise


### PR DESCRIPTION
Follow-up to #46. `generate_site_data.py` defaults
`DEFAULT_RESULTS_REPO` to a sibling-of-leaderboard path (`$REPO_ROOT.parent / 'lean-eval-submissions'`) that doesn't exist on the runner — `actions/checkout` placed the results repo INSIDE the leaderboard workspace at `./lean-eval-submissions`. `deploy.yml` passes `--results-repo` explicitly for this reason; the bump workflow was missing it.

Verified by tracing the failure of run 26399442700 (post-#46 admin-merge bump v3): script reached `build_leaderboard_payload` → tried to read default `$REPO_ROOT.parent / 'lean-eval-submissions'` → not found.

🤖 Prepared with Claude Code