### PR TITLE
Consume State model identity lifecycle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,6 +167,7 @@ jobs:
           python3 lean-eval-state/scripts/public_projection.py \
             --root lean-eval-state \
             --state-commit "$state_commit" \
+            --schema-version 4 \
             --output "$RUNNER_TEMP/public-state.json"
           python3 lean-eval-state/scripts/public_projection.py \
             --validate "$RUNNER_TEMP/public-state.json"
@@ -229,7 +230,7 @@ jobs:
           if [ "${{ github.ref }}" = 'refs/heads/main' ]; then
             test -f _site/site-data/public-state.json
             jq --exit-status \
-              '.schema_version == 1 and .environment == "production" and (.source_state_commit | test("^[0-9a-f]{40}$"))' \
+              '.schema_version == 4 and .environment == "production" and (.source_state_commit | test("^[0-9a-f]{40}$")) and (.model_identities | type == "array") and (.model_aliases | type == "array") and (.model_identity_history | type == "array")' \
               _site/site-data/public-state.json
             if rg -n 'source_repository|source_commit|archive_|submission_id|nonce_digest' \
                 _site/site-data/public-state.json; then

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ builds receive no State credential and exercise the explicitly labelled
 base-results fallback. Projection version 4 carries the public, owner-scoped
 model-identity review history and resolved aliases used for standings credit;
 immutable result IDs and declared labels remain unchanged. Neither raw State
-events nor the internal materialized domain enters the Pages artifact.
+events nor the internal materialized domain enters the Pages artifact. The
+vendored projection schemas through version 4 live in `schemas/`, and a
+State-generated transitive-consolidation artifact is pinned under
+`tests/fixtures/` as the producer/consumer compatibility vector.
 
 Benchmark catalog metadata is read from the required `group`, `status`,
 `visible`, `statement_revision`, and `tags` manifest fields. Problems marked

--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ results data repository.
 
 Production deploys additionally check out private production State through the
 read-only `PRODUCTION_STATE_READ_KEY` deploy key. They generate State's strict,
-redacted `public-state-projection-v1` artifact before site generation and
+redacted `public-state-projection-v4` artifact before site generation and
 publish that exact artifact as `site-data/public-state.json`. Pull-request
 builds receive no State credential and exercise the explicitly labelled
-base-results fallback. Neither raw State events nor the internal materialized
-domain enters the Pages artifact.
+base-results fallback. Projection version 4 carries the public, owner-scoped
+model-identity review history and resolved aliases used for standings credit;
+immutable result IDs and declared labels remain unchanged. Neither raw State
+events nor the internal materialized domain enters the Pages artifact.
 
 Benchmark catalog metadata is read from the required `group`, `status`,
 `visible`, `statement_revision`, and `tags` manifest fields. Problems marked

--- a/docs/site-data-v2.md
+++ b/docs/site-data-v2.md
@@ -6,16 +6,17 @@ files remain available to the preserved `/legacy/` surface and downstream
 consumers.
 
 The production generator reads State's redacted
-`public-state-projection-v1` artifact, never the private append-only events or
+`public-state-projection-v4` artifact, never the private append-only events or
 internal `materialized/domain.json`. The public artifact contains recorded
-results and public lifecycle evidence only; it excludes pending/rejected
-submissions, submission IDs, source and archive locators, and authentication
-nonces. Its source State commit, canonical event digest, and event count make
-the bytes reproducible by an authorized auditor. Presentation-only catalog
-fields come from the pinned benchmark checkout. If no State projection is
-provided, immutable base results are adapted instead. Every fallback appears
-in each payload's `data_limitations`; missing replay and release data is emitted
-as an explicit `unavailable` state rather than omitted or guessed.
+results, public lifecycle evidence, and public model-identity review history
+only; it excludes pending/rejected submissions, submission IDs, source and
+archive locators, and authentication nonces. Its source State commit, canonical
+event digest, and event count make the bytes reproducible by an authorized
+auditor. Presentation-only catalog fields come from the pinned benchmark
+checkout. If no State projection is provided, immutable base results are
+adapted instead. Every fallback appears in each payload's `data_limitations`;
+missing replay and release data is emitted as an explicit `unavailable` state
+rather than omitted or guessed.
 
 The split files are:
 
@@ -33,14 +34,17 @@ The authoritative structural contract is
 
 ## Credit and ordering
 
-An alias table maps declared labels to canonical credit identities before
-aggregation. Multiple base results that collide on `(canonical identity,
-problem)` retain their individual problem-page records but contribute one
-standings solve. Acceptance order is `(accepted_at, acceptance_event_id,
-result_id)`, so tied timestamps have a deterministic first solve. Unique means
-that exactly one canonical identity solved the problem in the selected scope;
-first means earliest acceptance order; total means distinct solved problems.
-The default order is unique, then first, then total.
+State aliases map the exact `(lowercase owner, verbatim declared label)` pair to
+an approved identity, then follow same-owner consolidation links to its current
+canonical identity. Renames change only the displayed canonical label. Multiple
+base results that resolve to the same `(canonical identity, problem)` retain
+their individual problem-page records but contribute one standings solve.
+Results without a reviewed State alias retain the legacy normalized-label
+fallback. Acceptance order is `(accepted_at, acceptance_event_id, result_id)`,
+so tied timestamps have a deterministic first solve. Unique means that exactly
+one canonical identity solved the problem in the selected scope; first means
+earliest acceptance order; total means distinct solved problems. The default
+order is unique, then first, then total.
 
 Standings are built and filtered inside one group payload. There is no
 cross-group score or ranking.
@@ -59,7 +63,9 @@ untrusted content with `textContent`, and RSS text is XML-escaped.
 
 ## Local fixture boundary
 
-State does not own catalog lifecycle histories or model-alias policy.
+State owns model-identity review and alias policy; it does not own catalog
+lifecycle histories. The fixture's aliases exercise fallback presentation when
+no State projection is supplied.
 `tests/fixtures/preview-domain-schema-version-1.json` exercises those
 presentation-only fixtures locally. It is loaded only via the explicit
 `--preview-fixture` flag

--- a/schemas/public-state-projection-v2.schema.json
+++ b/schemas/public-state-projection-v2.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lean-lang.org/schemas/lean-eval/public-state-projection-v2.schema.json",
+  "title": "lean-eval public State projection schema version 2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "environment", "source_state_commit",
+    "source_event_count", "source_digest", "results", "result_overlays"
+  ],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "environment": { "enum": ["staging", "production"] },
+    "source_state_commit": { "$ref": "#/$defs/commit" },
+    "source_event_count": { "type": "integer", "minimum": 1 },
+    "source_digest": { "$ref": "#/$defs/digest" },
+    "results": {
+      "type": "array",
+      "items": {
+        "$ref": "public-state-projection-v1.schema.json#/$defs/result"
+      }
+    },
+    "result_overlays": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/overlay" }
+    }
+  },
+  "$defs": {
+    "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "eventId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "resultId": { "type": "string", "pattern": "^r2_[0-9a-f]{64}$" },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^(?!0000-)[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\\.[0-9]{3}Z$"
+    },
+    "overlay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result_id", "owner_login", "declared_model", "problem_id",
+        "statement_revision", "claim_event_id", "mutation_event_id",
+        "claimed_at", "metadata"
+      ],
+      "properties": {
+        "result_id": { "$ref": "#/$defs/resultId" },
+        "owner_login": {
+          "type": "string",
+          "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$"
+        },
+        "declared_model": {
+          "type": "string", "minLength": 1, "maxLength": 256,
+          "pattern": "^[^\\u0000-\\u001f\\u007f]+$",
+          "x-utf8-maxBytes": 256
+        },
+        "problem_id": {
+          "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"
+        },
+        "statement_revision": {
+          "type": "integer", "minimum": 1, "maximum": 9007199254740991
+        },
+        "claim_event_id": { "$ref": "#/$defs/eventId" },
+        "mutation_event_id": { "$ref": "#/$defs/eventId" },
+        "claimed_at": { "$ref": "#/$defs/timestamp" },
+        "metadata": {
+          "$ref": "result-overlays-v1.schema.json#/$defs/metadata"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public-state-projection-v3.schema.json
+++ b/schemas/public-state-projection-v3.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lean-lang.org/schemas/lean-eval/public-state-projection-v3.schema.json",
+  "title": "lean-eval public State projection schema version 3",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "environment", "source_state_commit",
+    "source_event_count", "source_digest", "results", "result_overlays"
+  ],
+  "properties": {
+    "schema_version": { "const": 3 },
+    "environment": {
+      "$ref": "public-state-projection-v2.schema.json#/properties/environment"
+    },
+    "source_state_commit": {
+      "$ref": "public-state-projection-v2.schema.json#/properties/source_state_commit"
+    },
+    "source_event_count": {
+      "$ref": "public-state-projection-v2.schema.json#/properties/source_event_count"
+    },
+    "source_digest": {
+      "$ref": "public-state-projection-v2.schema.json#/properties/source_digest"
+    },
+    "results": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/result" }
+    },
+    "result_overlays": {
+      "$ref": "public-state-projection-v2.schema.json#/properties/result_overlays"
+    }
+  },
+  "$defs": {
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "release_at", "reason"],
+      "properties": {
+        "status": {
+          "enum": [
+            "scheduled", "running", "published", "failed", "cancelled", "removed"
+          ]
+        },
+        "release_at": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/nullableText"
+        },
+        "reason": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/nullableText"
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result_id", "problem_id", "statement_revision", "declared_model", "submitter",
+        "accepted_at", "acceptance_event_id", "recorded_at", "record_event_id",
+        "benchmark_commit", "production_metadata", "replay", "release", "public_solution"
+      ],
+      "properties": {
+        "result_id": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/result_id"
+        },
+        "problem_id": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/problem_id"
+        },
+        "statement_revision": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/statement_revision"
+        },
+        "declared_model": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/declared_model"
+        },
+        "submitter": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/submitter"
+        },
+        "accepted_at": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/accepted_at"
+        },
+        "acceptance_event_id": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/acceptance_event_id"
+        },
+        "recorded_at": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/recorded_at"
+        },
+        "record_event_id": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/record_event_id"
+        },
+        "benchmark_commit": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/benchmark_commit"
+        },
+        "production_metadata": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/production_metadata"
+        },
+        "replay": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/replay"
+        },
+        "release": {
+          "oneOf": [{ "$ref": "#/$defs/release" }, { "type": "null" }]
+        },
+        "public_solution": {
+          "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/public_solution"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public-state-projection-v4.schema.json
+++ b/schemas/public-state-projection-v4.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lean-lang.org/schemas/lean-eval/public-state-projection-v4.schema.json",
+  "title": "lean-eval public State projection schema version 4",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "environment", "source_state_commit", "source_event_count",
+    "source_digest", "results", "result_overlays", "model_identities",
+    "model_aliases", "model_identity_history"
+  ],
+  "properties": {
+    "schema_version": { "const": 4 },
+    "environment": { "$ref": "public-state-projection-v3.schema.json#/properties/environment" },
+    "source_state_commit": { "$ref": "public-state-projection-v3.schema.json#/properties/source_state_commit" },
+    "source_event_count": { "$ref": "public-state-projection-v3.schema.json#/properties/source_event_count" },
+    "source_digest": { "$ref": "public-state-projection-v3.schema.json#/properties/source_digest" },
+    "results": { "type": "array", "items": { "$ref": "#/$defs/result" } },
+    "result_overlays": { "type": "array", "items": { "$ref": "#/$defs/overlay" } },
+    "model_identities": { "type": "array", "items": { "$ref": "#/$defs/identity" } },
+    "model_aliases": { "type": "array", "items": { "$ref": "#/$defs/alias" } },
+    "model_identity_history": { "type": "array", "items": { "$ref": "#/$defs/history" } }
+  },
+  "$defs": {
+    "modelId": { "type": "string", "pattern": "^mi1_[0-9a-f]{64}$" },
+    "aliasKey": { "type": "string", "pattern": "^ma1_[0-9a-f]{64}$" },
+    "login": { "type": "string", "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$" },
+    "label": {
+      "type": "string", "minLength": 1, "maxLength": 256,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$", "x-utf8-maxBytes": 256
+    },
+    "reason": {
+      "type": "string", "pattern": "^[a-z][a-z0-9_]{1,63}$"
+    },
+    "timestamp": {
+      "type": "string", "format": "date-time",
+      "pattern": "^(?!0000-)[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$"
+    },
+    "nullableModelId": { "oneOf": [{ "$ref": "#/$defs/modelId" }, { "type": "null" }] },
+    "nullableEventId": {
+      "oneOf": [
+        { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        { "type": "null" }
+      ]
+    },
+    "nullableTimestamp": {
+      "oneOf": [
+        { "$ref": "#/$defs/timestamp" },
+        { "type": "null" }
+      ]
+    },
+    "nullableLabel": {
+      "oneOf": [{ "$ref": "#/$defs/label" }, { "type": "null" }]
+    },
+    "nullableReason": {
+      "oneOf": [{ "$ref": "#/$defs/reason" }, { "type": "null" }]
+    },
+    "result": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "result_id", "problem_id", "statement_revision", "declared_model", "submitter",
+        "accepted_at", "acceptance_event_id", "recorded_at", "record_event_id",
+        "benchmark_commit", "production_metadata", "replay", "release", "public_solution",
+        "model_id", "resolved_model_id"
+      ],
+      "properties": {
+        "result_id": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/result_id" },
+        "problem_id": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/problem_id" },
+        "statement_revision": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/statement_revision" },
+        "declared_model": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/declared_model" },
+        "submitter": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/submitter" },
+        "accepted_at": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/accepted_at" },
+        "acceptance_event_id": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/acceptance_event_id" },
+        "recorded_at": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/recorded_at" },
+        "record_event_id": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/record_event_id" },
+        "benchmark_commit": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/benchmark_commit" },
+        "production_metadata": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/production_metadata" },
+        "replay": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/replay" },
+        "release": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/release" },
+        "public_solution": { "$ref": "public-state-projection-v3.schema.json#/$defs/result/properties/public_solution" },
+        "model_id": { "$ref": "#/$defs/nullableModelId" },
+        "resolved_model_id": { "$ref": "#/$defs/nullableModelId" }
+      }
+    },
+    "overlay": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "result_id", "owner_login", "declared_model", "problem_id",
+        "statement_revision", "claim_event_id", "mutation_event_id", "claimed_at",
+        "metadata", "model_id", "resolved_model_id"
+      ],
+      "properties": {
+        "result_id": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/result_id" },
+        "owner_login": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/owner_login" },
+        "declared_model": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/declared_model" },
+        "problem_id": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/problem_id" },
+        "statement_revision": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/statement_revision" },
+        "claim_event_id": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/claim_event_id" },
+        "mutation_event_id": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/mutation_event_id" },
+        "claimed_at": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/claimed_at" },
+        "metadata": { "$ref": "public-state-projection-v2.schema.json#/$defs/overlay/properties/metadata" },
+        "model_id": { "$ref": "#/$defs/nullableModelId" },
+        "resolved_model_id": { "$ref": "#/$defs/nullableModelId" }
+      }
+    },
+    "identity": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "model_id", "owner_login", "requested_name", "display_name", "status",
+        "request_event_id", "requested_at", "decision_event_id", "decided_at",
+        "reviewer_login", "rejection_reason", "mutation_event_id",
+        "consolidated_into", "resolved_model_id"
+      ],
+      "properties": {
+        "model_id": { "$ref": "#/$defs/modelId" },
+        "owner_login": { "$ref": "#/$defs/login" },
+        "requested_name": { "$ref": "#/$defs/label" },
+        "display_name": { "$ref": "#/$defs/label" },
+        "status": { "enum": ["pending", "approved", "rejected", "consolidated"] },
+        "request_event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        "requested_at": { "$ref": "#/$defs/timestamp" },
+        "decision_event_id": { "$ref": "#/$defs/nullableEventId" },
+        "decided_at": { "$ref": "#/$defs/nullableTimestamp" },
+        "reviewer_login": { "oneOf": [{ "$ref": "#/$defs/login" }, { "type": "null" }] },
+        "rejection_reason": { "$ref": "#/$defs/nullableReason" },
+        "mutation_event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        "consolidated_into": { "$ref": "#/$defs/nullableModelId" },
+        "resolved_model_id": { "$ref": "#/$defs/nullableModelId" }
+      }
+    },
+    "alias": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "alias_key", "owner_login", "alias", "model_id", "resolved_model_id",
+        "assignment_event_id", "assigned_at"
+      ],
+      "properties": {
+        "alias_key": { "$ref": "#/$defs/aliasKey" },
+        "owner_login": { "$ref": "#/$defs/login" },
+        "alias": { "$ref": "#/$defs/label" },
+        "model_id": { "$ref": "#/$defs/modelId" },
+        "resolved_model_id": { "$ref": "#/$defs/modelId" },
+        "assignment_event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        "assigned_at": { "$ref": "#/$defs/timestamp" }
+      }
+    },
+    "history": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "event_id", "event_type", "model_id", "occurred_at", "causation_event_id",
+        "actor_login", "display_name", "alias", "target_model_id", "reviewer_login",
+        "reason_code"
+      ],
+      "properties": {
+        "event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        "event_type": {
+          "enum": [
+            "model_identity.requested", "model_identity.approved",
+            "model_identity.rejected", "model_identity.alias_assigned",
+            "model_identity.renamed", "model_identity.consolidated"
+          ]
+        },
+        "model_id": { "$ref": "#/$defs/modelId" },
+        "occurred_at": { "$ref": "#/$defs/timestamp" },
+        "causation_event_id": { "$ref": "#/$defs/nullableEventId" },
+        "actor_login": { "oneOf": [{ "$ref": "#/$defs/login" }, { "type": "null" }] },
+        "display_name": { "$ref": "#/$defs/nullableLabel" },
+        "alias": { "$ref": "#/$defs/nullableLabel" },
+        "target_model_id": { "$ref": "#/$defs/nullableModelId" },
+        "reviewer_login": { "oneOf": [{ "$ref": "#/$defs/login" }, { "type": "null" }] },
+        "reason_code": { "$ref": "#/$defs/nullableReason" }
+      }
+    }
+  }
+}

--- a/schemas/result-overlays-v1.schema.json
+++ b/schemas/result-overlays-v1.schema.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lean-lang.org/schemas/lean-eval/result-overlays-v1.schema.json",
+  "title": "lean-eval deterministic legacy-result overlay view schema version 1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "environment", "source_event_count", "source_digest",
+    "overlays"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "environment": { "enum": ["staging", "production"] },
+    "source_event_count": { "type": "integer", "minimum": 1 },
+    "source_digest": { "$ref": "#/$defs/digest" },
+    "overlays": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/overlay" }
+    }
+  },
+  "$defs": {
+    "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "eventId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "resultId": { "type": "string", "pattern": "^r2_[0-9a-f]{64}$" },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^(?!0000-)[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}Z$"
+    },
+    "text": {
+      "type": "string", "minLength": 1,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "baseResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "declared_model", "problem_id", "statement_revision",
+        "results_repository", "results_commit", "results_path",
+        "canonical_record_sha256"
+      ],
+      "properties": {
+        "declared_model": {
+          "x-utf8-maxBytes": 256,
+          "allOf": [
+            { "$ref": "#/$defs/text" },
+            { "type": "string", "maxLength": 256 }
+          ]
+        },
+        "problem_id": {
+          "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$"
+        },
+        "statement_revision": {
+          "type": "integer", "minimum": 1, "maximum": 9007199254740991
+        },
+        "results_repository": { "const": "leanprover/lean-eval-submissions" },
+        "results_commit": { "$ref": "#/$defs/commit" },
+        "results_path": {
+          "type": "string", "pattern": "^results/[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?\\.json$"
+        },
+        "canonical_record_sha256": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "provenance", "event_id", "recorded_at"],
+      "properties": {
+        "value": {},
+        "provenance": { "const": "backfilled" },
+        "event_id": { "$ref": "#/$defs/eventId" },
+        "recorded_at": { "$ref": "#/$defs/timestamp" }
+      }
+    },
+    "text256Provenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "allOf": [
+                { "$ref": "#/$defs/text" },
+                { "type": "string", "maxLength": 256 }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "text1024Provenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "allOf": [
+                { "$ref": "#/$defs/text" },
+                { "type": "string", "maxLength": 1024 }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "text4096Provenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "allOf": [
+                { "$ref": "#/$defs/text" },
+                { "type": "string", "maxLength": 4096 }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "text8192Provenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "allOf": [
+                { "$ref": "#/$defs/text" },
+                { "type": "string", "maxLength": 8192 }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "componentModelsProvenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "array", "maxItems": 16,
+              "items": {
+                "allOf": [
+                  { "$ref": "#/$defs/text" },
+                  { "type": "string", "maxLength": 256 }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "booleanProvenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": { "value": { "type": "boolean" } }
+        }
+      ]
+    },
+    "wallTimeProvenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": { "type": "number", "minimum": 0, "maximum": 31536000 }
+          }
+        }
+      ]
+    },
+    "tokenProvenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "integer", "minimum": 0, "maximum": 9007199254740991
+            }
+          }
+        }
+      ]
+    },
+    "costProvenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": { "type": "number", "minimum": 0, "maximum": 1000000 }
+          }
+        }
+      ]
+    },
+    "billingProvenance": {
+      "allOf": [
+        { "$ref": "#/$defs/provenance" },
+        {
+          "type": "object",
+          "properties": {
+            "value": { "enum": ["api", "subscription", "unknown"] }
+          }
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "credit_identity": { "$ref": "#/$defs/text256Provenance" },
+        "component_models": { "$ref": "#/$defs/componentModelsProvenance" },
+        "harness": { "$ref": "#/$defs/text1024Provenance" },
+        "human_involvement": { "$ref": "#/$defs/text1024Provenance" },
+        "web_access": { "$ref": "#/$defs/booleanProvenance" },
+        "wall_time_seconds": { "$ref": "#/$defs/wallTimeProvenance" },
+        "input_tokens": { "$ref": "#/$defs/tokenProvenance" },
+        "output_tokens": { "$ref": "#/$defs/tokenProvenance" },
+        "cost_usd": { "$ref": "#/$defs/costProvenance" },
+        "billing_mode": { "$ref": "#/$defs/billingProvenance" },
+        "prompt": { "$ref": "#/$defs/text8192Provenance" },
+        "notes": { "$ref": "#/$defs/text4096Provenance" }
+      }
+    },
+    "overlay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version", "result_id", "owner_login", "claim_event_id",
+        "mutation_event_id", "claimed_at", "base_result", "metadata"
+      ],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "result_id": { "$ref": "#/$defs/resultId" },
+        "owner_login": {
+          "type": "string",
+          "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$"
+        },
+        "claim_event_id": { "$ref": "#/$defs/eventId" },
+        "mutation_event_id": { "$ref": "#/$defs/eventId" },
+        "claimed_at": { "$ref": "#/$defs/timestamp" },
+        "base_result": { "$ref": "#/$defs/baseResult" },
+        "metadata": { "$ref": "#/$defs/metadata" }
+      }
+    }
+  }
+}

--- a/schemas/site-data-v2.schema.json
+++ b/schemas/site-data-v2.schema.json
@@ -45,7 +45,7 @@
         "benchmark": {"type": "object", "required": ["repo", "commit"]},
         "state": {"type": "object", "required": ["repo", "commit", "materialized", "environment", "source_event_count", "source_digest"]},
         "default_group": {"$ref": "#/$defs/groupId"},
-        "model_aliases": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["declared_label", "canonical_id", "label"], "properties": {"declared_label": {"$ref": "#/$defs/nonempty"}, "canonical_id": {"$ref": "#/$defs/nonempty"}, "label": {"$ref": "#/$defs/nonempty"}}}},
+        "model_aliases": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["declared_label", "canonical_id", "label"], "properties": {"owner_login": {"$ref": "#/$defs/nonempty"}, "declared_label": {"$ref": "#/$defs/nonempty"}, "model_id": {"$ref": "#/$defs/nonempty"}, "canonical_id": {"$ref": "#/$defs/nonempty"}, "label": {"$ref": "#/$defs/nonempty"}, "assignment_event_id": {"$ref": "#/$defs/nonempty"}}}},
         "groups": {"type": "array", "minItems": 3, "maxItems": 3, "items": {"type": "object", "required": ["id", "label", "policy", "default_scope", "problem_count", "solution_count", "data_url", "url"]}},
         "recent_solutions_url": {"$ref": "#/$defs/nonempty"},
         "recent_solutions_rss_url": {"$ref": "#/$defs/nonempty"},

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -67,6 +67,9 @@ BENCHMARK_COMMIT_FILE = REPO_ROOT / "benchmark-snapshot" / ".benchmark-commit"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 PROBLEM_ID_RE = re.compile(r"^[A-Za-z0-9_]+$")
 TAG_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+RESULT_USER_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"
+)
 ROOT_DECLARATIONS_BY_PROBLEM = {
     "annals_dirichlet_weyl_bound": {"Nat.IsCubeFree"},
 }
@@ -342,7 +345,17 @@ def load_results(results_root: pathlib.Path) -> list[dict[str, Any]]:
         return []
     results: list[dict[str, Any]] = []
     for path in sorted(results_root.glob("*.json")):
-        results.append(load_json(path))
+        document = load_json(path)
+        user = document.get("user") if isinstance(document, dict) else None
+        if (
+            not isinstance(user, str)
+            or RESULT_USER_RE.fullmatch(user) is None
+            or user.lower() != path.stem.lower()
+        ):
+            raise SystemExit(
+                f"{path}: results owner must be a canonical login matching its filename"
+            )
+        results.append(document)
     return results
 
 
@@ -360,7 +373,9 @@ def normalized_result_records(
 
     version = user_record.get("schema_version")
     if version == 1:
-        user = str(user_record["user"])
+        user = user_record.get("user")
+        if not isinstance(user, str) or RESULT_USER_RE.fullmatch(user) is None:
+            raise SystemExit(f"{context}: user must be a canonical GitHub login")
         normalized: list[dict[str, Any]] = []
         solved_per_model = user_record.get("solved", {})
         for raw_model_name, problems_for_model in solved_per_model.items():

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse
@@ -10,36 +9,39 @@ import shutil
 import subprocess
 import sys
 import time
-import tomllib
 import urllib.request
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+import tomllib
+
 try:
-    from scripts.results_schema import (
-        ResultsSchemaError,
-        parse_schema_version_2_file,
-    )
     from scripts.lifecycle_site_data import (
         adapt_results_store,
         adapt_state_projection,
         build_lifecycle_projection,
+        build_model_identity_index,
         load_preview_fixture,
         load_set_definitions,
         merge_solutions,
     )
+    from scripts.results_schema import (
+        ResultsSchemaError,
+        parse_schema_version_2_file,
+    )
 except ModuleNotFoundError:
-    from results_schema import ResultsSchemaError, parse_schema_version_2_file
     from lifecycle_site_data import (
         adapt_results_store,
         adapt_state_projection,
         build_lifecycle_projection,
+        build_model_identity_index,
         load_preview_fixture,
         load_set_definitions,
         merge_solutions,
     )
+    from results_schema import ResultsSchemaError, parse_schema_version_2_file
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -448,7 +450,7 @@ def collect_local_declarations(lines: list[str]) -> dict[str, str]:
     declarations: dict[str, str] = {}
     for line in lines:
         stripped = line.strip()
-        if not stripped or stripped.startswith("/-") or stripped.startswith("--"):
+        if not stripped or stripped.startswith(("/-", "--")):
             continue
         if stripped.startswith("namespace "):
             parts = stripped.split()
@@ -1012,7 +1014,6 @@ def build_leaderboard_payload(
 
         notable = sorted(solved_items, key=rarity_sort_key)
         for rank, item in enumerate(notable, start=1):
-            problem = problem_map.get(item["problem_id"])
             recency_component = int(timestamp_key(item["solved_at"]) // 86400)
             item["rarity_rank"] = rank
             item["rarity_score"] = (total_models - solving_model_counts[item["problem_id"]]) * 1_000_000 + recency_component
@@ -1289,8 +1290,13 @@ def main() -> int:
         raise SystemExit("State projection source_state_commit does not match --state-repo HEAD")
     if state_projection is not None:
         write_json(output_dir / "public-state.json", state_projection)
-    fallback_solutions = adapt_results_store(normalized_files, aliases)
-    state_solutions = adapt_state_projection(state_projection, aliases)
+    model_identities = build_model_identity_index(state_projection)
+    fallback_solutions = adapt_results_store(
+        normalized_files, aliases, model_identities
+    )
+    state_solutions = adapt_state_projection(
+        state_projection, aliases, model_identities
+    )
     lifecycle_files = build_lifecycle_projection(
         problems=problems,
         solutions=merge_solutions(state_solutions, fallback_solutions),
@@ -1302,6 +1308,7 @@ def main() -> int:
         state_commit=state_commit,
         state_metadata=state_projection,
         site_base_url=args.site_base_url,
+        model_aliases=model_identities.public_aliases,
     )
     for relative_path, payload in lifecycle_files.items():
         destination = output_dir / relative_path

--- a/scripts/lifecycle_site_data.py
+++ b/scripts/lifecycle_site_data.py
@@ -14,10 +14,11 @@ import json
 import pathlib
 import re
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 from html import escape as xml_escape
+from types import MappingProxyType
 from typing import Any
 from urllib.parse import quote
 
@@ -90,11 +91,11 @@ class SetDefinition:
 
 @dataclass(frozen=True)
 class ModelIdentityIndex:
-    aliases: dict[tuple[str, str], tuple[str, str, str]]
+    aliases: Mapping[tuple[str, str], tuple[str, str, str]]
     public_aliases: tuple[dict[str, str], ...]
 
 
-EMPTY_MODEL_IDENTITY_INDEX = ModelIdentityIndex({}, ())
+EMPTY_MODEL_IDENTITY_INDEX = ModelIdentityIndex(MappingProxyType({}), ())
 
 
 @dataclass
@@ -115,6 +116,7 @@ class Solution:
     replay: dict[str, Any]
     measurements: list[dict[str, Any]] = field(default_factory=list)
     release: dict[str, Any] = field(default_factory=dict)
+    model_identity_reviewed: bool = False
 
 
 def load_preview_fixture(path: pathlib.Path | None) -> dict[str, Any]:
@@ -277,6 +279,21 @@ def build_model_identity_index(raw: dict[str, Any] | None) -> ModelIdentityIndex
             raise SystemExit(
                 "State projection: incoherent model identity resolution"
             )
+        if status == "consolidated":
+            current = model_id
+            seen: set[str] = set()
+            while current != resolved_id:
+                if current in seen:
+                    raise SystemExit(
+                        "State projection: cyclic model identity consolidation"
+                    )
+                seen.add(current)
+                current_identity = identities.get(current)
+                if current_identity is None:
+                    raise SystemExit(
+                        "State projection: missing model identity consolidation target"
+                    )
+                current = current_identity["consolidated_into"]
 
     aliases: dict[tuple[str, str], tuple[str, str, str]] = {}
     summaries: list[dict[str, str]] = []
@@ -315,9 +332,12 @@ def build_model_identity_index(raw: dict[str, Any] | None) -> ModelIdentityIndex
         aliases[key] = (model_id, resolved_id, label)
         summaries.append(
             {
+                "owner_login": owner,
                 "declared_label": declared,
+                "model_id": model_id,
                 "canonical_id": resolved_id,
                 "label": label,
+                "assignment_event_id": alias["assignment_event_id"],
             }
         )
     return ModelIdentityIndex(
@@ -326,7 +346,8 @@ def build_model_identity_index(raw: dict[str, Any] | None) -> ModelIdentityIndex
             sorted(
                 summaries,
                 key=lambda item: (
-                    item["canonical_id"], item["declared_label"], item["label"]
+                    item["owner_login"], item["declared_label"],
+                    item["canonical_id"], item["label"]
                 ),
             )
         ),
@@ -337,9 +358,14 @@ def _canonical_identity(
     owner_login: str,
     declared_model: str,
     aliases: dict[str, dict[str, str]],
-    model_identities: ModelIdentityIndex = EMPTY_MODEL_IDENTITY_INDEX,
+    model_identities: ModelIdentityIndex | None = None,
 ) -> tuple[str, str]:
-    state_alias = model_identities.aliases.get(
+    identity_index = (
+        model_identities
+        if model_identities is not None
+        else EMPTY_MODEL_IDENTITY_INDEX
+    )
+    state_alias = identity_index.aliases.get(
         (owner_login.lower(), declared_model)
     )
     if state_alias is not None:
@@ -354,7 +380,7 @@ def _canonical_identity(
 def adapt_results_store(
     normalized_files: list[tuple[str, list[dict[str, Any]]]],
     aliases: dict[str, dict[str, str]],
-    model_identities: ModelIdentityIndex = EMPTY_MODEL_IDENTITY_INDEX,
+    model_identities: ModelIdentityIndex | None = None,
 ) -> list[Solution]:
     """Adapt the legacy/base results store into the materialized domain shape."""
 
@@ -362,9 +388,17 @@ def adapt_results_store(
     for user, records in normalized_files:
         for record in records:
             raw_declared = record["declared_model"]
-            declared = _normalized_model(raw_declared)
+            declared = raw_declared
+            identity_index = (
+                model_identities
+                if model_identities is not None
+                else EMPTY_MODEL_IDENTITY_INDEX
+            )
+            reviewed = (
+                user.lower(), raw_declared
+            ) in identity_index.aliases
             canonical_id, canonical_label = _canonical_identity(
-                user, raw_declared, aliases, model_identities
+                user, raw_declared, aliases, identity_index
             )
             intake = record["intake"]
             submission = record["submission"]
@@ -420,6 +454,7 @@ def adapt_results_store(
                         "url": url,
                         "reason": None if public else "not-materialized",
                     },
+                    model_identity_reviewed=reviewed,
                 )
             )
     return out
@@ -460,7 +495,11 @@ def adapt_state_projection(
     )
     if set(raw) != expected_top_fields:
         raise SystemExit("State projection: invalid top-level fields")
-    identity_index = model_identities or build_model_identity_index(raw)
+    identity_index = (
+        model_identities
+        if model_identities is not None
+        else build_model_identity_index(raw)
+    )
     solutions: list[Solution] = []
     for result in raw.get("results", []):
         required = {
@@ -474,7 +513,7 @@ def adapt_state_projection(
         if not isinstance(result, dict) or set(result) != required:
             raise SystemExit("State projection: invalid result fields")
         raw_declared = str(result["declared_model"])
-        declared = _normalized_model(raw_declared)
+        declared = raw_declared
         if result["result_id"] != expected_result_id(
             result["submitter"],
             result["declared_model"],
@@ -485,10 +524,10 @@ def adapt_state_projection(
         canonical_id, canonical_label = _canonical_identity(
             str(result["submitter"]), raw_declared, aliases, identity_index
         )
+        state_resolution = identity_index.aliases.get(
+            (str(result["submitter"]).lower(), raw_declared)
+        )
         if version == 4:
-            state_resolution = identity_index.aliases.get(
-                (str(result["submitter"]).lower(), raw_declared)
-            )
             projected_resolution = (
                 result["model_id"], result["resolved_model_id"]
             )
@@ -585,6 +624,7 @@ def adapt_state_projection(
                 replay=replay_view,
                 measurements=measurements,
                 release=release_view,
+                model_identity_reviewed=state_resolution is not None,
             )
         )
     return solutions
@@ -865,9 +905,9 @@ def build_lifecycle_projection(
     published_model_aliases = list(model_aliases) or fixture.get(
         "model_aliases", []
     )
-    if not published_model_aliases:
+    if any(not solution.model_identity_reviewed for solution in solutions):
         limitations.append(
-            "No reviewed model-alias policy is published; normalized declared model labels are used as canonical credit identities."
+            "Some results have no reviewed State model alias; their normalized declared model labels are used as fallback credit identities."
         )
 
     files: dict[str, Any] = {}

--- a/scripts/lifecycle_site_data.py
+++ b/scripts/lifecycle_site_data.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Build the split, client-facing lifecycle-aware leaderboard projection.
 
 The adapter consumes only State's redacted public projection. It never reads
@@ -15,10 +14,11 @@ import json
 import pathlib
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from html import escape as xml_escape
-from typing import Any, Iterable
+from typing import Any
 from urllib.parse import quote
 
 try:
@@ -52,6 +52,14 @@ STATUS_LABELS = {
     "resolved": "Resolved",
 }
 SLUG_RE = re.compile(r"[^a-z0-9]+")
+MODEL_ID_RE = re.compile(r"mi1_[0-9a-f]{64}")
+ALIAS_KEY_RE = re.compile(r"ma1_[0-9a-f]{64}")
+LOGIN_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?")
+EVENT_ID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+)
+MODEL_ID_DOMAIN = b"lean-eval-model-identity-v1\0"
+ALIAS_KEY_DOMAIN = b"lean-eval-model-alias-v1\0"
 
 
 def _slug(value: str) -> str:
@@ -67,7 +75,7 @@ def _stable_legacy_id(parts: Iterable[object]) -> str:
     return "legacy_" + hashlib.sha256(encoded).hexdigest()
 
 
-def _acceptance_key(solution: "Solution") -> tuple[str, str, str]:
+def _acceptance_key(solution: Solution) -> tuple[str, str, str]:
     return (solution.accepted_at, solution.acceptance_event_id, solution.result_id)
 
 
@@ -78,6 +86,15 @@ class SetDefinition:
     frozen: bool
     published_at: str | None
     members: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True)
+class ModelIdentityIndex:
+    aliases: dict[tuple[str, str], tuple[str, str, str]]
+    public_aliases: tuple[dict[str, str], ...]
+
+
+EMPTY_MODEL_IDENTITY_INDEX = ModelIdentityIndex({}, ())
 
 
 @dataclass
@@ -167,9 +184,166 @@ def _metadata_fields(values: dict[str, Any], provenance: str) -> dict[str, dict[
     }
 
 
+def _model_identity_id(request_event_id: str) -> str:
+    return "mi1_" + hashlib.sha256(
+        MODEL_ID_DOMAIN + request_event_id.encode("ascii")
+    ).hexdigest()
+
+
+def _model_alias_key(owner_login: str, alias: str) -> str:
+    canonical = json.dumps(
+        [owner_login, alias],
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "ma1_" + hashlib.sha256(ALIAS_KEY_DOMAIN + canonical).hexdigest()
+
+
+def _model_label(value: Any, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value.encode("utf-8")) > 256
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise SystemExit(f"State projection: invalid {label}")
+    return value
+
+
+def build_model_identity_index(raw: dict[str, Any] | None) -> ModelIdentityIndex:
+    """Validate and index the owner-scoped identity subset of projection v4."""
+
+    if raw is None or raw.get("schema_version") == 1:
+        return EMPTY_MODEL_IDENTITY_INDEX
+    if raw.get("schema_version") != 4:
+        raise SystemExit("State domain: unsupported schema_version")
+    identities: dict[str, dict[str, Any]] = {}
+    identity_fields = {
+        "model_id", "owner_login", "requested_name", "display_name", "status",
+        "request_event_id", "requested_at", "decision_event_id", "decided_at",
+        "reviewer_login", "rejection_reason", "mutation_event_id",
+        "consolidated_into", "resolved_model_id",
+    }
+    for identity in raw.get("model_identities", []):
+        if not isinstance(identity, dict) or set(identity) != identity_fields:
+            raise SystemExit("State projection: invalid model identity fields")
+        model_id = identity["model_id"]
+        owner = identity["owner_login"]
+        request_event_id = identity["request_event_id"]
+        if (
+            not isinstance(model_id, str)
+            or MODEL_ID_RE.fullmatch(model_id) is None
+            or not isinstance(owner, str)
+            or LOGIN_RE.fullmatch(owner) is None
+            or not isinstance(request_event_id, str)
+            or EVENT_ID_RE.fullmatch(request_event_id) is None
+            or model_id in identities
+            or model_id != _model_identity_id(request_event_id)
+        ):
+            raise SystemExit("State projection: invalid model identity")
+        _model_label(identity["requested_name"], "requested model name")
+        _model_label(identity["display_name"], "model display name")
+        if identity["status"] not in {
+            "pending", "approved", "rejected", "consolidated"
+        }:
+            raise SystemExit("State projection: invalid model identity status")
+        identities[model_id] = identity
+
+    for model_id, identity in identities.items():
+        status = identity["status"]
+        consolidated_into = identity["consolidated_into"]
+        resolved_id = identity["resolved_model_id"]
+        if status == "approved":
+            valid = consolidated_into is None and resolved_id == model_id
+        elif status == "consolidated":
+            direct_target = identities.get(consolidated_into)
+            target = identities.get(resolved_id)
+            valid = (
+                isinstance(consolidated_into, str)
+                and MODEL_ID_RE.fullmatch(consolidated_into) is not None
+                and direct_target is not None
+                and target is not None
+                and direct_target["owner_login"] == identity["owner_login"]
+                and direct_target["resolved_model_id"] == resolved_id
+                and target["owner_login"] == identity["owner_login"]
+                and target["status"] == "approved"
+                and consolidated_into != model_id
+                and target["model_id"] == resolved_id
+            )
+        else:
+            valid = consolidated_into is None and resolved_id is None
+        if not valid:
+            raise SystemExit(
+                "State projection: incoherent model identity resolution"
+            )
+
+    aliases: dict[tuple[str, str], tuple[str, str, str]] = {}
+    summaries: list[dict[str, str]] = []
+    alias_fields = {
+        "alias_key", "owner_login", "alias", "model_id", "resolved_model_id",
+        "assignment_event_id", "assigned_at",
+    }
+    for alias in raw.get("model_aliases", []):
+        if not isinstance(alias, dict) or set(alias) != alias_fields:
+            raise SystemExit("State projection: invalid model alias fields")
+        owner = alias["owner_login"]
+        declared = _model_label(alias["alias"], "model alias")
+        alias_key = alias["alias_key"]
+        model_id = alias["model_id"]
+        resolved_id = alias["resolved_model_id"]
+        source = identities.get(model_id)
+        target = identities.get(resolved_id)
+        key = (owner, declared)
+        if (
+            not isinstance(owner, str)
+            or LOGIN_RE.fullmatch(owner) is None
+            or not isinstance(alias_key, str)
+            or ALIAS_KEY_RE.fullmatch(alias_key) is None
+            or alias_key != _model_alias_key(owner, declared)
+            or key in aliases
+            or source is None
+            or target is None
+            or source["owner_login"] != owner
+            or target["owner_login"] != owner
+            or source["resolved_model_id"] != resolved_id
+            or target["resolved_model_id"] != resolved_id
+            or target["status"] != "approved"
+        ):
+            raise SystemExit("State projection: invalid model alias binding")
+        label = _model_label(target["display_name"], "resolved model display name")
+        aliases[key] = (model_id, resolved_id, label)
+        summaries.append(
+            {
+                "declared_label": declared,
+                "canonical_id": resolved_id,
+                "label": label,
+            }
+        )
+    return ModelIdentityIndex(
+        aliases,
+        tuple(
+            sorted(
+                summaries,
+                key=lambda item: (
+                    item["canonical_id"], item["declared_label"], item["label"]
+                ),
+            )
+        ),
+    )
+
+
 def _canonical_identity(
-    declared_model: str, aliases: dict[str, dict[str, str]]
+    owner_login: str,
+    declared_model: str,
+    aliases: dict[str, dict[str, str]],
+    model_identities: ModelIdentityIndex = EMPTY_MODEL_IDENTITY_INDEX,
 ) -> tuple[str, str]:
+    state_alias = model_identities.aliases.get(
+        (owner_login.lower(), declared_model)
+    )
+    if state_alias is not None:
+        return state_alias[1], state_alias[2]
     normalized = _normalized_model(declared_model)
     alias = aliases.get(normalized)
     if alias is None:
@@ -180,14 +354,18 @@ def _canonical_identity(
 def adapt_results_store(
     normalized_files: list[tuple[str, list[dict[str, Any]]]],
     aliases: dict[str, dict[str, str]],
+    model_identities: ModelIdentityIndex = EMPTY_MODEL_IDENTITY_INDEX,
 ) -> list[Solution]:
     """Adapt the legacy/base results store into the materialized domain shape."""
 
     out: list[Solution] = []
     for user, records in normalized_files:
         for record in records:
-            declared = _normalized_model(record["declared_model"])
-            canonical_id, canonical_label = _canonical_identity(declared, aliases)
+            raw_declared = record["declared_model"]
+            declared = _normalized_model(raw_declared)
+            canonical_id, canonical_label = _canonical_identity(
+                user, raw_declared, aliases, model_identities
+            )
             intake = record["intake"]
             submission = record["submission"]
             result_id = record.get("result_id") or _stable_legacy_id(
@@ -250,12 +428,14 @@ def adapt_results_store(
 def adapt_state_projection(
     raw: dict[str, Any] | None,
     aliases: dict[str, dict[str, str]],
+    model_identities: ModelIdentityIndex | None = None,
 ) -> list[Solution]:
-    """Normalize ``public-state-projection-v1`` without private State fields."""
+    """Normalize redacted State projection v1 or identity-aware v4."""
 
     if raw is None:
         return []
-    if raw.get("schema_version") != 1:
+    version = raw.get("schema_version")
+    if version not in {1, 4}:
         raise SystemExit("State domain: unsupported schema_version")
     if raw.get("environment") not in {"production", "staging"}:
         raise SystemExit("State domain: invalid environment")
@@ -265,11 +445,22 @@ def adapt_state_projection(
         raise SystemExit("State domain: invalid source_digest")
     if not re.fullmatch(r"[0-9a-f]{40}", str(raw.get("source_state_commit", ""))):
         raise SystemExit("State projection: invalid source_state_commit")
-    if set(raw) != {
+    common_fields = {
         "schema_version", "environment", "source_state_commit",
         "source_event_count", "source_digest", "results",
-    }:
+    }
+    expected_top_fields = (
+        common_fields
+        if version == 1
+        else common_fields
+        | {
+            "result_overlays", "model_identities", "model_aliases",
+            "model_identity_history",
+        }
+    )
+    if set(raw) != expected_top_fields:
         raise SystemExit("State projection: invalid top-level fields")
+    identity_index = model_identities or build_model_identity_index(raw)
     solutions: list[Solution] = []
     for result in raw.get("results", []):
         required = {
@@ -278,9 +469,12 @@ def adapt_state_projection(
             "record_event_id", "benchmark_commit", "production_metadata", "replay",
             "release", "public_solution",
         }
+        if version == 4:
+            required |= {"model_id", "resolved_model_id"}
         if not isinstance(result, dict) or set(result) != required:
             raise SystemExit("State projection: invalid result fields")
-        declared = _normalized_model(str(result["declared_model"]))
+        raw_declared = str(result["declared_model"])
+        declared = _normalized_model(raw_declared)
         if result["result_id"] != expected_result_id(
             result["submitter"],
             result["declared_model"],
@@ -288,7 +482,25 @@ def adapt_state_projection(
             result["statement_revision"],
         ):
             raise SystemExit("State projection: result_id does not match its identity fields")
-        canonical_id, canonical_label = _canonical_identity(declared, aliases)
+        canonical_id, canonical_label = _canonical_identity(
+            str(result["submitter"]), raw_declared, aliases, identity_index
+        )
+        if version == 4:
+            state_resolution = identity_index.aliases.get(
+                (str(result["submitter"]).lower(), raw_declared)
+            )
+            projected_resolution = (
+                result["model_id"], result["resolved_model_id"]
+            )
+            expected_resolution = (
+                (None, None)
+                if state_resolution is None
+                else (state_resolution[0], state_resolution[1])
+            )
+            if projected_resolution != expected_resolution:
+                raise SystemExit(
+                    "State projection: result model identity binding is inconsistent"
+                )
         replay = result["replay"]
         if replay is None:
             replay_view = {"status": "unavailable", "reason": "not-enqueued"}
@@ -600,6 +812,7 @@ def build_lifecycle_projection(
     state_commit: str | None,
     state_metadata: dict[str, Any] | None,
     site_base_url: str,
+    model_aliases: tuple[dict[str, str], ...] = (),
 ) -> dict[str, Any]:
     """Return path→payload for every schema-version-2 JSON file and RSS."""
 
@@ -649,7 +862,10 @@ def build_lifecycle_projection(
         limitations.append(
             "Catalog lifecycle history beyond the current pinned manifest is unavailable; the site shows the current status as a one-entry history."
         )
-    if not fixture.get("model_aliases"):
+    published_model_aliases = list(model_aliases) or fixture.get(
+        "model_aliases", []
+    )
+    if not published_model_aliases:
         limitations.append(
             "No reviewed model-alias policy is published; normalized declared model labels are used as canonical credit identities."
         )
@@ -820,8 +1036,10 @@ def build_lifecycle_projection(
         },
         "default_group": "formalization-evaluation",
         "model_aliases": sorted(
-            fixture.get("model_aliases", []),
-            key=lambda alias: (alias["canonical_id"], alias["declared_label"]),
+            published_model_aliases,
+            key=lambda alias: (
+                alias["canonical_id"], alias["declared_label"], alias["label"]
+            ),
         ),
         "groups": group_indexes,
         "recent_solutions_url": "site-data/v2/recent-solutions.json",

--- a/tests/fixtures/public-state-projection-v4-model-identity.json
+++ b/tests/fixtures/public-state-projection-v4-model-identity.json
@@ -239,4 +239,3 @@
   "source_event_count": 22,
   "source_state_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 }
-

--- a/tests/fixtures/public-state-projection-v4-model-identity.json
+++ b/tests/fixtures/public-state-projection-v4-model-identity.json
@@ -1,0 +1,242 @@
+{
+  "environment": "production",
+  "model_aliases": [
+    {
+      "alias": "Example Model",
+      "alias_key": "ma1_0695de8b4c324f8c0acea2ca20df6ec2e8347d0249a98899705629d5c900df75",
+      "assigned_at": "2026-11-20T06:07:26.000Z",
+      "assignment_event_id": "0198abcd-0000-7000-8000-00000000001a",
+      "model_id": "mi1_76d42eeee90389c2b0b8846cc170cb6916867a9e540628e505a10aff7d2e33f9",
+      "owner_login": "kim-em",
+      "resolved_model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d"
+    }
+  ],
+  "model_identities": [
+    {
+      "consolidated_into": "mi1_842c104f0d93dd9324ecd4ba42e7bfea70b3d271bc67d44ad233a52e85e0a737",
+      "decided_at": "2026-11-20T06:07:21.000Z",
+      "decision_event_id": "0198abcd-0000-7000-8000-000000000015",
+      "display_name": "First Renamed",
+      "model_id": "mi1_76d42eeee90389c2b0b8846cc170cb6916867a9e540628e505a10aff7d2e33f9",
+      "mutation_event_id": "0198abcd-0000-7000-8000-00000000001c",
+      "owner_login": "kim-em",
+      "rejection_reason": null,
+      "request_event_id": "0198abcd-0000-7000-8000-000000000014",
+      "requested_at": "2026-11-20T06:07:20.000Z",
+      "requested_name": "First",
+      "resolved_model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d",
+      "reviewer_login": "maintainer",
+      "status": "consolidated"
+    },
+    {
+      "consolidated_into": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d",
+      "decided_at": "2026-11-20T06:07:23.000Z",
+      "decision_event_id": "0198abcd-0000-7000-8000-000000000017",
+      "display_name": "Second",
+      "model_id": "mi1_842c104f0d93dd9324ecd4ba42e7bfea70b3d271bc67d44ad233a52e85e0a737",
+      "mutation_event_id": "0198abcd-0000-7000-8000-00000000001d",
+      "owner_login": "kim-em",
+      "rejection_reason": null,
+      "request_event_id": "0198abcd-0000-7000-8000-000000000016",
+      "requested_at": "2026-11-20T06:07:22.000Z",
+      "requested_name": "Second",
+      "resolved_model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d",
+      "reviewer_login": "maintainer",
+      "status": "consolidated"
+    },
+    {
+      "consolidated_into": null,
+      "decided_at": "2026-11-20T06:07:25.000Z",
+      "decision_event_id": "0198abcd-0000-7000-8000-000000000019",
+      "display_name": "Third",
+      "model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d",
+      "mutation_event_id": "0198abcd-0000-7000-8000-000000000019",
+      "owner_login": "kim-em",
+      "rejection_reason": null,
+      "request_event_id": "0198abcd-0000-7000-8000-000000000018",
+      "requested_at": "2026-11-20T06:07:24.000Z",
+      "requested_name": "Third",
+      "resolved_model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d",
+      "reviewer_login": "maintainer",
+      "status": "approved"
+    }
+  ],
+  "model_identity_history": [
+    {
+      "actor_login": "kim-em",
+      "alias": null,
+      "causation_event_id": null,
+      "display_name": "First",
+      "event_id": "0198abcd-0000-7000-8000-000000000014",
+      "event_type": "model_identity.requested",
+      "model_id": "mi1_76d42eeee90389c2b0b8846cc170cb6916867a9e540628e505a10aff7d2e33f9",
+      "occurred_at": "2026-11-20T06:07:20.000Z",
+      "reason_code": null,
+      "reviewer_login": null,
+      "target_model_id": null
+    },
+    {
+      "actor_login": null,
+      "alias": null,
+      "causation_event_id": "0198abcd-0000-7000-8000-000000000014",
+      "display_name": null,
+      "event_id": "0198abcd-0000-7000-8000-000000000015",
+      "event_type": "model_identity.approved",
+      "model_id": "mi1_76d42eeee90389c2b0b8846cc170cb6916867a9e540628e505a10aff7d2e33f9",
+      "occurred_at": "2026-11-20T06:07:21.000Z",
+      "reason_code": null,
+      "reviewer_login": "maintainer",
+      "target_model_id": null
+    },
+    {
+      "actor_login": "kim-em",
+      "alias": null,
+      "causation_event_id": null,
+      "display_name": "Second",
+      "event_id": "0198abcd-0000-7000-8000-000000000016",
+      "event_type": "model_identity.requested",
+      "model_id": "mi1_842c104f0d93dd9324ecd4ba42e7bfea70b3d271bc67d44ad233a52e85e0a737",
+      "occurred_at": "2026-11-20T06:07:22.000Z",
+      "reason_code": null,
+      "reviewer_login": null,
+      "target_model_id": null
+    },
+    {
+      "actor_login": null,
+      "alias": null,
+      "causation_event_id": "0198abcd-0000-7000-8000-000000000016",
+      "display_name": null,
+      "event_id": "0198abcd-0000-7000-8000-000000000017",
+      "event_type": "model_identity.approved",
+      "model_id": "mi1_842c104f0d93dd9324ecd4ba42e7bfea70b3d271bc67d44ad233a52e85e0a737",
+      "occurred_at": "2026-11-20T06:07:23.000Z",
+      "reason_code": null,
+      "reviewer_login": "maintainer",
+      "target_model_id": null
+    },
+    {
+      "actor_login": "kim-em",
+      "alias": null,
+      "causation_event_id": null,
+      "display_name": "Third",
+      "event_id": "0198abcd-0000-7000-8000-000000000018",
+      "event_type": "model_identity.requested",
+      "model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d",
+      "occurred_at": "2026-11-20T06:07:24.000Z",
+      "reason_code": null,
+      "reviewer_login": null,
+      "target_model_id": null
+    },
+    {
+      "actor_login": null,
+      "alias": null,
+      "causation_event_id": "0198abcd-0000-7000-8000-000000000018",
+      "display_name": null,
+      "event_id": "0198abcd-0000-7000-8000-000000000019",
+      "event_type": "model_identity.approved",
+      "model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d",
+      "occurred_at": "2026-11-20T06:07:25.000Z",
+      "reason_code": null,
+      "reviewer_login": "maintainer",
+      "target_model_id": null
+    },
+    {
+      "actor_login": "kim-em",
+      "alias": "Example Model",
+      "causation_event_id": "0198abcd-0000-7000-8000-000000000015",
+      "display_name": null,
+      "event_id": "0198abcd-0000-7000-8000-00000000001a",
+      "event_type": "model_identity.alias_assigned",
+      "model_id": "mi1_76d42eeee90389c2b0b8846cc170cb6916867a9e540628e505a10aff7d2e33f9",
+      "occurred_at": "2026-11-20T06:07:26.000Z",
+      "reason_code": null,
+      "reviewer_login": null,
+      "target_model_id": null
+    },
+    {
+      "actor_login": "kim-em",
+      "alias": null,
+      "causation_event_id": "0198abcd-0000-7000-8000-00000000001a",
+      "display_name": "First Renamed",
+      "event_id": "0198abcd-0000-7000-8000-00000000001b",
+      "event_type": "model_identity.renamed",
+      "model_id": "mi1_76d42eeee90389c2b0b8846cc170cb6916867a9e540628e505a10aff7d2e33f9",
+      "occurred_at": "2026-11-20T06:07:27.000Z",
+      "reason_code": null,
+      "reviewer_login": null,
+      "target_model_id": null
+    },
+    {
+      "actor_login": "kim-em",
+      "alias": null,
+      "causation_event_id": "0198abcd-0000-7000-8000-00000000001b",
+      "display_name": null,
+      "event_id": "0198abcd-0000-7000-8000-00000000001c",
+      "event_type": "model_identity.consolidated",
+      "model_id": "mi1_76d42eeee90389c2b0b8846cc170cb6916867a9e540628e505a10aff7d2e33f9",
+      "occurred_at": "2026-11-20T06:07:28.000Z",
+      "reason_code": null,
+      "reviewer_login": null,
+      "target_model_id": "mi1_842c104f0d93dd9324ecd4ba42e7bfea70b3d271bc67d44ad233a52e85e0a737"
+    },
+    {
+      "actor_login": "kim-em",
+      "alias": null,
+      "causation_event_id": "0198abcd-0000-7000-8000-000000000017",
+      "display_name": null,
+      "event_id": "0198abcd-0000-7000-8000-00000000001d",
+      "event_type": "model_identity.consolidated",
+      "model_id": "mi1_842c104f0d93dd9324ecd4ba42e7bfea70b3d271bc67d44ad233a52e85e0a737",
+      "occurred_at": "2026-11-20T06:07:29.000Z",
+      "reason_code": null,
+      "reviewer_login": null,
+      "target_model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d"
+    }
+  ],
+  "result_overlays": [],
+  "results": [
+    {
+      "acceptance_event_id": "0198abcd-0000-7000-8000-000000000005",
+      "accepted_at": "2026-08-20T06:07:05.000Z",
+      "benchmark_commit": "dddddddddddddddddddddddddddddddddddddddd",
+      "declared_model": "Example Model",
+      "model_id": "mi1_76d42eeee90389c2b0b8846cc170cb6916867a9e540628e505a10aff7d2e33f9",
+      "problem_id": "two_plus_two",
+      "production_metadata": {},
+      "public_solution": {
+        "available": false,
+        "url": null
+      },
+      "record_event_id": "0198abcd-0000-7000-8000-000000000006",
+      "recorded_at": "2026-08-20T06:07:06.000Z",
+      "release": {
+        "reason": "provider_error",
+        "release_at": "2026-10-20T06:07:05.000Z",
+        "status": "failed"
+      },
+      "replay": {
+        "attempt": 1,
+        "build_retired_instructions": 987654,
+        "build_retired_instructions_unavailable_reason": null,
+        "build_wall_time_ms": 4321,
+        "checker": "nanoda",
+        "checker_retired_instructions": null,
+        "checker_retired_instructions_unavailable_reason": "counter_not_supported",
+        "checker_wall_time_ms": 1234,
+        "file_count": 3,
+        "lines_of_code": 87,
+        "reason": null,
+        "status": "accepted"
+      },
+      "resolved_model_id": "mi1_bd8ea5404bc03695a793b49d5a3112e442e7dee8abeda7387465d1f10559c14d",
+      "result_id": "r2_80f02f892fb0b90474675aa0b572252a8758faf74b95400521e9da724583931f",
+      "statement_revision": 1,
+      "submitter": "kim-em"
+    }
+  ],
+  "schema_version": 4,
+  "source_digest": "0b5c7e51aa3f07e3ff9bb6f9d8d491a9d5f6fc8ab53d687588db6fafc31dd103",
+  "source_event_count": 22,
+  "source_state_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+

--- a/tests/test_generate_site_data.py
+++ b/tests/test_generate_site_data.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import tempfile
 import unittest
@@ -7,6 +8,7 @@ from scripts.generate_site_data import (
     dedupe_universe_declarations,
     fetch_json_url,
     load_manifest,
+    load_results,
     preserve_root_declarations,
     qualify_probability_root_opens,
 )
@@ -69,6 +71,29 @@ submitter = "Alice"
                 load_manifest(manifest_dir, pathlib.Path("benchmark"))
 
 
+class ResultOwnerBindingTests(unittest.TestCase):
+    def test_results_owner_must_match_canonical_filename(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            (root / "bob.json").write_text(
+                json.dumps({"schema_version": 1, "user": "alice", "solved": {}}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(SystemExit, "matching its filename"):
+                load_results(root)
+
+    def test_results_owner_filename_match_is_case_insensitive(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            document = {"schema_version": 1, "user": "Alice", "solved": {}}
+            (root / "alice.json").write_text(
+                json.dumps(document), encoding="utf-8"
+            )
+
+            self.assertEqual(load_results(root), [document])
+
+
 class SnapshotTransformationTests(unittest.TestCase):
     def test_deduplicates_universes_across_inlined_modules(self) -> None:
         fragments = [
@@ -85,42 +110,34 @@ class SnapshotTransformationTests(unittest.TestCase):
         )
 
     def test_roots_only_explicitly_selected_dotted_declarations(self) -> None:
-        fragment = "\n".join(
-            [
-                "def Nat.IsCubeFree (n : Nat) : Prop := True",
-                "noncomputable def Local.helper : Nat := 1",
-                "def _root_.Nat.AlreadyRooted : Nat := 2",
-            ]
+        fragment = (
+            "def Nat.IsCubeFree (n : Nat) : Prop := True\n"
+            "noncomputable def Local.helper : Nat := 1\n"
+            "def _root_.Nat.AlreadyRooted : Nat := 2"
         )
 
         self.assertEqual(
             preserve_root_declarations(fragment, {"Nat.IsCubeFree"}),
-            "\n".join(
-                [
-                    "def _root_.Nat.IsCubeFree (n : Nat) : Prop := True",
-                    "noncomputable def Local.helper : Nat := 1",
-                    "def _root_.Nat.AlreadyRooted : Nat := 2",
-                ]
+            (
+                "def _root_.Nat.IsCubeFree (n : Nat) : Prop := True\n"
+                "noncomputable def Local.helper : Nat := 1\n"
+                "def _root_.Nat.AlreadyRooted : Nat := 2"
             ),
         )
 
     def test_qualifies_only_ordinary_probability_opens(self) -> None:
-        fragment = "\n".join(
-            [
-                "  open  ProbabilityTheory MeasureTheory -- needed for measures",
-                "open scoped ProbabilityTheory",
-                "namespace ProbabilityTheory",
-            ]
+        fragment = (
+            "  open  ProbabilityTheory MeasureTheory -- needed for measures\n"
+            "open scoped ProbabilityTheory\n"
+            "namespace ProbabilityTheory"
         )
 
         self.assertEqual(
             qualify_probability_root_opens(fragment),
-            "\n".join(
-                [
-                    "  open  _root_.ProbabilityTheory MeasureTheory -- needed for measures",
-                    "open scoped ProbabilityTheory",
-                    "namespace ProbabilityTheory",
-                ]
+            (
+                "  open  _root_.ProbabilityTheory MeasureTheory -- needed for measures\n"
+                "open scoped ProbabilityTheory\n"
+                "namespace ProbabilityTheory"
             ),
         )
 

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -376,6 +376,75 @@ class LifecycleProjectionTests(unittest.TestCase):
             adapted[0].canonical_model_label, "Canonical Model Renamed"
         )
         self.assertEqual(index.public_aliases[0]["canonical_id"], target_id)
+        files = build_lifecycle_projection(
+            problems=[problem("alpha")],
+            solutions=adapted,
+            set_definitions=[],
+            tag_registry={},
+            fixture={},
+            generated_at="2026-08-20T12:00:00Z",
+            benchmark_commit="a" * 40,
+            state_commit=raw["source_state_commit"],
+            state_metadata=raw,
+            site_base_url="https://example.test/eval/",
+            model_aliases=index.public_aliases,
+        )
+        published_alias = files["v2/index.json"]["model_aliases"][0]
+        self.assertEqual(published_alias["owner_login"], "alice")
+        self.assertEqual(published_alias["model_id"], raw["model_identities"][0]["model_id"])
+        self.assertFalse(
+            any(
+                "no reviewed State model alias" in limitation
+                for limitation in files["v2/index.json"]["data_limitations"]
+            )
+        )
+        mixed_files = build_lifecycle_projection(
+            problems=[problem("alpha")],
+            solutions=[
+                *adapted,
+                solution(
+                    "legacy-unreviewed",
+                    "alpha",
+                    "unreviewed-model",
+                    "2026-08-21T00:00:00Z",
+                    "issue-2",
+                ),
+            ],
+            set_definitions=[],
+            tag_registry={},
+            fixture={},
+            generated_at="2026-08-20T12:00:00Z",
+            benchmark_commit="a" * 40,
+            state_commit=raw["source_state_commit"],
+            state_metadata=raw,
+            site_base_url="https://example.test/eval/",
+            model_aliases=index.public_aliases,
+        )
+        self.assertTrue(
+            any(
+                "no reviewed State model alias" in limitation
+                for limitation in mixed_files["v2/index.json"]["data_limitations"]
+            )
+        )
+
+    def test_state_generated_v4_fixture_is_consumed_without_rewriting(self) -> None:
+        raw = json.loads(
+            (
+                ROOT
+                / "tests/fixtures/public-state-projection-v4-model-identity.json"
+            ).read_text(encoding="utf-8")
+        )
+
+        index = build_model_identity_index(raw)
+        adapted = adapt_state_projection(raw, {}, index)
+
+        self.assertEqual(len(raw["model_identity_history"]), 10)
+        self.assertEqual(adapted[0].declared_model, "Example Model")
+        self.assertEqual(adapted[0].canonical_model_label, "Third")
+        self.assertEqual(
+            adapted[0].canonical_model_id,
+            index.aliases[("kim-em", "Example Model")][1],
+        )
 
     def test_projection_v4_aliases_are_owner_scoped(self) -> None:
         raw = identity_projection_v4()
@@ -471,6 +540,21 @@ class LifecycleProjectionTests(unittest.TestCase):
             raw["model_identities"][1]["model_id"],
         )
         self.assertEqual(adapted[0].declared_model, record["declared_model"])
+
+    def test_verbatim_alias_mismatch_stays_visible_and_falls_back(self) -> None:
+        raw = identity_projection_v4()
+        raw["results"][0]["declared_model"] = "Example  Model Revision A"
+        raw["results"][0]["result_id"] = result_id(
+            "alice", "Example  Model Revision A", "alpha", 1
+        )
+        raw["results"][0]["model_id"] = None
+        raw["results"][0]["resolved_model_id"] = None
+
+        adapted = adapt_state_projection(raw, {})
+
+        self.assertEqual(adapted[0].declared_model, "Example  Model Revision A")
+        self.assertEqual(adapted[0].canonical_model_id, "example-model-revision-a")
+        self.assertFalse(adapted[0].model_identity_reviewed)
 
     def test_state_record_replaces_matching_legacy_base_record(self) -> None:
         legacy = solution("legacy_a", "alpha", "model-a", "2026-08-20T00:00:00Z", "issue-1")

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -1,21 +1,119 @@
 from __future__ import annotations
 
+import copy
+import hashlib
+import json
 import pathlib
 import unittest
 from types import SimpleNamespace
 
-from scripts.results_schema import result_id
 from scripts.lifecycle_site_data import (
     SetDefinition,
     Solution,
+    adapt_results_store,
     adapt_state_projection,
     build_lifecycle_projection,
+    build_model_identity_index,
     load_preview_fixture,
     merge_solutions,
 )
-
+from scripts.results_schema import result_id
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def model_id(request_event_id: str) -> str:
+    return "mi1_" + hashlib.sha256(
+        b"lean-eval-model-identity-v1\0" + request_event_id.encode("ascii")
+    ).hexdigest()
+
+
+def alias_key(owner: str, alias: str) -> str:
+    canonical = json.dumps(
+        [owner, alias], ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")
+    return "ma1_" + hashlib.sha256(
+        b"lean-eval-model-alias-v1\0" + canonical
+    ).hexdigest()
+
+
+def identity_projection_v4() -> dict:
+    source_request = "0198abcd-0000-7000-8000-000000000100"
+    target_request = "0198abcd-0000-7000-8000-000000000200"
+    source_id = model_id(source_request)
+    target_id = model_id(target_request)
+    declared = "Example Model Revision A"
+    result = {
+        "result_id": result_id("alice", declared, "alpha", 1),
+        "problem_id": "alpha",
+        "statement_revision": 1,
+        "declared_model": declared,
+        "submitter": "alice",
+        "accepted_at": "2026-08-20T00:00:00.000Z",
+        "acceptance_event_id": "0198abcd-0000-7000-8000-000000000001",
+        "recorded_at": "2026-08-20T00:00:01.000Z",
+        "record_event_id": "0198abcd-0000-7000-8000-000000000002",
+        "benchmark_commit": "a" * 40,
+        "production_metadata": {},
+        "replay": None,
+        "release": None,
+        "public_solution": {"available": False, "url": None},
+        "model_id": source_id,
+        "resolved_model_id": target_id,
+    }
+    identity_common = {
+        "requested_at": "2026-08-20T00:00:00.000Z",
+        "decision_event_id": "0198abcd-0000-7000-8000-000000000300",
+        "decided_at": "2026-08-20T00:00:01.000Z",
+        "reviewer_login": "reviewer",
+        "rejection_reason": None,
+        "mutation_event_id": "0198abcd-0000-7000-8000-000000000400",
+    }
+    return {
+        "schema_version": 4,
+        "environment": "production",
+        "source_state_commit": "e" * 40,
+        "source_event_count": 8,
+        "source_digest": "f" * 64,
+        "results": [result],
+        "result_overlays": [],
+        "model_identities": [
+            {
+                **identity_common,
+                "model_id": source_id,
+                "owner_login": "alice",
+                "requested_name": "Original Model",
+                "display_name": "Renamed Before Consolidation",
+                "status": "consolidated",
+                "request_event_id": source_request,
+                "consolidated_into": target_id,
+                "resolved_model_id": target_id,
+            },
+            {
+                **identity_common,
+                "model_id": target_id,
+                "owner_login": "alice",
+                "requested_name": "Canonical Model",
+                "display_name": "Canonical Model Renamed",
+                "status": "approved",
+                "request_event_id": target_request,
+                "consolidated_into": None,
+                "resolved_model_id": target_id,
+            },
+        ],
+        "model_aliases": [
+            {
+                "alias_key": alias_key("alice", declared),
+                "owner_login": "alice",
+                "alias": declared,
+                "model_id": source_id,
+                "resolved_model_id": target_id,
+                "assignment_event_id": "0198abcd-0000-7000-8000-000000000500",
+                "assigned_at": "2026-08-20T00:00:02.000Z",
+            }
+        ],
+        "model_identity_history": [],
+    }
 
 
 def problem(
@@ -257,6 +355,122 @@ class LifecycleProjectionTests(unittest.TestCase):
         }
         with self.assertRaisesRegex(SystemExit, "result_id does not match"):
             adapt_state_projection(raw, {})
+
+    def test_projection_v4_uses_owner_scoped_consolidated_identity(self) -> None:
+        raw = identity_projection_v4()
+        index = build_model_identity_index(raw)
+        adapted = adapt_state_projection(
+            raw,
+            {
+                "Example Model Revision A": {
+                    "canonical_id": "unreviewed-static-alias",
+                    "label": "Unreviewed Static Alias",
+                }
+            },
+            index,
+        )
+
+        target_id = raw["model_identities"][1]["model_id"]
+        self.assertEqual(adapted[0].canonical_model_id, target_id)
+        self.assertEqual(
+            adapted[0].canonical_model_label, "Canonical Model Renamed"
+        )
+        self.assertEqual(index.public_aliases[0]["canonical_id"], target_id)
+
+    def test_projection_v4_aliases_are_owner_scoped(self) -> None:
+        raw = identity_projection_v4()
+        bob_request = "0198abcd-0000-7000-8000-000000000600"
+        bob_id = model_id(bob_request)
+        bob_identity = copy.deepcopy(raw["model_identities"][1])
+        bob_identity.update(
+            model_id=bob_id,
+            owner_login="bob",
+            request_event_id=bob_request,
+            requested_name="Bob Canonical",
+            display_name="Bob Canonical",
+            consolidated_into=None,
+            resolved_model_id=bob_id,
+        )
+        raw["model_identities"].append(bob_identity)
+        bob_alias = copy.deepcopy(raw["model_aliases"][0])
+        bob_alias.update(
+            alias_key=alias_key("bob", bob_alias["alias"]),
+            owner_login="bob",
+            model_id=bob_id,
+            resolved_model_id=bob_id,
+        )
+        raw["model_aliases"].append(bob_alias)
+
+        index = build_model_identity_index(raw)
+
+        self.assertNotEqual(
+            index.aliases[("alice", "Example Model Revision A")][1],
+            index.aliases[("bob", "Example Model Revision A")][1],
+        )
+
+    def test_projection_v4_rejects_alias_collisions_and_spoofed_bindings(self) -> None:
+        duplicate = identity_projection_v4()
+        duplicate["model_aliases"].append(
+            copy.deepcopy(duplicate["model_aliases"][0])
+        )
+        with self.assertRaisesRegex(SystemExit, "invalid model alias binding"):
+            build_model_identity_index(duplicate)
+
+        hostile_key = identity_projection_v4()
+        hostile_key["model_aliases"][0]["alias_key"] = "ma1_" + "0" * 64
+        with self.assertRaisesRegex(SystemExit, "invalid model alias binding"):
+            build_model_identity_index(hostile_key)
+
+        spoofed_result = identity_projection_v4()
+        spoofed_result["results"][0]["model_id"] = spoofed_result[
+            "model_identities"
+        ][1]["model_id"]
+        with self.assertRaisesRegex(SystemExit, "binding is inconsistent"):
+            adapt_state_projection(spoofed_result, {})
+
+    def test_projection_v4_rejects_identity_and_resolution_drift(self) -> None:
+        wrong_id = identity_projection_v4()
+        wrong_id["model_identities"][0]["model_id"] = "mi1_" + "0" * 64
+        with self.assertRaisesRegex(SystemExit, "invalid model identity"):
+            build_model_identity_index(wrong_id)
+
+        cross_owner = identity_projection_v4()
+        cross_owner["model_identities"][1]["owner_login"] = "bob"
+        with self.assertRaisesRegex(SystemExit, "incoherent model identity"):
+            build_model_identity_index(cross_owner)
+
+        hostile_label = identity_projection_v4()
+        hostile_label["model_identities"][1]["display_name"] = "bad\nlabel"
+        with self.assertRaisesRegex(SystemExit, "invalid model display name"):
+            build_model_identity_index(hostile_label)
+
+    def test_base_result_fallback_uses_state_identity_without_mutation(self) -> None:
+        raw = identity_projection_v4()
+        index = build_model_identity_index(raw)
+        record = {
+            "result_id": raw["results"][0]["result_id"],
+            "problem_id": "alpha",
+            "statement_revision": 1,
+            "declared_model": "Example Model Revision A",
+            "accepted_at": "2026-08-20T00:00:00Z",
+            "benchmark_commit": "a" * 40,
+            "intake": {"kind": "issue", "issue_number": 1},
+            "submission": {
+                "kind": "github_repo",
+                "repo": "alice/proofs",
+                "ref": "b" * 40,
+                "public": False,
+            },
+            "production_metadata": {},
+        }
+
+        adapted = adapt_results_store([("alice", [record])], {}, index)
+
+        self.assertEqual(
+            adapted[0].canonical_model_id,
+            raw["model_identities"][1]["model_id"],
+        )
+        self.assertEqual(adapted[0].declared_model, record["declared_model"])
 
     def test_state_record_replaces_matching_legacy_base_record(self) -> None:
         legacy = solution("legacy_a", "alpha", "model-a", "2026-08-20T00:00:00Z", "issue-1")

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -513,6 +513,29 @@ class LifecycleProjectionTests(unittest.TestCase):
         with self.assertRaisesRegex(SystemExit, "invalid model display name"):
             build_model_identity_index(hostile_label)
 
+        cycle = identity_projection_v4()
+        terminal_request = "0198abcd-0000-7000-8000-000000000700"
+        terminal_id = model_id(terminal_request)
+        terminal = copy.deepcopy(cycle["model_identities"][1])
+        terminal.update(
+            model_id=terminal_id,
+            request_event_id=terminal_request,
+            requested_name="Terminal",
+            display_name="Terminal",
+            consolidated_into=None,
+            resolved_model_id=terminal_id,
+        )
+        source, target = cycle["model_identities"]
+        source["resolved_model_id"] = terminal_id
+        target.update(
+            status="consolidated",
+            consolidated_into=source["model_id"],
+            resolved_model_id=terminal_id,
+        )
+        cycle["model_identities"].append(terminal)
+        with self.assertRaisesRegex(SystemExit, "cyclic model identity"):
+            build_model_identity_index(cycle)
+
     def test_base_result_fallback_uses_state_identity_without_mutation(self) -> None:
         raw = identity_projection_v4()
         index = build_model_identity_index(raw)


### PR DESCRIPTION
## Summary

- request and consume the redacted production State projection schema v4
- resolve owner-scoped reviewed aliases, renames, and transitive consolidations for standings credit while preserving immutable result IDs and verbatim declared labels
- retain explicitly labelled base-results fallback for pull-request previews and for results not yet materialized in State
- bind base-results owners to their canonical filenames and reject identity collisions, spoofed bindings, invalid labels, cross-owner consolidation, and cycles
- vendor the exact State projection schema chain and a State-generated transitive-consolidation compatibility vector

The authoritative event/authorization/materialization contract is already merged in leanprover/lean-eval-state#12 (`889e07e3b8cf38ad147d8a23b7d1b35826de740f`). This consumer reads only State's validated public projection; it does not gain access to raw events or internal State materializations, and it does not expand credentials. PR builds remain uncredentialed. Existing preview and legacy rollback routes are unchanged.

## Validation

- `python -m unittest discover -s tests` — 39 passed
- `uvx ruff check` on all edited Python — clean
- `python -m py_compile` on all edited Python — clean
- exact State v1-v4 schema-chain hash comparison — identical
- State producer validation and denylist leak scan against production State `163e9314c881493e08d23baf35ff40456f9c2331`
- AJV validation of the State-generated v4 compatibility fixture
- end-to-end site-data generation against the pinned benchmark, current results store, and current production State v4 projection
- lifecycle validator and existing preview/leaderboard parity check — clean
