### PR TITLE
Raise recursion limit for expanded problems page

### DIFF
--- a/LeaderboardSite/Pages/Problems.lean
+++ b/LeaderboardSite/Pages/Problems.lean
@@ -11,6 +11,7 @@ open Verso.Code.External
 
 set_option verso.exampleProject "benchmark-snapshot"
 set_option maxHeartbeats 1000000
+set_option maxRecDepth 65536
 
 namespace LeaderboardSite.Pages
 


### PR DESCRIPTION
## Summary

Raise `maxRecDepth` for the generated Problems page to the same 65,536 setting already used by `LeaderboardSite/Pages/Front.lean`.

The first Pages build of the new 297-problem / 50-Annals snapshot compiled the snapshot and generated site data successfully, then failed while elaborating the generated Problems page:

```
LeaderboardSite/Pages/Problems.lean:232:4: maximum recursion depth has been reached
```

## Verification

- production failure isolated to `Lean.Elab.Term.elabTerm pageTerm`
- `git diff --check`
- local build reached dependency compilation but is blocked by the host's stale Nix linker wrapper (`ld-wrapper.sh` references a removed store path); the protected Pages build exercises the exact 297-problem data and is the authoritative check
