### PR TITLE
chore: update submission URL

### DIFF
--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -331,7 +331,7 @@ def submitStep3HtmlId : String := "step-3"
 def submitStep3Body : VersoDoc Page :=
   verso (Page) "submitStep3"
   :::
-  Click [Submit benchmark solution](https://github.com/leanprover/lean-eval/issues/new?template=submit.yml)
+  Click [Submit benchmark solution](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
   to open a pre-filled issue. The form asks for two things:
 
   - a submission URL in one of the shapes above


### PR DESCRIPTION
https://lean-lang.org/eval/submit/ points to this deprecation notice:

<img width="1050" height="708" alt="image" src="https://github.com/user-attachments/assets/dd031d78-f73e-45ce-b430-b2e574c21ab6" />



It should point to this page instead:

<img width="1051" height="878" alt="image" src="https://github.com/user-attachments/assets/70b0c016-57e5-4472-ae5d-faa2283a0116" />
