### PR TITLE
Fix Annals benchmark snapshot context

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,9 @@ jobs:
         # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-08-06).
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      - name: Test snapshot generator
+        run: python3 -m unittest discover -s tests
+
       - name: Checkout benchmark repo at the snapshot's pinned commit
         # site-data/leaderboard.json is regenerated each deploy from the
         # results store. The generator needs the benchmark repo for problem

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -38,6 +38,12 @@ RESULTS_REPO_SLUG = "leanprover/lean-eval-submissions"
 # dependencies" for the procedure.
 BENCHMARK_COMMIT_FILE = REPO_ROOT / "benchmark-snapshot" / ".benchmark-commit"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+ROOT_DECLARATIONS_BY_PROBLEM = {
+    "annals_dirichlet_weyl_bound": {"Nat.IsCubeFree"},
+}
+ANNALS_PROBABILITY_NOTATION_IMPORT = (
+    "import LeanEval.Analysis.AnnalsProbabilityNotation"
+)
 
 
 @dataclass(frozen=True)
@@ -494,6 +500,88 @@ def snapshot_module_name(problem: Problem) -> str:
     return f"BenchmarkProblems.{snapshot_namespace(problem)}"
 
 
+def dedupe_universe_declarations(fragments: list[str]) -> list[str]:
+    """Remove repeated universe names when generated modules are inlined.
+
+    `ChallengeDeps.lean` and `Challenge.lean` are separate Lean modules and may
+    legitimately repeat `universe u`. A snapshot file concatenates their bodies,
+    where redeclaring the same universe name is an error. Preserve declaration
+    order while emitting each name only once.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for fragment in fragments:
+        lines: list[str] = []
+        for line in fragment.splitlines():
+            code, separator, comment = line.partition("--")
+            stripped = code.strip()
+            if not stripped.startswith("universe "):
+                lines.append(line)
+                continue
+            names = stripped.removeprefix("universe ").split()
+            fresh = [name for name in names if name not in seen]
+            seen.update(names)
+            if fresh:
+                indent = code[:len(code) - len(code.lstrip())]
+                rebuilt = indent + "universe " + " ".join(fresh)
+                if separator:
+                    rebuilt += " " + separator + comment
+                lines.append(rebuilt)
+            elif separator and comment.strip():
+                indent = code[:len(code) - len(code.lstrip())]
+                lines.append(indent + separator + comment)
+        result.append("\n".join(lines))
+    return result
+
+
+def preserve_root_declarations(fragment: str, names: set[str]) -> str:
+    """Keep selected dotted declaration names rooted inside a wrapper.
+
+    A declaration such as `def Nat.IsCubeFree` intentionally extends an existing
+    root namespace. Snapshot packaging adds a per-problem namespace for isolation;
+    without `_root_.`, Lean instead creates `Problem<Id>.Nat.IsCubeFree`. The
+    allowlist is explicit because other dotted declarations intentionally refer
+    to namespaces created inside the per-problem wrapper.
+    """
+    declaration = re.compile(
+        r"(?m)^(?P<prefix>\s*(?:(?:noncomputable|protected|private)\s+)*"
+        r"(?:abbrev|class|def|inductive|lemma|structure|theorem)\s+)"
+        r"(?P<name>(?!_root_\.)[^\s({\[]+\.[^\s({\[]+)"
+    )
+
+    def replace(match: re.Match[str]) -> str:
+        name = match.group("name")
+        if name not in names:
+            return match.group(0)
+        return match.group("prefix") + "_root_." + name
+
+    return declaration.sub(replace, fragment)
+
+
+def qualify_probability_root_opens(fragment: str) -> str:
+    """Disambiguate Mathlib's root probability namespace under isolation.
+
+    Annals' shared probability-notation helper introduces a sibling
+    `ProbabilityTheory` namespace inside the per-problem wrapper. The problem
+    source also opens Mathlib's root namespace for definitions such as
+    `bernoulliMeasure`; make that open explicit while leaving the isolated
+    notation namespace in place.
+    """
+    lines: list[str] = []
+    for line in fragment.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("open ") and not stripped.startswith("open scoped "):
+            code, separator, comment = line.partition("--")
+            code = re.sub(
+                r"(?<![\w.])ProbabilityTheory(?![\w.])",
+                "_root_.ProbabilityTheory",
+                code,
+            )
+            line = code + separator + comment
+        lines.append(line)
+    return "\n".join(lines)
+
+
 def write_benchmark_snapshot(benchmark_repo: pathlib.Path, problems: list[Problem]) -> None:
     if BENCHMARK_SNAPSHOT_ROOT.exists():
         shutil.rmtree(BENCHMARK_SNAPSHOT_ROOT)
@@ -515,9 +603,22 @@ def write_benchmark_snapshot(benchmark_repo: pathlib.Path, problems: list[Proble
     umbrella_imports: list[str] = []
     for problem in sorted_problems:
         imports, fragments = build_problem_fragment(problem, benchmark_repo)
+        fragments = dedupe_universe_declarations(fragments)
         namespace = snapshot_namespace(problem)
         body_lines: list[str] = []
         if is_legacy_single_theorem(problem):
+            root_declarations = ROOT_DECLARATIONS_BY_PROBLEM.get(problem.id, set())
+            fragments = [
+                preserve_root_declarations(fragment, root_declarations)
+                for fragment in fragments
+            ]
+            source_imports, _ = strip_imports(
+                (benchmark_repo / module_to_source_path(problem.module)).read_text(
+                    encoding="utf-8"
+                )
+            )
+            if ANNALS_PROBABILITY_NOTATION_IMPORT in source_imports:
+                fragments = [qualify_probability_root_opens(fragment) for fragment in fragments]
             # Legacy single-theorem problems wrap their helpers and
             # theorem in a per-problem `Problem<CamelId>` namespace so
             # any short helper names from `ChallengeDeps` don't collide

--- a/tests/test_generate_site_data.py
+++ b/tests/test_generate_site_data.py
@@ -1,0 +1,67 @@
+import unittest
+
+from scripts.generate_site_data import (
+    dedupe_universe_declarations,
+    preserve_root_declarations,
+    qualify_probability_root_opens,
+)
+
+
+class SnapshotContextTests(unittest.TestCase):
+    def test_deduplicates_universes_across_inlined_modules(self) -> None:
+        fragments = [
+            "universe u v\ndef first := 1",
+            "universe u w -- shared context\nuniverse v -- keep this comment",
+        ]
+
+        self.assertEqual(
+            dedupe_universe_declarations(fragments),
+            [
+                "universe u v\ndef first := 1",
+                "universe w -- shared context\n-- keep this comment",
+            ],
+        )
+
+    def test_roots_only_explicitly_selected_dotted_declarations(self) -> None:
+        fragment = "\n".join(
+            [
+                "def Nat.IsCubeFree (n : Nat) : Prop := True",
+                "noncomputable def Local.helper : Nat := 1",
+                "def _root_.Nat.AlreadyRooted : Nat := 2",
+            ]
+        )
+
+        self.assertEqual(
+            preserve_root_declarations(fragment, {"Nat.IsCubeFree"}),
+            "\n".join(
+                [
+                    "def _root_.Nat.IsCubeFree (n : Nat) : Prop := True",
+                    "noncomputable def Local.helper : Nat := 1",
+                    "def _root_.Nat.AlreadyRooted : Nat := 2",
+                ]
+            ),
+        )
+
+    def test_qualifies_only_ordinary_probability_opens(self) -> None:
+        fragment = "\n".join(
+            [
+                "  open  ProbabilityTheory MeasureTheory -- needed for measures",
+                "open scoped ProbabilityTheory",
+                "namespace ProbabilityTheory",
+            ]
+        )
+
+        self.assertEqual(
+            qualify_probability_root_opens(fragment),
+            "\n".join(
+                [
+                    "  open  _root_.ProbabilityTheory MeasureTheory -- needed for measures",
+                    "open scoped ProbabilityTheory",
+                    "namespace ProbabilityTheory",
+                ]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- deduplicate repeated `universe` declarations when `ChallengeDeps.lean` and `Challenge.lean` are inlined into one snapshot module
- preserve the root `Nat.IsCubeFree` extension and Mathlib's root `ProbabilityTheory` open inside per-problem isolation namespaces
- add regression tests and run them in the deploy workflow

This fixes the snapshot compile failure that prevented the 50 Annals problems from advancing to the leaderboard after leanprover/lean-eval#535 repaired long-running regeneration pushes.

## Verification

- `python3 -m unittest discover -s tests -v`
- regenerated the snapshot from leanprover/lean-eval `7699436464052268e6c04b41554bfbc2c6908ec5`
- confirmed exactly 50 `ProblemAnnals*.lean` modules
- `lake build BenchmarkProblems` — 9,005 jobs, successful
