### PR TITLE
fix: stop rendering public proof links on the leaderboard

### DIFF
--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -129,7 +129,6 @@ def coverageCellAria (title : String) (solved : Bool) : String :=
 
 /-! ## Problem chips / theorem cards -/
 
-def proofWord                   : String := "proof"
 def howProducedSummary          : String := "How produced"
 def theoremStatementUnavailable : String := "Theorem statement unavailable."
 def versoTheoremPreviewLabel    : String := "Verso theorem preview"

--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -166,29 +166,20 @@ private def theoremCard
 
 /-- Render a single problem chip with a hover-popover theorem card.
 `title` is the human-readable problem title; `statement` is the Lean
-theorem text shown in the static-fallback popover. `proofUrl?`, when
-set, adds a public proof link next to the chip. The `anchorMap` carries
-pre-rendered Verso theorem blocks keyed by problem id. -/
+theorem text shown in the static-fallback popover. The `anchorMap` carries
+pre-rendered Verso theorem blocks keyed by problem id.
+
+Public proof links are intentionally not rendered here; the underlying
+`public_solution` data still lives in `leaderboard.json`. -/
 private def problemItem
     (anchorMap : Std.HashMap String (Array (Block Page)))
     (problemId : String) (title : String) (statement : String)
-    (proofUrl? : Option String)
     (rarityRank? : Option Nat)
     (productionDescription? : Option String) : Block Page :=
   let problemHref := s!"problems/{problemId}/"
   let titleLink := htmlBlobBlock {{
     <a class="problem-title-link" href={{problemHref}}>{{textHtml title}}</a>
   }}
-  let proofLink := match proofUrl? with
-    | some url => htmlBlobBlock {{
-        <a class="problem-proof-link" href={{url}}>
-          <span>{{textHtml proofWord}}</span>
-          <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <path d="M9 1v1.5h3.44L6.97 7.97l1.06 1.06L13.5 3.56V7H15V1H9zM2 3v11h11V8.5h-1.5V12.5h-8v-8H6.5V3H2z"/>
-          </svg>
-        </a>
-      }}
-    | none => htmlBlobBlock {{ <span></span> }}
   let rarityChip := match rarityRank? with
     | some r => htmlBlobBlock {{
         <span class="problem-meta">{{textHtml s!"#{r}"}}</span>
@@ -220,8 +211,7 @@ private def problemItem
         }},
         theoremCard anchorMap problemId statement
       ],
-      rarityChip,
-      proofLink
+      rarityChip
     ],
     productionNote
   ]
@@ -261,8 +251,7 @@ private def entryBody
   let isTest := fun (pid : String) => kindMap.getD pid false
   let renderItem (item : SolvedProblem) : Block Page :=
     let (title, statement) := problemTitleAndStatement problems item.problemId
-    let proofUrl? := if item.publicSolution.available then item.publicSolution.url else none
-    problemItem anchorMap item.problemId title statement proofUrl? (some item.rarityRank)
+    problemItem anchorMap item.problemId title statement (some item.rarityRank)
       item.productionDescription
   let renderSection (label : String) (items : Array SolvedProblem) : Array (Block Page) :=
     if items.isEmpty then #[] else
@@ -342,7 +331,7 @@ private def emptyShowcase
     (anchorMap : Std.HashMap String (Array (Block Page)))
     (preview : Array (String × String × String)) : Block Page :=
   let previewItems : Array (Block Page) := preview.map fun (id, title, statement) =>
-    problemItem anchorMap id title statement none none none
+    problemItem anchorMap id title statement none none
   divBlock "empty-showcase" #[
     divBlock "empty-copy" #[
       sectionLabel emptyShowcaseLabel,

--- a/LeaderboardSite/Pages/ProblemDetail.lean
+++ b/LeaderboardSite/Pages/ProblemDetail.lean
@@ -64,7 +64,6 @@ structure SolverRecord where
   user : String
   modelName : String
   solvedAt : String
-  publicSolutionUrl : Option String
 deriving Quote, Inhabited, Repr
 
 /-- Collect all solves of `problemId`, one row per (model, submitter), sorted
@@ -78,22 +77,18 @@ def solversFor (entries : Array LeaderboardEntry) (problemId : String) : Array S
           user := sp.provenance.user
           modelName := entry.modelName
           solvedAt := sp.solvedAt
-          publicSolutionUrl := sp.publicSolution.url
         }
       else none
   rows.qsort (fun a b => a.solvedAt < b.solvedAt)
 
+-- Public proof links are intentionally not rendered here; the underlying
+-- `public_solution` data still lives in `leaderboard.json`.
 private def solverParagraph (s : SolverRecord) : Block Page :=
-  let baseInlines : Array (Inline Page) := #[
+  paragraph #[
     textInline "• ",
     linkInline s!"@{s.user}" s!"https://github.com/{s.user}",
     textInline (solverWithModelOnDate s.modelName (formatDate s.solvedAt))
   ]
-  let inlines := match s.publicSolutionUrl with
-    | some url =>
-      baseInlines ++ #[textInline " (", linkInline proofWord url, textInline ")"]
-    | none => baseInlines
-  paragraph inlines
 
 private def solversSection (solvers : Array SolverRecord) : Array (Block Page) :=
   if solvers.isEmpty then

--- a/static/style.css
+++ b/static/style.css
@@ -836,8 +836,7 @@ nav.top .home { display: none; }
   display: inline-flex;
 }
 
-.problem-id-trigger,
-.problem-proof-link {
+.problem-id-trigger {
   display: inline-flex;
   align-items: center;
   min-height: 28px;
@@ -855,24 +854,12 @@ nav.top .home { display: none; }
     color var(--transition-fast);
 }
 
-.dark-theme .problem-id-trigger,
-.dark-theme .problem-proof-link {
+.dark-theme .problem-id-trigger {
   background: rgba(59, 148, 255, 0.10);
   border-color: rgba(59, 148, 255, 0.28);
 }
 
 .problem-id-trigger { cursor: default; }
-
-.problem-proof-link:hover {
-  color: var(--color-text-contrast);
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-}
-
-.problem-proof-link:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
 
 /* Theorem-statement popover, anchored to the problem-id pill */
 .theorem-card {


### PR DESCRIPTION
This PR removes the public proof hyperlinks from the rendered leaderboard HTML, on both the main leaderboard (the per-problem chips) and the per-problem detail pages (the "Solved by" list), and deletes the now-dead rendering support that fed them: the `proofUrl?` parameter and proof-link markup in `problemItem`, the `SolverRecord.publicSolutionUrl` field, the `proofWord` copy string, and the `.problem-proof-link` CSS.

The underlying `public_solution` data is still generated into `leaderboard.json` and carried through `SolvedProblem.publicSolution`, so it remains available to other tooling and the links can be restored later by reintroducing the renderer rather than by an accidental argument change.

🤖 Prepared with Claude Code