### PR TITLE
fix: stop Pages deploys and PR validations cancelling each other

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,15 @@ permissions:
   pages: write
   id-token: write
 
+# PR validation builds are disposable, so they get a per-PR group and
+# supersede each other freely. Everything that can publish shares the single
+# `github-pages` group and is never cancelled: a cancelled deploy is a lost
+# publication, and GitHub does not retry it. Superseding only establishes that
+# the newer build carries the same data, not that it succeeds, so cancelling a
+# running deploy in favour of one that then fails leaves nothing published.
 concurrency:
-  group: github-pages
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('pages-pr-{0}', github.event.pull_request.number) || 'github-pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -157,15 +163,17 @@ jobs:
         run: |
           python3 scripts/check_links.py --site-dir _site --prefix lean-eval-leaderboard
 
+      # Publish only from `main`. A positive ref check rather than "not a PR",
+      # so a `workflow_dispatch` aimed at a feature branch cannot publish it.
       - name: Upload Pages artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main'
         # actions/upload-pages-artifact pinned to fc324d35 (= refs/tags/v5.0.0 as of 2026-08-06).
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: _site
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This PR splits the Pages workflow's concurrency so that publishing runs and pull request validations no longer evict one another, and stops cancelling anything that can publish. Every event previously shared the `github-pages` group with `cancel-in-progress: true`, so any run cancelled any other. Both directions were observed within one day: a main deploy cancelled a PR validation at 6m51s, and then a PR validation cancelled the main deploy for https://github.com/leanprover/lean-eval-leaderboard/pull/60 ("fix: raise maxRecDepth for the leaderboard front page") at 13m06s.

A cancelled deploy is a lost publication. GitHub does not retry it, and the run reports "cancelled" rather than failing, so no notification fires. Superseding establishes only that a newer build carries the same data, not that it succeeds: if the run that did the cancelling then fails at checkout, `lake update`, the build, artifact upload, or the Pages deployment itself, nothing is published. `actions/deploy-pages@v4` also installs signal handlers and calls the Pages cancellation endpoint for its outstanding deployment, so cancellation partway through publishing is not merely a status change. This site went stale for two days before anyone noticed, which is exactly the outcome silent non-publication produces.

PR builds upload no artifact and are disposable, so they get a per-PR group and continue to supersede each other. Everything that can publish stays on the single `github-pages` group and is never cancelled, matching GitHub's guidance of letting an in-flight Pages deployment finish.

Publishing is now also gated on a positive `github.ref == 'refs/heads/main'` check rather than "not a pull request". A `workflow_dispatch` can select any branch or tag, so the old condition allowed a manual run from a feature branch to publish that branch.

Note that a `workflow_dispatch` from a branch predating this change still runs that branch's copy of the workflow, so it can still cancel a main deploy. Restricting the `github-pages` environment to `main` in repository settings closes that remaining path, and is worth doing alongside this.

Reviewed with a second opinion from Codex, which caught that an earlier version of this fix isolated PR runs but left publishing runs cancelling each other, the more damaging half of the problem.

🤖 Prepared with Claude Code