### PR TITLE
doc: acknowledge AI tools in problem preparation

### DIFF
--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -244,6 +244,14 @@ def frontIntro : VersoDoc Page :=
   follow best practices in Lean. In particular, the only requirement for
   a solution to be accepted is that it is correct and passes the
   comparator tests.
+
+  I'd like to acknowledge the use of Aristotle, Claude Code, and Codex in
+  the preparation of many of the problems here. In particular I should
+  point out that Aristotle has a handicap on the leaderboard: typically,
+  if a single query to Aristotle could resolve a problem, I would deem it
+  too easy and drop it from consideration for the eval set. I think it's a
+  testament to the public service that Aristotle provides that this is
+  both possible, and useful!
   :::
   :::::
 


### PR DESCRIPTION
This PR adds a closing paragraph to the front-page intro acknowledging the use of Aristotle, Claude Code, and Codex in preparing many of the benchmark problems. It also records that Aristotle carries a handicap on the leaderboard — problems that a single Aristotle query could resolve are deemed too easy and dropped from the eval set — and notes that this is itself a testament to the service Aristotle provides.

The text sits at the end of `frontIntro` in `LeaderboardSite/Copy.lean`, inside the existing `wrap prose page-copy` block, so it renders below the leaderboard widget and intro prose rather than competing with them.

🤖 Prepared with Claude Code