### PR TITLE
fix: pin snapshot SubVerso revision

### DIFF
--- a/benchmark-snapshot/lakefile.toml
+++ b/benchmark-snapshot/lakefile.toml
@@ -9,7 +9,8 @@ rev = "5450b53e5ddc"
 [[require]]
 name = "subverso"
 git = "https://github.com/leanprover/subverso"
-rev = "main"
+# Must match the site-side SubVerso revision pulled in by Verso.
+rev = "ce893b9042128037e2d3c0158b9567fab9fae268"
 
 [[lean_lib]]
 name = "BenchmarkProblems"

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -29,6 +29,9 @@ DEFAULT_RESULTS_REPO = pathlib.Path(
     os.environ.get("LEAN_EVAL_RESULTS_REPO", str(REPO_ROOT.parent / "lean-eval-submissions"))
 )
 RESULTS_REPO_SLUG = "leanprover/lean-eval-submissions"
+# Keep the snapshot producer's highlighted JSON schema aligned with the
+# site-side SubVerso revision pulled in by the pinned Verso release.
+SNAPSHOT_SUBVERSO_REV = "ce893b9042128037e2d3c0158b9567fab9fae268"
 # Path to the SHA pin file the deploy workflow already uses to know
 # which lean-eval commit benchmark-snapshot/ was built from. Single
 # line, 40 hex chars + trailing newline. Bumping this file is the
@@ -176,7 +179,7 @@ def benchmark_snapshot_lakefile(benchmark_repo: pathlib.Path) -> str:
             "[[require]]",
             'name = "subverso"',
             'git = "https://github.com/leanprover/subverso"',
-            'rev = "main"',
+            f'rev = "{SNAPSHOT_SUBVERSO_REV}"',
             "",
             "[[lean_lib]]",
             'name = "BenchmarkProblems"',

--- a/templates/benchmark-snapshot/lakefile.toml
+++ b/templates/benchmark-snapshot/lakefile.toml
@@ -9,7 +9,8 @@ rev = "v4.30.0-rc2"
 [[require]]
 name = "subverso"
 git = "https://github.com/leanprover/subverso"
-rev = "main"
+# Must match the site-side SubVerso revision pulled in by Verso.
+rev = "ce893b9042128037e2d3c0158b9567fab9fae268"
 
 [[lean_lib]]
 name = "BenchmarkProblems"


### PR DESCRIPTION
## Summary

The deploy workflow builds highlighted benchmark-snapshot artifacts and then the site reads those artifacts while elaborating `LeaderboardSite.AnchorRegistry`.

`benchmark-snapshot` was tracking `subverso`'s moving `main`, while the site-side decoder comes from the SubVerso revision pulled in by the pinned Verso release. After SubVerso added new token constructors, the snapshot producer emitted highlighted JSON that the site-side decoder could not deserialize.

This pins the snapshot producer to the same SubVerso revision currently pulled in by the site-side Verso dependency, and updates the snapshot generator/template so future snapshot bumps preserve the pin.

## Verification

- `uv run --python 3.12 python scripts/generate_site_data.py --no-write-snapshot --benchmark-repo ../lean-eval --results-repo ../lean-eval-submissions`
- Generated 153 highlighted JSON artifacts with the pinned snapshot SubVerso revision during a local deploy-shaped build attempt.
- `find benchmark-snapshot/.lake/build/highlighted/BenchmarkProblems -maxdepth 1 -name '*.json' -print0 | xargs -0 -n 16 jq empty`
- Confirmed the generated highlighted JSON no longer contains the newer token constructors (`delim`, `wildcard`, `num`, `char`, `lineComment`, `blockComment`, `commentDelim`, `operator`, `bracket`, `separator`) that the site-side decoder does not know about.

I did not finish a full local site build because `LeaderboardSite.AnchorRegistry` lingered for a long time on this machine; CI should exercise the full deploy path.
