### PR TITLE
fix: derive snapshot SubVerso pin from Verso, guard against drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,23 @@ jobs:
           set -euo pipefail
           cd benchmark-snapshot
           lake update
+          # Fail fast if the snapshot producer and the site decoder resolved
+          # different SubVerso revisions. Otherwise the highlighted JSON this
+          # step emits fails to deserialize later in
+          # LeaderboardSite.AnchorRegistry with a cryptic
+          # "no inductive constructor matched". The snapshot's SubVerso pin is
+          # derived from the site's Verso pin in scripts/generate_site_data.py;
+          # this guard catches a Verso bump that landed without re-pinning the
+          # snapshot. The site manifest is one level up.
+          site_subverso=$(jq -r '.packages[] | select(.name == "subverso") | .rev' ../lake-manifest.json)
+          snap_subverso=$(jq -r '.packages[] | select(.name == "subverso") | .rev' lake-manifest.json)
+          if [ "$site_subverso" != "$snap_subverso" ]; then
+            echo "::error::SubVerso revision mismatch between the site decoder and the snapshot producer."
+            echo "  site (LeaderboardSite, via Verso): ${site_subverso:-<none>}"
+            echo "  snapshot (benchmark-snapshot):     ${snap_subverso:-<none>}"
+            echo "Re-run the 'Advance benchmark-snapshot' workflow to re-pin and rebuild the snapshot."
+            exit 1
+          fi
           highlighted_targets=$(
             find BenchmarkProblems -maxdepth 1 -name 'Problem*.lean' -print \
               | sed 's|^BenchmarkProblems/||;s|\.lean$||' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,12 @@ jobs:
           # snapshot. The site manifest is one level up.
           site_subverso=$(jq -r '.packages[] | select(.name == "subverso") | .rev' ../lake-manifest.json)
           snap_subverso=$(jq -r '.packages[] | select(.name == "subverso") | .rev' lake-manifest.json)
+          if [ -z "$site_subverso" ] || [ -z "$snap_subverso" ]; then
+            echo "::error::Could not read a resolved SubVerso revision from a Lake manifest."
+            echo "  site (../lake-manifest.json):  ${site_subverso:-<none>}"
+            echo "  snapshot (lake-manifest.json): ${snap_subverso:-<none>}"
+            exit 1
+          fi
           if [ "$site_subverso" != "$snap_subverso" ]; then
             echo "::error::SubVerso revision mismatch between the site decoder and the snapshot producer."
             echo "  site (LeaderboardSite, via Verso): ${site_subverso:-<none>}"

--- a/benchmark-snapshot/lakefile.toml
+++ b/benchmark-snapshot/lakefile.toml
@@ -9,7 +9,9 @@ rev = "5450b53e5ddc"
 [[require]]
 name = "subverso"
 git = "https://github.com/leanprover/subverso"
-# Must match the site-side SubVerso revision pulled in by Verso.
+# Pinned to the SubVerso revision Verso pulls into LeaderboardSite, so the
+# highlighted JSON this snapshot emits stays decodable by the site. Derived
+# from the site lakefile's Verso pin by scripts/generate_site_data.py.
 rev = "ce893b9042128037e2d3c0158b9567fab9fae268"
 
 [[lean_lib]]

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -10,7 +10,6 @@ import shutil
 import subprocess
 import sys
 import tomllib
-import urllib.error
 import urllib.request
 from collections import defaultdict
 from dataclasses import dataclass
@@ -191,9 +190,9 @@ def consumer_subverso_rev() -> str:
     slug = re.sub(r"\.git$", "", verso_git).rstrip("/").removeprefix("https://github.com/")
     url = f"https://raw.githubusercontent.com/{slug}/{verso_rev}/lake-manifest.json"
     try:
-        with urllib.request.urlopen(url) as response:
+        with urllib.request.urlopen(url, timeout=30) as response:
             manifest = json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise SystemExit(f"Could not fetch Verso's lake-manifest from {url}: {exc}")
     for pkg in manifest.get("packages", []):
         if pkg.get("name") == "subverso":

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -10,6 +10,8 @@ import shutil
 import subprocess
 import sys
 import tomllib
+import urllib.error
+import urllib.request
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -29,9 +31,6 @@ DEFAULT_RESULTS_REPO = pathlib.Path(
     os.environ.get("LEAN_EVAL_RESULTS_REPO", str(REPO_ROOT.parent / "lean-eval-submissions"))
 )
 RESULTS_REPO_SLUG = "leanprover/lean-eval-submissions"
-# Keep the snapshot producer's highlighted JSON schema aligned with the
-# site-side SubVerso revision pulled in by the pinned Verso release.
-SNAPSHOT_SUBVERSO_REV = "ce893b9042128037e2d3c0158b9567fab9fae268"
 # Path to the SHA pin file the deploy workflow already uses to know
 # which lean-eval commit benchmark-snapshot/ was built from. Single
 # line, 40 hex chars + trailing newline. Bumping this file is the
@@ -164,8 +163,50 @@ def benchmark_mathlib_require(benchmark_repo: pathlib.Path) -> tuple[str, str]:
     raise SystemExit(f"Could not find mathlib requirement in {lakefile}")
 
 
+# `require verso from git "<url>" @ "<rev>"` in the site lakefile. The site
+# decodes the snapshot's highlighted JSON with the SubVerso that this Verso
+# pulls in, so the Verso revision is the source of truth for the snapshot pin.
+VERSO_REQUIRE_RE = re.compile(
+    r'require\s+verso\s+from\s+git\s+"(?P<git>[^"]+)"\s*@\s*"(?P<rev>[^"]+)"'
+)
+
+
+def site_verso_require() -> tuple[str, str]:
+    lakefile = REPO_ROOT / "lakefile.lean"
+    match = VERSO_REQUIRE_RE.search(lakefile.read_text(encoding="utf-8"))
+    if not match:
+        raise SystemExit(f"Could not find a `require verso` line in {lakefile}")
+    return match.group("git"), match.group("rev")
+
+
+def consumer_subverso_rev() -> str:
+    """The SubVerso revision LeaderboardSite decodes highlighted JSON with.
+
+    It is whatever Verso (pinned in the site lakefile) pins SubVerso to in its
+    own lake-manifest, fetched straight from GitHub so this works without a
+    resolved Lake workspace — the bump workflow regenerates the snapshot
+    without ever running the site's `lake update`.
+    """
+    verso_git, verso_rev = site_verso_require()
+    slug = re.sub(r"\.git$", "", verso_git).rstrip("/").removeprefix("https://github.com/")
+    url = f"https://raw.githubusercontent.com/{slug}/{verso_rev}/lake-manifest.json"
+    try:
+        with urllib.request.urlopen(url) as response:
+            manifest = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"Could not fetch Verso's lake-manifest from {url}: {exc}")
+    for pkg in manifest.get("packages", []):
+        if pkg.get("name") == "subverso":
+            rev = str(pkg.get("rev", "")).strip()
+            if SHA_RE.fullmatch(rev):
+                return rev
+            raise SystemExit(f"Verso manifest at {url} has a non-SHA subverso rev: {rev!r}")
+    raise SystemExit(f"No subverso package in Verso's lake-manifest at {url}")
+
+
 def benchmark_snapshot_lakefile(benchmark_repo: pathlib.Path) -> str:
     mathlib_git, mathlib_rev = benchmark_mathlib_require(benchmark_repo)
+    subverso_rev = consumer_subverso_rev()
     return "\n".join(
         [
             'name = "benchmark-snapshot"',
@@ -179,7 +220,10 @@ def benchmark_snapshot_lakefile(benchmark_repo: pathlib.Path) -> str:
             "[[require]]",
             'name = "subverso"',
             'git = "https://github.com/leanprover/subverso"',
-            f'rev = "{SNAPSHOT_SUBVERSO_REV}"',
+            "# Pinned to the SubVerso revision Verso pulls into LeaderboardSite, so the",
+            "# highlighted JSON this snapshot emits stays decodable by the site. Derived",
+            "# from the site lakefile's Verso pin by scripts/generate_site_data.py.",
+            f'rev = "{subverso_rev}"',
             "",
             "[[lean_lib]]",
             'name = "BenchmarkProblems"',

--- a/templates/benchmark-snapshot/lakefile.toml
+++ b/templates/benchmark-snapshot/lakefile.toml
@@ -9,8 +9,10 @@ rev = "v4.30.0-rc2"
 [[require]]
 name = "subverso"
 git = "https://github.com/leanprover/subverso"
-# Must match the site-side SubVerso revision pulled in by Verso.
-rev = "ce893b9042128037e2d3c0158b9567fab9fae268"
+# Reference only: scripts/generate_site_data.py writes benchmark-snapshot/
+# lakefile.toml directly and replaces this with the SubVerso revision Verso
+# pulls into LeaderboardSite, so the snapshot stays decodable by the site.
+rev = "main"
 
 [[lean_lib]]
 name = "BenchmarkProblems"


### PR DESCRIPTION
This PR derives benchmark-snapshot's SubVerso revision from the site's Verso pin rather than hard-coding it, and fails the deploy loudly if the snapshot producer and the site decoder ever resolve different SubVerso revisions.

The snapshot producer emits highlighted JSON that `LeaderboardSite.AnchorRegistry` decodes with the SubVerso that Verso pulls in. When those two SubVerso revisions drift, decoding dies with a cryptic `SubVerso.Highlighting.Token.kind: no inductive constructor matched` — which is exactly what took the leaderboard deploy down from 3 June. https://github.com/leanprover/lean-eval-leaderboard/pull/54 pinned the producer by hand to the revision Verso currently resolves; this follow-up reads that revision straight from Verso's `lake-manifest.json` at the pinned Verso rev in `scripts/generate_site_data.py` (the single point that writes the snapshot lakefile, used by the bump workflow), so a Verso bump can no longer silently desync the two. It also adds a fast pre-build check in `deploy.yml` that compares the resolved SubVerso revisions across the two Lake workspaces and, on mismatch, errors with a clear message before the unreadable deserialize wall.

The derived revision and the regenerated `benchmark-snapshot/lakefile.toml` are byte-identical to what #54 pinned, so this is behaviour-preserving today and drift-proof going forward.

🤖 Prepared with Claude Code