### PR TITLE
fix: inline ChallengeDeps in multi-hole snapshot rendering

### DIFF
--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -421,9 +421,18 @@ def build_problem_fragment(problem: Problem, benchmark_repo: pathlib.Path) -> tu
         theorem_text = qualify_theorem_text("\n".join(challenge_body).strip(), hole.basename, local_declarations)
         body_parts.append(inject_legacy_theorem_anchor(problem, hole, theorem_text).strip())
     else:
-        # Multi-hole path: the entire source module is reproduced verbatim
-        # in Challenge.lean (with `@[eval_problem]` already stripped).
-        # Inject one anchor block per hole around its `body` substring.
+        # Multi-hole path: helper definitions are extracted into
+        # `ChallengeDeps.lean`, while `Challenge.lean` holds only the
+        # `@[eval_problem]` theorems. Inline the deps body first — both files
+        # reproduce the source module's namespace structure, so the helper
+        # defs and the theorems land in the same namespace and the theorems'
+        # references resolve. Without this the helper names are unbound
+        # (autobound to implicits) and the snapshot fails to compile. Then
+        # inject one anchor block per hole around its `body` substring in the
+        # challenge text.
+        if deps_path.is_file():
+            _, deps_body = strip_imports(deps_path.read_text(encoding="utf-8"))
+            body_parts.append("\n".join(deps_body).strip())
         text = "\n".join(challenge_body).strip()
         for hole in problem.holes:
             text = inject_multi_hole_anchor(problem, hole, text)


### PR DESCRIPTION
This PR fixes the benchmark-snapshot renderer so multi-hole problems compile. The multi-hole path in `generate_site_data.py` emitted only `Challenge.lean`'s body — the `@[eval_problem]` theorems — but not the helper definitions, which the current generator extracts into `ChallengeDeps.lean`. The theorems' references to those helpers were then unbound (autobound to implicits), so the generated `BenchmarkProblems/Problem<Name>.lean` failed to compile (`Function expected at`), which failed the entire `lake build BenchmarkProblems` in `bump-benchmark-snapshot.yml` and froze the live site on an old snapshot. Every multi-hole problem hit this, including the pre-existing `ProblemFamiliesOfMapsB01`, so the deploy had been red independently of any new problems.

The multi-hole path now inlines the `ChallengeDeps` body ahead of the challenge body, mirroring what the legacy single-theorem path already does. Both files reproduce the source module's namespace structure, so the helper defs and the theorems land in the same namespace and references resolve. I verified locally that the regenerated `ProblemFourierDirichletFejer`, `ProblemLpMaximumPrinciple`, and `ProblemFamiliesOfMapsB01` snapshot files compile against mathlib (only `sorry` warnings). Once this merges, the next snapshot advance should build and republish, bringing the recently-added problems (and `FamiliesOfMapsB01`) onto the leaderboard.

🤖 Prepared with Claude Code