### PR TITLE
Restore statements on lifecycle problem pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -244,6 +244,16 @@ jobs:
             test -f "_site/problems/$problem_id/index.html"
             test -f "_site/legacy/problems/$problem_id/index.html"
             test -f "_site/site-data/v2/problems/$problem_id.json"
+            grep -F 'data-lifecycle-view="problem"' \
+              "_site/problems/$problem_id/index.html"
+            grep -F 'class="wrap prose lifecycle-problem-statement"' \
+              "_site/problems/$problem_id/index.html"
+            grep -F 'class="hl lean block"' \
+              "_site/problems/$problem_id/index.html"
+            grep -F 'data-lifecycle-view="problem"' \
+              "_site/preview/problems/$problem_id/index.html"
+            grep -F 'class="hl lean block"' \
+              "_site/preview/problems/$problem_id/index.html"
           done < <(jq -r '.problems[].id' _site/site-data/problems.json)
           grep -F "LeanEval leaderboard" _site/index.html
           grep -F 'data-lifecycle-app="true"' _site/index.html

--- a/LeaderboardSite/Pages/Preview.lean
+++ b/LeaderboardSite/Pages/Preview.lean
@@ -1,6 +1,7 @@
 import Lean
 import VersoBlog
 import LeaderboardSite.Data
+import LeaderboardSite.Pages.ProblemDetail
 
 set_option maxRecDepth 65536
 
@@ -18,6 +19,12 @@ private def textHtml (text : String) : Html := Html.text true text
 
 private def htmlBlob (html : Html) : Block Page :=
   .other (BlockExt.blob html) #[]
+
+private def headingBlock (text : String) : Block Page :=
+  .other (BlockExt.blob {{ <h2>{{textHtml text}}</h2> }}) #[]
+
+private def divBlock (classes : String) (contents : Array (Block Page)) : Block Page :=
+  .other (BlockExt.htmlDiv classes) contents
 
 private def groupTabs : Html := {{
   <nav class="lifecycle-group-tabs" aria-label="Leaderboard groups">
@@ -108,8 +115,16 @@ def _root_.LeaderboardSite.Pages.PreviewRecent : VersoDoc Page :=
 def _root_.LeaderboardSite.Pages.PreviewProblems : VersoDoc Page :=
   .mk (fun _ => pagePart true "Problem comparisons" "group" "formalization-evaluation") "{}"
 
-private def problemPart (preview : Bool) (title problemId : String) : Part Page :=
-  pagePart preview title "problem" problemId
+private def problemPart
+    (preview : Bool)
+    (title problemId : String)
+    (notesText sourceText informalSolution : Option String)
+    (anchors : Array (Block Page)) : Part Page :=
+  let statement := divBlock "wrap prose lifecycle-problem-statement" <|
+    #[headingBlock "Problem statement"] ++
+      LeaderboardSite.Pages.ProblemDetail.problemStatementBlocks
+        notesText sourceText informalSolution anchors
+  .mk #[textInline title] title none #[appShell preview "problem" problemId, statement] #[]
 
 private def previewPageName (namePrefix problemId : String) : Lean.Name :=
   ((`LeaderboardSite.Pages.Preview).str namePrefix).str problemId
@@ -122,7 +137,15 @@ private def problemPageTerms (preview : Bool) (namePrefix : String) : TermElabM 
   let mut terms : Array (TSyntax `term) := #[]
   for problem in problems do
     let pageName := previewPageName namePrefix problem.id
-    let part ← `(problemPart $(quote preview) $(quote problem.title) $(quote problem.id))
+    let anchors : TSyntaxArray `term := anchorBlockTerms problem
+    let part ← `(problemPart
+      $(quote preview)
+      $(quote problem.title)
+      $(quote problem.id)
+      $(quote problem.notesText)
+      $(quote problem.sourceText)
+      $(quote problem.informalSolution)
+      #[$anchors,*])
     terms := terms.push (← `(Dir.page $(quote problem.id) $(quote pageName) $part #[]))
   let result : TSyntax `term ← `(#[$[$terms],*])
   let expected ← Lean.Elab.Term.elabTerm (← `(Array Dir)) none

--- a/LeaderboardSite/Pages/ProblemDetail.lean
+++ b/LeaderboardSite/Pages/ProblemDetail.lean
@@ -117,6 +117,18 @@ private def sourceParagraph (value : Option String) : Block Page :=
       paragraph #[textInline s!"{problemsSourcePrefix}{s}"]
   | none => paragraph #[textInline s!"{problemsSourcePrefix}{unavailable}"]
 
+/-- The authored context and highlighted Lean declarations that constitute a
+problem statement. Kept as one shared renderer so the lifecycle-aware and
+legacy detail routes cannot silently diverge again. -/
+def problemStatementBlocks
+    (notesText sourceText informalSolution : Option String)
+    (anchors : Array (Block Page)) : Array (Block Page) :=
+  #[
+    optionalParagraph problemsNotesLabel notesText,
+    sourceParagraph sourceText,
+    optionalParagraph problemsInformalSolutionLabel informalSolution
+  ] ++ anchors.map holeWrap
+
 private def backLink : Block Page :=
   -- Verso emits a `<base href>` pointing at the site root, so a plain
   -- `problems/` href resolves to `<root>/problems/` rather than back up
@@ -135,14 +147,11 @@ private def assembleDetailPart
   let prelude : Array (Block Page) := #[
     backLink,
     paragraph #[codeInline id],
-    paragraph #[textInline submitterText],
-    optionalParagraph problemsNotesLabel notesText,
-    sourceParagraph sourceText,
-    optionalParagraph problemsInformalSolutionLabel informalSolution
+    paragraph #[textInline submitterText]
   ]
   let body :=
     prelude
-    ++ anchors.map holeWrap
+    ++ problemStatementBlocks notesText sourceText informalSolution anchors
     ++ solversSection solvers
   Verso.Doc.Part.mk #[textInline title] title none body #[]
 

--- a/static/style.css
+++ b/static/style.css
@@ -270,6 +270,14 @@ body::before {
 .lifecycle-app-content h2 { font-size: var(--fs-xl); }
 .lifecycle-app-content h3 { font-size: var(--fs-lg); }
 
+.lifecycle-problem-statement {
+  margin-top: var(--space-8);
+}
+
+.lifecycle-problem-statement > h2 {
+  font-size: var(--fs-xl);
+}
+
 .lifecycle-policy,
 .lifecycle-limitations,
 .lifecycle-panel,

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -30,6 +30,20 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn('href="legacy/"', page)
         self.assertNotIn("Local-only preview", page)
 
+    def test_lifecycle_problem_pages_retain_the_complete_problem_statement(self) -> None:
+        page = (REPO_ROOT / "LeaderboardSite/Pages/Preview.lean").read_text()
+        detail = (
+            REPO_ROOT / "LeaderboardSite/Pages/ProblemDetail.lean"
+        ).read_text()
+        self.assertIn("anchorBlockTerms problem", page)
+        self.assertIn('headingBlock "Problem statement"', page)
+        self.assertIn('"wrap prose lifecycle-problem-statement"', page)
+        self.assertIn("problemStatementBlocks", page)
+        self.assertIn("def problemStatementBlocks", detail)
+        self.assertIn("optionalParagraph problemsNotesLabel notesText", detail)
+        self.assertIn("sourceParagraph sourceText", detail)
+        self.assertIn("anchors.map holeWrap", detail)
+
     def test_site_data_uses_stable_cutover_routes(self) -> None:
         generator = (REPO_ROOT / "scripts/lifecycle_site_data.py").read_text()
         self.assertIn('"url": f"problems/', generator)


### PR DESCRIPTION
## Summary

- restore the authored notes, source, informal-solution context, and exact highlighted Lean declarations on every stable lifecycle problem page
- keep those statements outside the JavaScript-owned lifecycle container so asynchronous rendering cannot erase them
- share the statement renderer with the retained legacy pages to prevent the two routes from drifting again
- add source checks and generated-page assertions that require both lifecycle detail and highlighted Lean content on every stable and preview problem route

## Regression

The lifecycle cutover in #72 replaced the server-rendered stable problem detail pages with lifecycle shells. The new client rendered metadata, lifecycle history, sets, and solutions, but never rendered `anchorBlockTerms`; consequently every `/eval/problems/<id>/` page lost its actual problem statement. The old statement remained visible only under `/eval/legacy/problems/<id>/`.

This fix preserves the lifecycle UI and splices the existing source-exact Verso anchor blocks back into the stable page. It does not duplicate statement text into the lifecycle JSON projection.

## Verification

- 40 Python tests passed
- actionlint passed
- `git diff --check` passed
- independent source review found no merge blockers
- hosted Pages build is exercising the real per-problem snapshot and must prove every generated stable and preview problem page contains both `data-lifecycle-view="problem"` and a highlighted Lean block before merge
