### PR TITLE
refactor: use lifecycle terminology in live preview

### DIFF
--- a/LeaderboardSite/Pages/Preview.lean
+++ b/LeaderboardSite/Pages/Preview.lean
@@ -20,12 +20,12 @@ private def htmlBlob (html : Html) : Block Page :=
   .other (BlockExt.blob html) #[]
 
 private def groupTabs : Html := {{
-  <nav class="v2-group-tabs" aria-label="Leaderboard groups">
-    <a data-v2-group-tab="formalization-evaluation"
+  <nav class="lifecycle-group-tabs" aria-label="Leaderboard groups">
+    <a data-lifecycle-group-tab="formalization-evaluation"
        href="preview/formalization-evaluation/">{{textHtml "Formalization evaluation"}}</a>
-    <a data-v2-group-tab="software-verification"
+    <a data-lifecycle-group-tab="software-verification"
        href="preview/software-verification/">{{textHtml "Software verification"}}</a>
-    <a data-v2-group-tab="open-conjectures"
+    <a data-lifecycle-group-tab="open-conjectures"
        href="preview/open-conjectures/">{{textHtml "Open conjectures"}}</a>
     <a href="preview/recent/">{{textHtml "Recent solutions"}}</a>
   </nav>
@@ -33,21 +33,21 @@ private def groupTabs : Html := {{
 
 private def appShell (view : String) (identity : String := "") : Block Page :=
   htmlBlob {{
-    <section class="v2-app wrap" data-v2-app="true" data-v2-view={{view}}
-             data-v2-identity={{identity}} aria-labelledby="v2-preview-title">
-      <aside class="v2-preview-banner">
-        <span class="v2-preview-badge">{{textHtml "Preview"}}</span>
+    <section class="lifecycle-app wrap" data-lifecycle-app="true" data-lifecycle-view={{view}}
+             data-lifecycle-identity={{identity}} aria-labelledby="lifecycle-preview-title">
+      <aside class="lifecycle-preview-banner">
+        <span class="lifecycle-preview-badge">{{textHtml "Preview"}}</span>
         <div>
-          <h1 id="v2-preview-title">{{textHtml "LeanEval lifecycle-aware leaderboard"}}</h1>
+          <h1 id="lifecycle-preview-title">{{textHtml "LeanEval lifecycle-aware leaderboard"}}</h1>
           <p>{{textHtml "Local-only preview of the normalized materialized-domain contract."}}</p>
         </div>
         <a href=".">{{textHtml "Current leaderboard"}}</a>
       </aside>
       {{groupTabs}}
-      <div class="v2-app-status" role="status" aria-live="polite">
+      <div class="lifecycle-app-status" role="status" aria-live="polite">
         {{textHtml "Loading leaderboard data…"}}
       </div>
-      <div class="v2-app-content"></div>
+      <div class="lifecycle-app-content"></div>
       <noscript>
         <p>{{textHtml "This preview uses client-side tables. Enable JavaScript to inspect it; the current leaderboard remains available at the site root."}}</p>
       </noscript>

--- a/SiteTheme.lean
+++ b/SiteTheme.lean
@@ -80,7 +80,7 @@ def theme (_name : String) (siteName : String) : Theme := {
           <script src="static/theme-toggle.js"></script>
           <script defer="true" src="static/background.js"></script>
           <script defer="true" src="static/site.js"></script>
-          <script defer="true" src="static/v2-preview.js"></script>
+          <script defer="true" src="static/lifecycle-preview.js"></script>
         </head>
         <body class={{pageClass}}>
           <div class="site-shell">

--- a/static/lifecycle-preview.js
+++ b/static/lifecycle-preview.js
@@ -46,15 +46,15 @@
 
   function limitations(items) {
     if (!items || !items.length) return null;
-    return node("aside", { className: "v2-limitations", "aria-label": "Preview data limitations" }, [
+    return node("aside", { className: "lifecycle-limitations", "aria-label": "Preview data limitations" }, [
       heading(2, "Data limitations"),
       node("ul", {}, items.map(function (item) { return node("li", { text: item }); }))
     ]);
   }
 
   function markGroupTab(groupId) {
-    document.querySelectorAll("[data-v2-group-tab]").forEach(function (tab) {
-      if (tab.getAttribute("data-v2-group-tab") === groupId) {
+    document.querySelectorAll("[data-lifecycle-group-tab]").forEach(function (tab) {
+      if (tab.getAttribute("data-lifecycle-group-tab") === groupId) {
         tab.setAttribute("aria-current", "page");
       } else {
         tab.removeAttribute("aria-current");
@@ -114,16 +114,16 @@
       body.appendChild(node("tr", {}, [
         node("td", { text: String(index + 1) }),
         node("th", { scope: "row", text: row.label }),
-        node("td", { className: sortKey === "unique" ? "v2-leading-count" : "", text: String(row.counts.unique) }),
-        node("td", { className: sortKey === "first" ? "v2-leading-count" : "", text: String(row.counts.first) }),
-        node("td", { className: sortKey === "total" ? "v2-leading-count" : "", text: String(row.counts.total) }),
+        node("td", { className: sortKey === "unique" ? "lifecycle-leading-count" : "", text: String(row.counts.unique) }),
+        node("td", { className: sortKey === "first" ? "lifecycle-leading-count" : "", text: String(row.counts.first) }),
+        node("td", { className: sortKey === "total" ? "lifecycle-leading-count" : "", text: String(row.counts.total) }),
         node("td", { text: Array.from(row.submitters).map(function (user) { return "@" + user; }).join(", ") })
       ]));
     });
     if (!rows.length) {
       body.appendChild(node("tr", {}, [node("td", { colspan: "6", text: "No accepted solves in this scope." })]));
     }
-    return node("div", { className: "v2-table-scroll" }, [node("table", { className: "v2-table" }, [
+    return node("div", { className: "lifecycle-table-scroll" }, [node("table", { className: "lifecycle-table" }, [
       node("caption", { text: groupLabel + " — " + scopeLabel + " standings; ordered by " + sortKey + " solves" }),
       node("thead", {}, [node("tr", {}, [
         node("th", { scope: "col", text: "Rank" }),
@@ -137,13 +137,13 @@
   }
 
   function tagChip(tag) {
-    return node("span", { className: "v2-tag", text: tag });
+    return node("span", { className: "lifecycle-tag", text: tag });
   }
 
   function problemsTable(problems) {
     var body = node("tbody");
     problems.forEach(function (problem) {
-      var tags = node("div", { className: "v2-tag-list" }, problem.tags.map(tagChip));
+      var tags = node("div", { className: "lifecycle-tag-list" }, problem.tags.map(tagChip));
       body.appendChild(node("tr", {}, [
         node("th", { scope: "row" }, [node("a", { href: problem.url, text: problem.title })]),
         node("td", { text: problem.status }),
@@ -154,7 +154,7 @@
     if (!problems.length) {
       body.appendChild(node("tr", {}, [node("td", { colspan: "4", text: "No problems match these filters." })]));
     }
-    return node("div", { className: "v2-table-scroll" }, [node("table", { className: "v2-table" }, [
+    return node("div", { className: "lifecycle-table-scroll" }, [node("table", { className: "lifecycle-table" }, [
       node("caption", { text: "Problems in the selected scope" }),
       node("thead", {}, [node("tr", {}, [
         node("th", { scope: "col", text: "Problem" }), node("th", { scope: "col", text: "Status" }),
@@ -174,7 +174,7 @@
       var selectedTags = new Set((params.get("tags") || "").split(",").filter(Boolean));
 
       var title = heading(2, data.group.label);
-      var policy = node("p", { className: "v2-policy", text: data.group.policy });
+      var policy = node("p", { className: "lifecycle-policy", text: data.group.policy });
       if (!scope) {
         var emptyChildren = [title, policy, node("p", { text: "No visible problems are published in this group yet." })];
         var emptyNote = limitations(data.data_limitations);
@@ -182,31 +182,31 @@
         content.replaceChildren.apply(content, emptyChildren);
         return;
       }
-      var controls = node("div", { className: "v2-controls" });
+      var controls = node("div", { className: "lifecycle-controls" });
       var scopeSelect;
       if (data.scopes.length > 1) {
-        scopeSelect = node("select", { id: "v2-scope" }, data.scopes.map(function (item) {
+        scopeSelect = node("select", { id: "lifecycle-scope" }, data.scopes.map(function (item) {
           var option = node("option", { value: item.id, text: item.label });
           option.selected = item.id === scope.id;
           return option;
         }));
         controls.appendChild(node("label", { text: "Scope " }, [scopeSelect]));
       }
-      var sortSelect = node("select", { id: "v2-sort" }, ["unique", "first", "total"].map(function (key) {
+      var sortSelect = node("select", { id: "lifecycle-sort" }, ["unique", "first", "total"].map(function (key) {
         var option = node("option", { value: key, text: key[0].toUpperCase() + key.slice(1) + " solves" });
         option.selected = key === sortKey;
         return option;
       }));
       controls.appendChild(node("label", { text: "Order " }, [sortSelect]));
-      var tagFieldset = node("fieldset", { className: "v2-tag-filter" }, [node("legend", { text: "Filter by tag" })]);
+      var tagFieldset = node("fieldset", { className: "lifecycle-tag-filter" }, [node("legend", { text: "Filter by tag" })]);
       data.tags.forEach(function (tag) {
         var checkbox = node("input", { type: "checkbox", value: tag.id, id: "tag-" + tag.id });
         checkbox.checked = selectedTags.has(tag.id);
         tagFieldset.appendChild(node("label", { title: tag.description }, [checkbox, document.createTextNode(tag.label)]));
       });
       if (data.tags.length) controls.appendChild(tagFieldset);
-      var standingsRoot = node("section", { className: "v2-panel", "aria-labelledby": "v2-standings-title" });
-      var problemsRoot = node("section", { className: "v2-panel", "aria-labelledby": "v2-problems-title" });
+      var standingsRoot = node("section", { className: "lifecycle-panel", "aria-labelledby": "lifecycle-standings-title" });
+      var problemsRoot = node("section", { className: "lifecycle-panel", "aria-labelledby": "lifecycle-problems-title" });
 
       function update() {
         scopeId = scopeSelect ? scopeSelect.value : scope.id;
@@ -251,7 +251,7 @@
         node("option", { value: "open-conjectures", text: "Open conjectures" })
       ]);
       select.value = selected;
-      var list = node("ol", { className: "v2-recent-list" });
+      var list = node("ol", { className: "lifecycle-recent-list" });
       function update() {
         selected = select.value;
         list.replaceChildren();
@@ -259,9 +259,9 @@
           return selected === "all" || solution.group === selected;
         }).forEach(function (solution) {
           var badges = [tagChip(solution.group)];
-          if (solution.first_solve) badges.push(node("span", { className: "v2-first", text: "First solve" }));
+          if (solution.first_solve) badges.push(node("span", { className: "lifecycle-first", text: "First solve" }));
           list.appendChild(node("li", {}, [
-            node("div", { className: "v2-tag-list" }, badges),
+            node("div", { className: "lifecycle-tag-list" }, badges),
             node("a", { href: solution.problem_url, text: solution.problem_title }),
             node("span", { text: solution.canonical_credit.label + " · @" + solution.submitter + " · " + formattedDate(solution.accepted_at) })
           ]));
@@ -280,7 +280,7 @@
   }
 
   function definitionList(values) {
-    var list = node("dl", { className: "v2-definition-list" });
+    var list = node("dl", { className: "lifecycle-definition-list" });
     values.forEach(function (pair) {
       list.appendChild(node("dt", { text: pair[0] }));
       list.appendChild(node("dd", { text: pair[1] === null || pair[1] === undefined || pair[1] === "" ? "Unavailable" : String(pair[1]) }));
@@ -293,15 +293,15 @@
       status.hidden = true;
       var problem = data.problem;
       markGroupTab(problem.group);
-      var history = node("ol", { className: "v2-history" }, data.lifecycle.status_history.map(function (entry) {
+      var history = node("ol", { className: "lifecycle-history" }, data.lifecycle.status_history.map(function (entry) {
         return node("li", { text: entry.status + (entry.effective_at ? " · " + formattedDate(entry.effective_at) : " · date unavailable") });
       }));
       var sets = node("ul", {}, data.sets.length ? data.sets.map(function (set) {
         return node("li", { text: set.title + " · statement r" + set.statement_revision + (set.frozen ? " · frozen" : " · draft") });
       }) : [node("li", { text: "No named set membership." })]);
-      var solutions = node("div", { className: "v2-solution-grid" });
+      var solutions = node("div", { className: "lifecycle-solution-grid" });
       data.solutions.forEach(function (solution) {
-        var card = node("article", { className: "v2-solution-card" }, [
+        var card = node("article", { className: "lifecycle-solution-card" }, [
           heading(4, solution.canonical_credit.label),
           definitionList([
             ["Submitter", "@" + solution.submitter], ["Accepted", formattedDate(solution.accepted_at)],
@@ -334,7 +334,7 @@
             ]));
           });
         } else {
-          card.appendChild(node("p", { className: "v2-unavailable", text: "Replay measurements unavailable." }));
+          card.appendChild(node("p", { className: "lifecycle-unavailable", text: "Replay measurements unavailable." }));
         }
         solutions.appendChild(card);
       });
@@ -354,12 +354,12 @@
   }
 
   function run() {
-    var app = document.querySelector("[data-v2-app]");
+    var app = document.querySelector("[data-lifecycle-app]");
     if (!app) return;
-    var view = app.getAttribute("data-v2-view");
-    var identity = app.getAttribute("data-v2-identity") || "";
-    var content = app.querySelector(".v2-app-content");
-    var status = app.querySelector(".v2-app-status");
+    var view = app.getAttribute("data-lifecycle-view");
+    var identity = app.getAttribute("data-lifecycle-identity") || "";
+    var content = app.querySelector(".lifecycle-app-content");
+    var status = app.querySelector(".lifecycle-app-status");
     if (view === "recent") renderRecent(content, status);
     else if (view === "problem") renderProblem(content, status, identity);
     else renderGroup(app, content, status, identity || "formalization-evaluation");

--- a/static/style.css
+++ b/static/style.css
@@ -184,7 +184,7 @@ body::before {
   flex-grow: 1;
 }
 
-.v2-preview-banner {
+.lifecycle-preview-banner {
   width: min(1120px, calc(100vw - 48px));
   margin: 0 auto var(--space-8);
   padding: var(--space-5) var(--space-6);
@@ -197,21 +197,21 @@ body::before {
   background: color-mix(in srgb, var(--color-primary) 8%, var(--color-bg));
 }
 
-.v2-preview-banner h1,
-.v2-preview-banner p {
+.lifecycle-preview-banner h1,
+.lifecycle-preview-banner p {
   margin: 0;
 }
 
-.v2-preview-banner h1 {
+.lifecycle-preview-banner h1 {
   font-size: 1.25rem;
 }
 
-.v2-preview-banner p {
+.lifecycle-preview-banner p {
   margin-top: var(--space-1);
   color: var(--color-text-muted);
 }
 
-.v2-preview-badge {
+.lifecycle-preview-badge {
   padding: 0.25rem 0.6rem;
   border-radius: 999px;
   background: var(--color-primary);
@@ -223,24 +223,24 @@ body::before {
 }
 
 @media (max-width: 760px) {
-  .v2-preview-banner {
+  .lifecycle-preview-banner {
     grid-template-columns: 1fr;
   }
 }
 
 /* ── Local-only lifecycle-aware leaderboard preview ───────────────────── */
 
-.v2-app {
+.lifecycle-app {
   display: grid;
   gap: var(--space-6);
 }
 
-.v2-app .v2-preview-banner {
+.lifecycle-app .lifecycle-preview-banner {
   width: 100%;
   margin-bottom: 0;
 }
 
-.v2-group-tabs {
+.lifecycle-group-tabs {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
@@ -248,32 +248,32 @@ body::before {
   border-bottom: 1px solid var(--color-border);
 }
 
-.v2-group-tabs a {
+.lifecycle-group-tabs a {
   padding: var(--space-2) var(--space-4);
   border-radius: var(--radius-pill);
   color: var(--color-text);
   text-decoration: none;
 }
 
-.v2-group-tabs a:hover,
-.v2-group-tabs a:focus-visible,
-.v2-group-tabs a[aria-current="page"] {
+.lifecycle-group-tabs a:hover,
+.lifecycle-group-tabs a:focus-visible,
+.lifecycle-group-tabs a[aria-current="page"] {
   background: var(--color-primary);
   color: var(--color-text-contrast);
 }
 
-.v2-app-content {
+.lifecycle-app-content {
   display: grid;
   gap: var(--space-6);
 }
 
-.v2-app-content h2 { font-size: var(--fs-xl); }
-.v2-app-content h3 { font-size: var(--fs-lg); }
+.lifecycle-app-content h2 { font-size: var(--fs-xl); }
+.lifecycle-app-content h3 { font-size: var(--fs-lg); }
 
-.v2-policy,
-.v2-limitations,
-.v2-panel,
-.v2-solution-card {
+.lifecycle-policy,
+.lifecycle-limitations,
+.lifecycle-panel,
+.lifecycle-solution-card {
   padding: var(--space-5);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -281,34 +281,34 @@ body::before {
   box-shadow: var(--soft-shadow);
 }
 
-.v2-policy {
+.lifecycle-policy {
   border-inline-start: 4px solid var(--color-primary);
 }
 
-.v2-limitations {
+.lifecycle-limitations {
   color: var(--color-text-light);
   background: var(--color-surface-soft);
 }
 
-.v2-limitations h2 { font-size: var(--fs-base); }
-.v2-limitations ul { margin: var(--space-2) 0 0 var(--space-5); }
+.lifecycle-limitations h2 { font-size: var(--fs-base); }
+.lifecycle-limitations ul { margin: var(--space-2) 0 0 var(--space-5); }
 
-.v2-controls {
+.lifecycle-controls {
   display: flex;
   flex-wrap: wrap;
   align-items: start;
   gap: var(--space-4);
 }
 
-.v2-controls > label,
-.v2-tag-filter {
+.lifecycle-controls > label,
+.lifecycle-tag-filter {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   min-height: 44px;
 }
 
-.v2-controls select {
+.lifecycle-controls select {
   min-height: 40px;
   padding: var(--space-2);
   color: var(--color-text);
@@ -317,65 +317,65 @@ body::before {
   border-radius: var(--radius-sm);
 }
 
-.v2-tag-filter {
+.lifecycle-tag-filter {
   flex-wrap: wrap;
   padding: var(--space-2) var(--space-3);
   border: 1px solid var(--color-border-light);
   border-radius: var(--radius-md);
 }
 
-.v2-tag-filter label {
+.lifecycle-tag-filter label {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
   cursor: pointer;
 }
 
-.v2-panel {
+.lifecycle-panel {
   display: grid;
   gap: var(--space-4);
 }
 
-.v2-table-scroll { overflow-x: auto; }
+.lifecycle-table-scroll { overflow-x: auto; }
 
-.v2-table {
+.lifecycle-table {
   width: 100%;
   border-collapse: collapse;
   text-align: left;
 }
 
-.v2-table caption {
+.lifecycle-table caption {
   padding-bottom: var(--space-3);
   color: var(--color-text-light);
   text-align: left;
 }
 
-.v2-table th,
-.v2-table td {
+.lifecycle-table th,
+.lifecycle-table td {
   padding: var(--space-3);
   border-bottom: 1px solid var(--color-border);
   vertical-align: top;
 }
 
-.v2-table thead th {
+.lifecycle-table thead th {
   color: var(--color-text-light);
   font-size: var(--fs-sm);
 }
 
-.v2-leading-count {
+.lifecycle-leading-count {
   color: var(--color-primary);
   font-size: var(--fs-lg);
   font-weight: 700;
 }
 
-.v2-tag-list {
+.lifecycle-tag-list {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-1);
 }
 
-.v2-tag,
-.v2-first {
+.lifecycle-tag,
+.lifecycle-first {
   display: inline-flex;
   padding: 0.15rem 0.5rem;
   border-radius: var(--radius-pill);
@@ -384,19 +384,19 @@ body::before {
   font-size: var(--fs-xs);
 }
 
-.v2-first {
+.lifecycle-first {
   background: color-mix(in srgb, var(--color-primary) 14%, var(--color-surface));
   color: var(--color-primary);
   font-weight: 700;
 }
 
-.v2-recent-list {
+.lifecycle-recent-list {
   display: grid;
   gap: var(--space-3);
   list-style-position: inside;
 }
 
-.v2-recent-list li {
+.lifecycle-recent-list li {
   display: grid;
   grid-template-columns: minmax(8rem, auto) minmax(14rem, 1fr) minmax(12rem, auto);
   align-items: center;
@@ -405,39 +405,39 @@ body::before {
   border-bottom: 1px solid var(--color-border);
 }
 
-.v2-definition-list {
+.lifecycle-definition-list {
   display: grid;
   grid-template-columns: minmax(9rem, auto) 1fr;
   gap: var(--space-2) var(--space-4);
 }
 
-.v2-definition-list dt {
+.lifecycle-definition-list dt {
   color: var(--color-text-light);
   font-weight: 600;
 }
 
-.v2-definition-list dd { margin: 0; overflow-wrap: anywhere; }
+.lifecycle-definition-list dd { margin: 0; overflow-wrap: anywhere; }
 
-.v2-history { margin-left: var(--space-5); }
+.lifecycle-history { margin-left: var(--space-5); }
 
-.v2-solution-grid {
+.lifecycle-solution-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
   gap: var(--space-4);
 }
 
-.v2-solution-card {
+.lifecycle-solution-card {
   display: grid;
   align-content: start;
   gap: var(--space-3);
 }
 
-.v2-unavailable { color: var(--color-text-light); font-style: italic; }
+.lifecycle-unavailable { color: var(--color-text-light); font-style: italic; }
 
 @media (max-width: 760px) {
-  .v2-recent-list li { grid-template-columns: 1fr; }
-  .v2-definition-list { grid-template-columns: 1fr; }
-  .v2-definition-list dd { margin-bottom: var(--space-2); }
+  .lifecycle-recent-list li { grid-template-columns: 1fr; }
+  .lifecycle-definition-list { grid-template-columns: 1fr; }
+  .lifecycle-definition-list dd { margin-bottom: var(--space-2); }
 }
 
 /* ─────────────────────────────────────────────────────────────────────────

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -22,13 +22,25 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn('href="."', page)
 
     def test_client_uses_safe_dom_and_url_persistent_filters(self) -> None:
-        client = (REPO_ROOT / "static/v2-preview.js").read_text()
+        client = (REPO_ROOT / "static/lifecycle-preview.js").read_text()
         self.assertNotIn("innerHTML", client)
         self.assertIn("textContent", client)
         self.assertIn("history.replaceState", client)
         self.assertIn('tags:', client)
         self.assertIn('["unique", "first", "total"]', client)
         self.assertIn("recent-solutions.xml", client)
+
+    def test_product_ui_uses_lifecycle_not_schema_terminology(self) -> None:
+        sources = [
+            REPO_ROOT / "LeaderboardSite/Pages/Preview.lean",
+            REPO_ROOT / "SiteTheme.lean",
+            REPO_ROOT / "static/lifecycle-preview.js",
+            REPO_ROOT / "static/style.css",
+        ]
+        for source in sources:
+            with self.subTest(source=source.relative_to(REPO_ROOT)):
+                self.assertNotIn("v2-", source.read_text())
+        self.assertFalse((REPO_ROOT / "static/v2-preview.js").exists())
 
     def test_deploy_checks_preview_parity_and_links(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/deploy.yml").read_text()


### PR DESCRIPTION
The currently deployed preview still exposed product-level `v2-*` script, CSS, DOM, and data-attribute names even though bare v1/v2 are reserved for problem sets. This terminology-only PR renames those live preview internals to `lifecycle-*` without changing routes, wire paths such as `site-data/v2/`, data contracts, or the held cutover in #72.

It can deploy independently while #72 remains held for stakeholder review.

Verification:
- 27 Python tests under warning mode
- `node --check static/lifecycle-preview.js`
- `lake build LeaderboardSite.Pages.Preview` — 122 jobs, warning-free project build (using the already-validated local MD4Lean link cache because the host Elan linker wrapper points at a collected Nix store path)
- regression rejects `v2-*` names in product UI sources
- `git diff --check`