### PR TITLE
fix: raise maxRecDepth for the leaderboard front page

### DIFF
--- a/LeaderboardSite/Pages/Front.lean
+++ b/LeaderboardSite/Pages/Front.lean
@@ -5,6 +5,14 @@ import LeaderboardSite.Copy
 set_option verso.exampleProject "benchmark-snapshot"
 set_option maxHeartbeats 1000000
 
+-- `leaderboard%` expands to one binding per notable problem, so elaboration
+-- depth grows with the catalog. Flattening the anchor map (#59) cut the cost
+-- per binding by about 4x, but the growth is still linear and the default
+-- budget of 512 was already exhausted once, at 118 notable problems, which
+-- broke the published site for two days. Raise the ceiling so the next
+-- threshold is far beyond any plausible catalog size.
+set_option maxRecDepth 4000
+
 open Lean
 open Verso Doc
 open Verso.Genre.Blog


### PR DESCRIPTION
This PR raises `maxRecDepth` to 4000 for `LeaderboardSite/Pages/Front.lean`, so that catalog growth cannot exhaust the elaborator's recursion budget again. The `leaderboard%` elaborator emits one binding per notable problem, so elaboration depth grows linearly with the catalog. https://github.com/leanprover/lean-eval-leaderboard/pull/59 ("Avoid recursion overflow in leaderboard anchor map") reduced the cost per binding by roughly 4x, but the growth is still linear, and the default budget of 512 had already been exhausted once at 118 notable problems, breaking every Deploy GitHub Pages run for two days before it was diagnosed.

Measured on v4.30.0-rc2 at the default budget, in a minimal model of the two encodings, the nested-insert form failed at 252 bindings and the flattened form at 994. Scaling by the point at which the real page actually broke puts the post-#59 ceiling somewhere near 450 to 470 notable problems, against 118 today. That is comfortable but finite, and the only warning signal is the published site going stale.

`benchmark-snapshot/BenchmarkProblems/ProblemConwayKnotTopologicallySlice.lean` and `ProblemConwayKnotNotSmoothlySlice.lean` already use `set_option maxRecDepth 10000`, so 4000 is well within existing practice for this repository.

🤖 Prepared with Claude Code