### PR TITLE
fix: render replay measurement fields

### DIFF
--- a/scripts/lifecycle_site_data.py
+++ b/scripts/lifecycle_site_data.py
@@ -556,7 +556,7 @@ def adapt_state_projection(
                     "kind": "checker-replay",
                     "status": (
                         "unavailable"
-                        if replay.get("retired_instructions") is None
+                        if replay.get("checker_retired_instructions") is None
                         else "available"
                     ),
                     "checker": replay.get("checker"),

--- a/static/lifecycle-preview.js
+++ b/static/lifecycle-preview.js
@@ -330,7 +330,13 @@
           solution.measurements.forEach(function (measurement) {
             card.appendChild(definitionList([
               ["Checker", measurement.checker], ["Status", measurement.status],
-              ["Retired instructions", measurement.retired_instructions], ["Wall time (ms)", measurement.wall_time_ms]
+              ["Checker wall time (ms)", measurement.checker_wall_time_ms],
+              ["Checker retired instructions", measurement.checker_retired_instructions],
+              ["Checker counter unavailable reason", measurement.checker_retired_instructions_unavailable_reason],
+              ["Build wall time (ms)", measurement.build_wall_time_ms],
+              ["Build retired instructions", measurement.build_retired_instructions],
+              ["Build counter unavailable reason", measurement.build_retired_instructions_unavailable_reason],
+              ["Lines of code", measurement.lines_of_code], ["File count", measurement.file_count]
             ]));
           });
         } else {

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -313,8 +313,50 @@ class LifecycleProjectionTests(unittest.TestCase):
 
         self.assertEqual(adapted[0].canonical_model_id, "example-model")
         self.assertEqual(adapted[0].replay["status"], "accepted")
-        self.assertEqual(adapted[0].measurements[0]["status"], "unavailable")
+        expected_measurement = {
+            "kind": "checker-replay",
+            "status": "unavailable",
+            "checker": "lean4lean",
+            "checker_wall_time_ms": 20,
+            "checker_retired_instructions": None,
+            "checker_retired_instructions_unavailable_reason": (
+                "counter_not_supported"
+            ),
+            "build_wall_time_ms": 40,
+            "build_retired_instructions": 100,
+            "build_retired_instructions_unavailable_reason": None,
+            "lines_of_code": 12,
+            "file_count": 1,
+            "unavailable_reason": "performance-counter-unavailable",
+            "attempt": 1,
+        }
+        self.assertEqual(
+            adapted[0].measurements[0],
+            expected_measurement,
+        )
         self.assertEqual(adapted[0].release["status"], "scheduled")
+        files = build_lifecycle_projection(
+            problems=[problem("alpha")],
+            solutions=adapted,
+            set_definitions=[],
+            tag_registry={},
+            fixture={},
+            generated_at="2026-08-20T12:00:00Z",
+            benchmark_commit="a" * 40,
+            state_commit=raw["source_state_commit"],
+            state_metadata=raw,
+            site_base_url="https://example.test/eval/",
+        )
+        published = files["v2/problems/alpha.json"]["solutions"][0]
+        self.assertEqual(published["measurements"], [expected_measurement])
+
+        raw["results"][0]["replay"]["checker_retired_instructions"] = 200
+        raw["results"][0]["replay"][
+            "checker_retired_instructions_unavailable_reason"
+        ] = None
+        available = adapt_state_projection(raw, aliases)[0].measurements[0]
+        self.assertEqual(available["status"], "available")
+        self.assertIsNone(available["unavailable_reason"])
 
     def test_public_state_projection_rejects_private_internal_fields(self) -> None:
         raw = {

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -61,6 +61,23 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn('["unique", "first", "total"]', client)
         self.assertIn("recent-solutions.xml", client)
 
+    def test_client_renders_current_replay_measurement_fields(self) -> None:
+        client = (REPO_ROOT / "static/lifecycle-preview.js").read_text()
+        for field in (
+            "checker_wall_time_ms",
+            "checker_retired_instructions",
+            "checker_retired_instructions_unavailable_reason",
+            "build_wall_time_ms",
+            "build_retired_instructions",
+            "build_retired_instructions_unavailable_reason",
+            "lines_of_code",
+            "file_count",
+        ):
+            with self.subTest(field=field):
+                self.assertIn(f"measurement.{field}", client)
+        self.assertNotIn("measurement.wall_time_ms", client)
+        self.assertNotIn("measurement.retired_instructions", client)
+
     def test_product_ui_uses_lifecycle_not_schema_terminology(self) -> None:
         sources = [
             REPO_ROOT / "LeaderboardSite/Pages/Preview.lean",


### PR DESCRIPTION
## Summary

- derive replay measurement availability from the current `checker_retired_instructions` field
- render the checker/build wall-time and retired-instruction fields emitted by the public State projection
- render replay size fields (`lines_of_code` and `file_count`) and counter-unavailability reasons
- add adapter-to-site-data and browser-field contract regressions for the current schema

## Validation

- `python3 -m unittest discover -v -s tests` (41 tests)
- `python3 scripts/generate_site_data.py --no-write-snapshot ...`
- `python3 scripts/validate_lifecycle_site_data.py --root site-data/v2`
- `node --check static/lifecycle-preview.js`
- `python3 -m py_compile scripts/*.py tests/*.py`
- pinned benchmark snapshot build completed successfully