### PR TITLE
Retry transient snapshot network fetches

### DIFF
--- a/.github/workflows/bump-benchmark-snapshot.yml
+++ b/.github/workflows/bump-benchmark-snapshot.yml
@@ -77,11 +77,17 @@ jobs:
         if: steps.target.outputs.skip != 'true'
         shell: bash
         run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 10 \
+            --output "$RUNNER_TEMP/elan-init.sh"
+          sh "$RUNNER_TEMP/elan-init.sh" -y
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Regenerate benchmark-snapshot from target lean-eval
         if: steps.target.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           python3 scripts/generate_site_data.py \
             --benchmark-repo lean-eval-benchmark \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,11 @@ jobs:
       - name: Set up elan
         shell: bash
         run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 10 \
+            --output "$RUNNER_TEMP/elan-init.sh"
+          sh "$RUNNER_TEMP/elan-init.sh" -y
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Configure Pages

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 import tomllib
 import urllib.request
 from collections import defaultdict
@@ -184,6 +185,29 @@ def site_verso_require() -> tuple[str, str]:
     return match.group("git"), match.group("rev")
 
 
+def fetch_json_url(
+    url: str,
+    *,
+    attempts: int = 5,
+    retry_delay_seconds: float = 5,
+) -> Any:
+    """Fetch JSON with bounded retries for transient hosting failures."""
+    headers = {"User-Agent": "lean-eval-leaderboard-snapshot-generator"}
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+    request = urllib.request.Request(url, headers=headers)
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            if attempt == attempts:
+                raise
+            time.sleep(retry_delay_seconds * attempt)
+    raise AssertionError("unreachable")
+
+
 def consumer_subverso_rev() -> str:
     """The SubVerso revision LeaderboardSite decodes highlighted JSON with.
 
@@ -196,8 +220,7 @@ def consumer_subverso_rev() -> str:
     slug = re.sub(r"\.git$", "", verso_git).rstrip("/").removeprefix("https://github.com/")
     url = f"https://raw.githubusercontent.com/{slug}/{verso_rev}/lake-manifest.json"
     try:
-        with urllib.request.urlopen(url, timeout=30) as response:
-            manifest = json.loads(response.read().decode("utf-8"))
+        manifest = fetch_json_url(url)
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise SystemExit(f"Could not fetch Verso's lake-manifest from {url}: {exc}")
     for pkg in manifest.get("packages", []):

--- a/tests/test_generate_site_data.py
+++ b/tests/test_generate_site_data.py
@@ -1,13 +1,31 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 from scripts.generate_site_data import (
     dedupe_universe_declarations,
+    fetch_json_url,
     preserve_root_declarations,
     qualify_probability_root_opens,
 )
 
 
 class SnapshotContextTests(unittest.TestCase):
+    @patch("scripts.generate_site_data.time.sleep")
+    @patch("scripts.generate_site_data.urllib.request.urlopen")
+    def test_retries_transient_json_fetches(
+        self, urlopen: MagicMock, sleep: MagicMock
+    ) -> None:
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = b'{"ok": true}'
+        urlopen.side_effect = [OSError("rate limited"), response]
+
+        self.assertEqual(
+            fetch_json_url("https://example.test/data.json", retry_delay_seconds=2),
+            {"ok": True},
+        )
+        self.assertEqual(urlopen.call_count, 2)
+        sleep.assert_called_once_with(2)
+
     def test_deduplicates_universes_across_inlined_modules(self) -> None:
         fragments = [
             "universe u v\ndef first := 1",


### PR DESCRIPTION
## Summary

- retry the elan installer download in both leaderboard workflows
- authenticate the Verso manifest request in the snapshot bump workflow
- retry transient JSON fetch failures with bounded backoff
- cover the retry path with a unit test

This follows #66. The first production bump attempt was blocked by HTTP 429 responses from `raw.githubusercontent.com`: once while fetching Verso's manifest and once while installing elan. No snapshot change was pushed.

## Verification

- `python3 -m unittest discover -s tests -v`
- Python byte-compilation and workflow YAML parse
- authenticated live `consumer_subverso_rev()` lookup
- `git diff --check`
