### PR TITLE
Avoid recursion overflow in leaderboard anchor map

### DIFF
--- a/LeaderboardSite/Leaderboard.lean
+++ b/LeaderboardSite/Leaderboard.lean
@@ -483,6 +483,17 @@ sections. Used from `Front.lean` via the `leaderboard%` syntax. -/
 
 scoped syntax "leaderboard%" : term
 
+/-- Build the anchor lookup at runtime from a flat array of bindings.
+
+Keeping the generated term flat matters here: emitting one nested `.insert`
+per notable problem makes elaboration depth grow linearly as the catalog
+grows, eventually exhausting Lean's default recursion budget. -/
+def anchorMapFromBindings
+    (bindings : Array (String × Array (Block Page))) :
+    Std.HashMap String (Array (Block Page)) :=
+  bindings.foldl (init := {}) fun acc (problemId, anchors) =>
+    acc.insert problemId anchors
+
 /-- Build a syntax tree for an `Std.HashMap String (Array (Block Page))`
 whose keys are problem ids and whose values are the spliced per-hole
 anchor terms. -/
@@ -490,9 +501,11 @@ private def anchorMapTerm
     (problems : Array ProblemEntry)
     (neededIds : Array String) : TermElabM (TSyntax `term) := do
   let needed := problems.filter fun p => neededIds.contains p.id
-  needed.foldlM (init := ← `((∅ : Std.HashMap String (Array (Block Page))))) fun acc p => do
+  let bindings ← needed.mapM fun p => do
     let anchorsArr : TSyntaxArray `term := anchorBlockTerms p
-    `(($acc).insert $(quote p.id) #[$anchorsArr,*])
+    `(($(quote p.id), #[$anchorsArr,*]))
+  let bindings : TSyntaxArray `term := bindings
+  `(LeaderboardSite.Leaderboard.anchorMapFromBindings #[$bindings,*])
 
 elab_rules : term
   | `(leaderboard%) => do


### PR DESCRIPTION
Fixes the deterministic maximum-recursion-depth failure in the Build site step of Deploy GitHub Pages run https://github.com/leanprover/lean-eval-leaderboard/actions/runs/30838325044.

The leaderboard term elaborator currently emits one nested HashMap insertion per notable problem. With the current generated dataset (118 distinct notable problem IDs), that expression crosses Lean's default elaboration recursion budget. This change emits a flat array of bindings and builds the map with a runtime fold, preserving catalog order and later-insertion semantics without increasing any recursion option.

Validated against the exact current data (52 model entries, 1,036 solves, 118 notable IDs):

- lake build LeaderboardSite.AnchorRegistry: 121/121 jobs passed
- lake build LeaderboardSite.Pages.Front: 124/124 jobs passed
- lake exe lean-eval-leaderboard --output _site: passed
- scripts/check_links.py: 8,488 links across 240 pages passed
- Generated furstenberg_measure page lists @Vilin97 with gpt-5.6-Sol

This unblocks publication of the already accepted Furstenberg-measure result from https://github.com/leanprover/lean-eval-submissions/issues/929.