### PR TITLE
docs: reserve v2 for the problem set

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
             '.summary.problems == $count and .summary.main_problems == $count and .summary.test_problems == 0' \
             _site/site-data/leaderboard.json
 
-      - name: Verify leaderboard v2 preview artifacts
+      - name: Verify lifecycle-aware leaderboard preview artifacts
         run: |
           set -euo pipefail
           test -f _site/preview/index.html
@@ -189,7 +189,7 @@ jobs:
             test -f "_site/problems/$problem_id/index.html"
             test -f "_site/site-data/v2/problems/$problem_id.json"
           done < <(jq -r '.problems[].id' _site/site-data/problems.json)
-          grep -F "LeanEval leaderboard v2" _site/preview/index.html
+          grep -F "LeanEval lifecycle-aware leaderboard" _site/preview/index.html
           grep -F 'aria-live="polite"' _site/preview/index.html
           jq --exit-status '.preview.kind == "results-v2-compatibility"' \
             _site/site-data/leaderboard-preview.json

--- a/LeaderboardSite/Pages/Preview.lean
+++ b/LeaderboardSite/Pages/Preview.lean
@@ -38,7 +38,7 @@ private def appShell (view : String) (identity : String := "") : Block Page :=
       <aside class="v2-preview-banner">
         <span class="v2-preview-badge">{{textHtml "Preview"}}</span>
         <div>
-          <h1 id="v2-preview-title">{{textHtml "LeanEval leaderboard v2"}}</h1>
+          <h1 id="v2-preview-title">{{textHtml "LeanEval lifecycle-aware leaderboard"}}</h1>
           <p>{{textHtml "Local-only preview of the normalized materialized-domain contract."}}</p>
         </div>
         <a href=".">{{textHtml "Current leaderboard"}}</a>
@@ -58,7 +58,7 @@ private def pagePart (title view : String) (identity : String := "") : Part Page
   .mk #[textInline title] title none #[appShell view identity] #[]
 
 def _root_.LeaderboardSite.Pages.Preview : VersoDoc Page :=
-  .mk (fun _ => pagePart "Leaderboard v2 preview" "group" "formalization-evaluation") "{}"
+  .mk (fun _ => pagePart "Lifecycle-aware leaderboard preview" "group" "formalization-evaluation") "{}"
 
 def _root_.LeaderboardSite.Pages.PreviewFormalization : VersoDoc Page :=
   .mk (fun _ => pagePart "Formalization evaluation" "group" "formalization-evaluation") "{}"

--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ recorded in `benchmark-snapshot/.benchmark-commit`, so the regenerated
 site-data and the checked-in snapshot's catalog stay in lockstep; the results
 clone is always read at `main` HEAD.
 
-The generator preserves the legacy nested-v1 reader and also accepts the
-strict flat-v2 results contract. V2 files are rejected unless their complete
+The generator preserves the legacy nested schema-version-1 reader and also
+accepts the strict flat results schema-version-2 contract. Schema-version-2
+files are rejected unless their complete
 envelope, stable identifiers, uniqueness constraints, source pins, and intake
 shape validate. Both versions normalize into one internal record shape before
 aggregation. `leaderboard-preview.json` remains a parity artifact for the
-strict results-v2 transition. The local-only `/preview/` UI consumes the split
+strict results schema-version-2 transition. The local-only `/preview/` UI
+contains the lifecycle-aware leaderboard and consumes the split
 `site-data/v2/` materialized-domain projection documented in
 [docs/site-data-v2.md](docs/site-data-v2.md).
 The vendored machine-readable contract is `schemas/results-v2.schema.json`,
@@ -92,7 +94,7 @@ it is never modified or removed.
 The text below is retained for reference; the authoritative schema is the
 one in the submissions repo's README.
 
-### Record schema (v2)
+### Results record schema version 2
 
 ```json
 {

--- a/docs/site-data-schema.md
+++ b/docs/site-data-schema.md
@@ -92,8 +92,9 @@ This file is the benchmark catalog as consumed by the website.
 This file is the site-facing leaderboard representation. It is already
 aggregated, ranked, and enriched with provenance and notability metadata.
 
-The generator accepts raw results schemas v1 and v2. The `raw_results_schema_versions`
-top-level array records which versions contributed to a build. V2 is validated
+The generator accepts raw results schema versions 1 and 2. The
+`raw_results_schema_versions` top-level array records which versions
+contributed to a build. Schema version 2 is validated
 against the flat public contract, including recomputing every `result_id`,
 before aggregation. A new statement revision remains a distinct base record,
 while this compatibility view counts a model/user/problem only once.
@@ -113,9 +114,10 @@ therefore cannot create a leaderboard row or leak through the public site data.
 ```
 
 CI removes only `preview` and requires the remaining JSON to equal
-`leaderboard.json` exactly. The artifact is retained as a strict results-v2
-parity check. The richer local-only `/preview/` UI consumes the split v2
-materialized-domain projection documented in
+`leaderboard.json` exactly. The artifact is retained as a strict results
+schema-version-2 parity check. The richer local-only `/preview/` UI contains
+the lifecycle-aware leaderboard and consumes the split materialized-domain
+projection (wire schema version 2) documented in
 [`site-data-v2.md`](site-data-v2.md).
 
 ```json

--- a/docs/site-data-v2.md
+++ b/docs/site-data-v2.md
@@ -1,7 +1,8 @@
-# Split leaderboard site-data v2
+# Lifecycle-aware leaderboard site-data
 
-`site-data/v2/` is the local preview's versioned browser interface. The
-existing `/` site and its `problems.json`/`leaderboard.json` files are unchanged.
+`site-data/v2/` is the lifecycle-aware leaderboard's browser interface, using
+wire schema version 2. The existing `/` site and its
+`problems.json`/`leaderboard.json` files are unchanged.
 
 The generator reads the public State `materialized/domain.json`, never the
 append-only events. It joins submissions, results, replay tasks, and release
@@ -47,8 +48,8 @@ non-default scope or ordering persist in the query string.
 
 The old `/problems/<id>/` routes remain unchanged, preserving the public
 `/eval/problems/<id>/` URLs under the site's mount point. Preview comparisons
-live at `/preview/problems/<id>/`. The v2 client constructs untrusted content
-with `textContent`, and RSS text is XML-escaped.
+live at `/preview/problems/<id>/`. The lifecycle-aware client constructs
+untrusted content with `textContent`, and RSS text is XML-escaped.
 
 ## Local fixture boundary
 

--- a/schemas/results-v2.schema.json
+++ b/schemas/results-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://leanprover.github.io/lean-eval/schemas/results-v2.schema.json",
-  "title": "LeanEval per-user results file v2",
+  "title": "LeanEval per-user results file schema version 2",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "user", "results"],

--- a/schemas/site-data-v2.schema.json
+++ b/schemas/site-data-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://leanprover.github.io/lean-eval-leaderboard/schemas/site-data-v2.schema.json",
-  "title": "LeanEval split site-data v2 payload",
+  "title": "LeanEval lifecycle-aware site-data payload, schema version 2",
   "oneOf": [
     {"$ref": "#/$defs/index"},
     {"$ref": "#/$defs/group"},

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -346,11 +346,11 @@ def normalized_result_records(
     *,
     context: str,
 ) -> tuple[str, list[dict[str, Any]]]:
-    """Return the v2-shaped internal view of one v1 or v2 user file.
+    """Return the normalized internal view of a schema-version-1/2 user file.
 
     The v1 branch intentionally retains the original reader's permissive
-    behavior. The v2 branch validates the complete flat envelope and stable
-    identifiers before any value reaches aggregation.
+    behavior. The schema-version-2 branch validates the complete flat envelope
+    and stable identifiers before any value reaches aggregation.
     """
 
     version = user_record.get("schema_version")

--- a/scripts/results_v2.py
+++ b/scripts/results_v2.py
@@ -1,4 +1,4 @@
-"""Strict raw-results v2 reader used by the leaderboard generator.
+"""Strict raw-results schema-version-2 reader used by the leaderboard.
 
 The stable identifier contract and envelope mirror
 ``lean-eval-submissions/docs/results-schema-v2.md``.  This module is vendored
@@ -38,7 +38,7 @@ V2_FIELDS = {
 
 
 class ResultsV2Error(ValueError):
-    """A schema-v2 results file violates the public contract."""
+    """A schema-version-2 results file violates the public contract."""
 
 
 def _canonical_identity(value: list[Any]) -> bytes:
@@ -134,7 +134,7 @@ def _validate_production_metadata(
 
 
 def parse_v2_file(document: Any, *, context: str) -> list[dict[str, Any]]:
-    """Validate a complete v2 file and return its records unchanged."""
+    """Validate a complete schema-version-2 file and return its records."""
 
     data = _object(document, context)
     if set(data) != {"schema_version", "user", "results"}:
@@ -142,7 +142,7 @@ def parse_v2_file(document: Any, *, context: str) -> list[dict[str, Any]]:
             f"{context} must contain only schema_version, user, and results"
         )
     if data.get("schema_version") != 2:
-        raise ResultsV2Error(f"{context} is not schema v2")
+        raise ResultsV2Error(f"{context} is not results schema version 2")
     user = _string(data.get("user"), f"{context}.user")
     if not LOGIN_RE.fullmatch(user):
         raise ResultsV2Error(f"{context}.user is not a valid GitHub login")

--- a/scripts/v2_site_data.py
+++ b/scripts/v2_site_data.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build the split, client-facing leaderboard v2 projection.
+"""Build the split, client-facing lifecycle-aware leaderboard projection.
 
 The adapter deliberately consumes only materialized State data.  It never reads
 the append-only event log and it never executes submission source.  While the
@@ -589,7 +589,7 @@ def build_v2_projection(
     state_metadata: dict[str, Any] | None,
     site_base_url: str,
 ) -> dict[str, Any]:
-    """Return path→payload for every v2 JSON file plus the RSS string."""
+    """Return path→payload for every schema-version-2 JSON file and RSS."""
 
     fixture_metadata = fixture.get("metadata_amendments", {})
     fixture_retractions = set(fixture.get("retracted_result_ids", []))
@@ -605,16 +605,16 @@ def build_v2_projection(
 
     problem_ids = [problem.id for problem in problems]
     if len(problem_ids) != len(set(problem_ids)):
-        raise SystemExit("v2 projection: duplicate catalog problem id")
+        raise SystemExit("lifecycle-aware projection: duplicate catalog problem id")
     for problem in problems:
         if problem.group not in GROUP_BY_ID:
             raise SystemExit(
-                f"v2 projection: unsupported group {problem.group!r} for {problem.id}"
+                f"lifecycle-aware projection: unsupported group {problem.group!r} for {problem.id}"
             )
         unknown_tags = set(problem.tags) - set(tag_registry)
         if unknown_tags:
             raise SystemExit(
-                f"v2 projection: unregistered tags for {problem.id}: {sorted(unknown_tags)}"
+                f"lifecycle-aware projection: unregistered tags for {problem.id}: {sorted(unknown_tags)}"
             )
     visible = [problem for problem in problems if problem.visible]
     visible_ids = {problem.id for problem in visible}

--- a/scripts/validate_site_data_v2.py
+++ b/scripts/validate_site_data_v2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate generated split site-data v2 without third-party dependencies."""
+"""Validate lifecycle-aware site-data schema version 2 without dependencies."""
 
 from __future__ import annotations
 
@@ -150,7 +150,7 @@ def main() -> int:
     except ContractError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    print("site-data v2 contract: ok")
+    print("lifecycle-aware site-data schema version 2: ok")
     return 0
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -228,7 +228,7 @@ body::before {
   }
 }
 
-/* ── Local-only leaderboard v2 preview ─────────────────────────────────── */
+/* ── Local-only lifecycle-aware leaderboard preview ───────────────────── */
 
 .v2-app {
   display: grid;

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -17,7 +17,7 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn('Dir.page "open-conjectures"', site)
         self.assertIn('Dir.page "recent"', site)
         self.assertIn("preview_problem_pages%", site)
-        self.assertIn("LeanEval leaderboard v2", page)
+        self.assertIn("LeanEval lifecycle-aware leaderboard", page)
         self.assertIn('aria-live="polite"', page)
         self.assertIn('href="."', page)
 


### PR DESCRIPTION
## Summary

- rename the public preview from “leaderboard v2” to the lifecycle-aware leaderboard
- qualify results and site-data machine formats as schema version 2
- retain compatibility-sensitive paths, filenames, DOM hooks, and JSON IDs

## Verification

- 26 Python tests pass
- JavaScript syntax check passes
- `git diff --check` passes
- focused Lean build attempted from a fresh checkout; Python structure coverage passed, while the host linker remains blocked by its known garbage-collected Nix wrapper and the fresh tree lacks generated site-data