### PR TITLE
feat: add open problems and production submit entry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,14 +214,17 @@ jobs:
           test -f _site/index.html
           test -f _site/formalization-evaluation/index.html
           test -f _site/software-verification/index.html
+          test -f _site/open-problems/index.html
+          # Former public URL retained only as a neutral compatibility alias.
           test -f _site/open-conjectures/index.html
           test -f _site/recent/index.html
+          test -f _site/submit/index.html
           test -f _site/legacy/index.html
           test -f _site/legacy/problems/index.html
           test -f _site/preview/index.html
           test -f _site/preview/formalization-evaluation/index.html
           test -f _site/preview/software-verification/index.html
-          test -f _site/preview/open-conjectures/index.html
+          test -f _site/preview/open-problems/index.html
           test -f _site/preview/recent/index.html
           test -f _site/site-data/leaderboard-preview.json
           test -f _site/site-data/v2/index.json
@@ -265,10 +268,33 @@ jobs:
           fi
           grep -F "LeanEval lifecycle-aware leaderboard" _site/preview/index.html
           grep -F 'aria-live="polite"' _site/preview/index.html
+          grep -F 'data-lifecycle-identity="open-problems"' \
+            _site/open-conjectures/index.html
+          if grep -F 'data-lifecycle-group-tab="open-conjectures"' \
+              _site/open-conjectures/index.html; then
+            echo "::error::The compatibility route leaked into canonical group navigation."
+            exit 1
+          fi
+          grep -F 'https://lean-eval-submission-server.lean-eval.workers.dev/' \
+            _site/submit/index.html
+          grep -F 'https://github.com/apps/lean-eval-source-reader' \
+            _site/submit/index.html
+          if grep -F 'https://github.com/apps/lean-eval-bot' \
+              _site/submit/index.html; then
+            echo "::error::The server intake page points at the legacy issue-workflow App."
+            exit 1
+          fi
+          grep -F 'GitHub OAuth callbacks' _site/submit/index.html
+          grep -F 'two UTC calendar months after acceptance' _site/submit/index.html
+          grep -F 'automatically publishes' _site/submit/index.html
+          grep -F 'Apache License 2.0' _site/submit/index.html
+          grep -F 'legacy GitHub issue form' _site/submit/index.html
+          grep -F '<a href="https://lean-lang.org/eval/">return to the leaderboard</a>' \
+            _site/submit/index.html
           jq --exit-status '.preview.kind == "results-v2-compatibility"' \
             _site/site-data/leaderboard-preview.json
           jq --exit-status \
-            '.schema_version == 2 and .default_group == "formalization-evaluation" and (.groups | map(.id) | sort) == ["formalization-evaluation", "open-conjectures", "software-verification"] and all(.groups[]; (.url | startswith("preview/") | not))' \
+            '.schema_version == 2 and .default_group == "formalization-evaluation" and (.groups | map(.id) | sort) == ["formalization-evaluation", "open-problems", "software-verification"] and all(.groups[]; (.url | startswith("preview/") | not))' \
             _site/site-data/v2/index.json
           jq --exit-status \
             '.problems as $problems | .schema_version == 2 and .standings_default_sort == "unique" and all(.credits[]; .problem_id as $id | any($problems[]; .id == $id)) and all(.problems[]; .url | startswith("problems/"))' \

--- a/LeaderboardSite.lean
+++ b/LeaderboardSite.lean
@@ -36,9 +36,14 @@ def leaderboardSite : Site :=
     Dir.page "software-verification"
       (%docName? LeaderboardSite.Pages.LifecycleSoftware)
       (%doc? LeaderboardSite.Pages.LifecycleSoftware) #[],
+    Dir.page "open-problems"
+      (%docName? LeaderboardSite.Pages.LifecycleOpenProblems)
+      (%doc? LeaderboardSite.Pages.LifecycleOpenProblems) #[],
+    -- Keep the former public URL as a neutral compatibility alias. It has no
+    -- independent group identity and is intentionally absent from navigation.
     Dir.page "open-conjectures"
-      (%docName? LeaderboardSite.Pages.LifecycleConjectures)
-      (%doc? LeaderboardSite.Pages.LifecycleConjectures) #[],
+      (%docName? LeaderboardSite.Pages.LifecycleOpenProblemsCompatibility)
+      (%doc? LeaderboardSite.Pages.LifecycleOpenProblemsCompatibility) #[],
     Dir.page "recent"
       (%docName? LeaderboardSite.Pages.LifecycleRecent)
       (%doc? LeaderboardSite.Pages.LifecycleRecent) #[],
@@ -65,9 +70,9 @@ def leaderboardSite : Site :=
         Dir.page "software-verification"
           (%docName? LeaderboardSite.Pages.PreviewSoftware)
           (%doc? LeaderboardSite.Pages.PreviewSoftware) #[],
-        Dir.page "open-conjectures"
-          (%docName? LeaderboardSite.Pages.PreviewConjectures)
-          (%doc? LeaderboardSite.Pages.PreviewConjectures) #[],
+        Dir.page "open-problems"
+          (%docName? LeaderboardSite.Pages.PreviewOpenProblems)
+          (%doc? LeaderboardSite.Pages.PreviewOpenProblems) #[],
         Dir.page "recent"
           (%docName? LeaderboardSite.Pages.PreviewRecent)
           (%doc? LeaderboardSite.Pages.PreviewRecent) #[],

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -269,41 +269,42 @@ def submitTitle : String := "Submit"
 def submitLeadBody : VersoDoc Page :=
   verso (Page) "submitLead"
   :::
-  Submissions are made by opening a GitHub issue on the
-  [lean-eval submissions repository](https://github.com/leanprover/lean-eval-submissions).
+  The authenticated submission application is hosted at
+  [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/).
+  This separate origin is intentional: GitHub OAuth callbacks and the
+  application session are scoped to the Worker that handles private intake.
+  After submitting, you can
+  [return to the leaderboard](https://lean-lang.org/eval/).
+
+  During the temporary transition, the
+  [legacy GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+  remains available as a secondary path for existing users. New submissions
+  should use the authenticated application above.
   :::
 
 def submitStep1Title  : String :=
-  "1. Put your proof somewhere the lean-eval CI can fetch it"
+  "1. Prepare a source LeanEval can fetch"
 def submitStep1HtmlId : String := "step-1"
 
 def submitStep1Body : VersoDoc Page :=
   verso (Page) "submitStep1"
   :::
-  Accepted submission sources are URLs of one of these shapes:
-
-  - a GitHub repository: `https://github.com/<owner>/<repo>`
-  - a GitHub repository pinned to a branch, tag, or commit:
-    `https://github.com/<owner>/<repo>/tree/<ref>` or
-    `https://github.com/<owner>/<repo>/commit/<sha>`
-  - a public gist: `https://gist.github.com/<user>/<gist-id>`
-    (optionally with a revision suffix)
-
-  Private GitHub repositories are supported. To use one,
-  [install the lean-eval-bot GitHub App](https://github.com/apps/lean-eval-bot)
-  on the repository first, so that the CI can clone it.
-
-  Secret (unlisted) gists are not supported by the current intake flow. Make
-  your gist public, or host the proof in a repository.
+  Launch intake requires a private GitHub repository in `owner/repository`
+  form and the exact 40-character source commit to evaluate. Before submitting,
+  [install the Lean Eval Source Reader GitHub App](https://github.com/apps/lean-eval-source-reader)
+  on that repository so that LeanEval can clone it.
   :::
 
-def submitStep2Title  : String := "2. Lay out the proof so CI can find it"
+def submitStep2Title  : String := "2. Submit through the authenticated application"
 def submitStep2HtmlId : String := "step-2"
 
 def submitStep2Body : VersoDoc Page :=
   verso (Page) "submitStep2"
   :::
-  The CI walks whatever you submit and tries every directory containing a
+  [Continue to the secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/)
+  and sign in with GitHub. Choose the source and identify the model or system
+  that produced the proof. The application walks the submitted source and
+  tries every directory containing a
   `lakefile.toml` whose `name` field matches a benchmark problem id, and
   which has a `Submission.lean` next to it. For example:
 
@@ -313,81 +314,55 @@ def submitStep2Body : VersoDoc Page :=
     relevant `generated/<problem_id>/` directories
   - a custom repository containing several benchmark workspaces side by
     side
-  - a gist containing a two-file minimum: a `lakefile.toml` with
-    `name = "<problem_id>"` and a `Submission.lean`
 
-  For each matched directory the CI overlays only your `Submission.lean`
+  For each matched directory LeanEval overlays only your `Submission.lean`
   and any files under `Submission/**/*.lean` onto a pristine copy of the
   benchmark's workspace for that problem. Every other file in your
   submission is ignored, including `Solution.lean`, `Challenge.lean`, or
   any modified `lakefile.toml`. The CI then runs
   [comparator](https://github.com/leanprover/comparator) to check the
   proof.
+
+  Before evaluation, LeanEval records the exact source revision and digest
+  and stores a private encrypted archive bound to that submission. Submission
+  source and credentials are not exposed through public workflow artifacts or
+  logs.
   :::
 
-def submitStep3Title  : String := "3. Open a submission issue"
+def submitStep3Title  : String := "3. Confirm the release terms"
 def submitStep3HtmlId : String := "step-3"
 
 def submitStep3Body : VersoDoc Page :=
   verso (Page) "submitStep3"
   :::
-  Click [Submit benchmark solution](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  to open a pre-filled issue. The form asks for:
+  The submission action includes this acknowledgement:
 
-  - a submission URL in one of the shapes above
-  - a free-form model identifier that identifies the model or system that
-    produced the proof
-  - whether the exact solutions are public, planned for publication, or
-    private with no current publication plan
-  - an actual or intended publication date in `YYYY-MM-DD` format when
-    applicable
+  > By submitting, I confirm that I have authority to provide this source. I authorize Lean Eval to store and run it privately for evaluation, publish evaluation metadata and results, and, two UTC calendar months after acceptance, publish the submitted source under the Apache License 2.0. I will not submit secrets or material I am not authorized to disclose.
 
-  You can also provide an optional description of how the solution was
-  produced.
-
-  When you submit the issue, the lean-eval CI takes over. It clones your
-  content, scans for benchmark workspaces, runs comparator on every
-  match, and records any newly-solved problems in the leaderboard
-  repository. The CI comments on your issue with a per-problem pass/fail
-  summary and closes it when done. Any problem that passes is added to
-  your `results/<your-github-login>.json` record.
-
-  Submissions are cumulative. Every success is sticky, and there is no
-  limit on how many times you can submit. Resubmit whenever you have new
-  proofs.
+  Accepted source is scheduled for publication by default. You may opt out in
+  the submission application, or ask to opt out at any time before release.
+  The public result then remains visible with its solution marked as withheld.
   :::
 
-def submitWhatPublicTitle  : String := "What becomes public"
+def submitWhatPublicTitle  : String := "What becomes public, and when"
 def submitWhatPublicHtmlId : String := "what-becomes-public"
 
 def submitWhatPublicBody : VersoDoc Page :=
   verso (Page) "submitWhatPublic"
   :::
-  Only the information you enter on the submission form, plus the list of
-  problems your submission solved, becomes public. Your proof is never
-  copied out of the ephemeral workflow runner into any public artifact.
-  The public results store records submission provenance, timestamps, and
-  your submission-time publication declaration.
+  Submission metadata and evaluation results may become public when the
+  result is recorded. Private source remains in the encrypted archive during
+  the release delay.
 
-  If your submission source was a public repository or a public gist, the
-  leaderboard may link to it so that others can inspect your solution. If
-  the source was private, no link is published.
+  Unless you opt out, LeanEval automatically publishes the exact accepted
+  `Submission.lean` and files under `Submission/` under the Apache License 2.0
+  two UTC calendar months after acceptance. Repository metadata, credentials,
+  challenge files, modified build files, and unrelated source files are not
+  included in that release.
 
-  LeanEval supports open science and does not prohibit publishing exact
-  solutions. Making solutions public can help library development and let
-  others study and build on your work. However, it also lets solutions be
-  copied directly and may cause them to enter future model-training data,
-  reducing our ability to treat those problems as unseen evaluation data.
-
-  Please consider these tradeoffs when deciding whether and when to
-  publish. You can freely publish methods, tooling, prompts, aggregate
-  results, and reusable library contributions without publishing the exact
-  benchmark solutions. There is no required embargo: the decision remains
-  yours.
-
-  The intended date requested for planned publication is your current best
-  estimate. It records your intention when you submit and is not a
-  commitment.
+  Only submit files that you have authority to provide and license. Do not
+  include secrets. If you opt out before release, the public leaderboard keeps
+  the evaluation result but shows that the solution is withheld.
   :::
 
 /-! ### Submit-page CTA + TL;DR widgets
@@ -398,21 +373,19 @@ paragraph splices a `<code>` and an `<a>` mid-sentence, so its prose is
 broken into chunks rather than authored as a single string. -/
 
 def submitCtaUrl    : String :=
-  "https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml"
-def submitCtaLabel  : String := "Submit benchmark solution"
+  "https://lean-eval-submission-server.lean-eval.workers.dev/"
+def submitCtaLabel  : String := "Continue to secure submission service"
 def submitCtaArrow  : String := " →"
 
 def submitTldrPart1 : String :=
-  "Three steps: host your proof on GitHub or in a public gist, lay it \
-   out so CI can match each "
+  "Sign in with GitHub, choose the exact source snapshot, and confirm the "
 def submitTldrCode1 : String := "Submission.lean"
 def submitTldrPart2 : String :=
-  " to a problem id, and open a pre-filled issue. CI runs the proof \
-   through "
+  " archive and release terms. LeanEval verifies each matching proof with "
 def submitTldrComparatorLabel : String := "comparator"
 def submitTldrComparatorUrl   : String :=
   "https://github.com/leanprover/comparator"
 def submitTldrPart3 : String :=
-  " and updates the leaderboard automatically."
+  " before recording an accepted result."
 
 end LeaderboardSite.Copy

--- a/LeaderboardSite/Pages/Preview.lean
+++ b/LeaderboardSite/Pages/Preview.lean
@@ -32,8 +32,8 @@ private def groupTabs : Html := {{
        href="formalization-evaluation/">{{textHtml "Formalization evaluation"}}</a>
     <a data-lifecycle-group-tab="software-verification"
        href="software-verification/">{{textHtml "Software verification"}}</a>
-    <a data-lifecycle-group-tab="open-conjectures"
-       href="open-conjectures/">{{textHtml "Open conjectures"}}</a>
+    <a data-lifecycle-group-tab="open-problems"
+       href="open-problems/">{{textHtml "Open problems"}}</a>
     <a href="recent/">{{textHtml "Recent solutions"}}</a>
   </nav>
 }}
@@ -88,8 +88,14 @@ def _root_.LeaderboardSite.Pages.LifecycleFormalization : VersoDoc Page :=
 def _root_.LeaderboardSite.Pages.LifecycleSoftware : VersoDoc Page :=
   .mk (fun _ => pagePart false "Software verification" "group" "software-verification") "{}"
 
-def _root_.LeaderboardSite.Pages.LifecycleConjectures : VersoDoc Page :=
-  .mk (fun _ => pagePart false "Open conjectures" "group" "open-conjectures") "{}"
+def _root_.LeaderboardSite.Pages.LifecycleOpenProblems : VersoDoc Page :=
+  .mk (fun _ => pagePart false "Open problems" "group" "open-problems") "{}"
+
+/-- Neutral compatibility page for the former public route. It deliberately
+uses the canonical open-problems identity and copy rather than preserving the
+retired product concept in navigation or data. -/
+def _root_.LeaderboardSite.Pages.LifecycleOpenProblemsCompatibility : VersoDoc Page :=
+  .mk (fun _ => pagePart false "Open problems" "group" "open-problems") "{}"
 
 def _root_.LeaderboardSite.Pages.LifecycleRecent : VersoDoc Page :=
   .mk (fun _ => pagePart false "Recent solutions" "recent") "{}"
@@ -106,8 +112,8 @@ def _root_.LeaderboardSite.Pages.PreviewFormalization : VersoDoc Page :=
 def _root_.LeaderboardSite.Pages.PreviewSoftware : VersoDoc Page :=
   .mk (fun _ => pagePart true "Software verification" "group" "software-verification") "{}"
 
-def _root_.LeaderboardSite.Pages.PreviewConjectures : VersoDoc Page :=
-  .mk (fun _ => pagePart true "Open conjectures" "group" "open-conjectures") "{}"
+def _root_.LeaderboardSite.Pages.PreviewOpenProblems : VersoDoc Page :=
+  .mk (fun _ => pagePart true "Open problems" "group" "open-problems") "{}"
 
 def _root_.LeaderboardSite.Pages.PreviewRecent : VersoDoc Page :=
   .mk (fun _ => pagePart true "Recent solutions" "recent") "{}"

--- a/LeaderboardSite/Pages/Submit.lean
+++ b/LeaderboardSite/Pages/Submit.lean
@@ -24,7 +24,7 @@ private def pagePart
 private def htmlBlob (h : Verso.Output.Html) : Block Page :=
   Verso.Doc.Block.other (BlockExt.blob h) #[]
 
-/-- Big "Submit benchmark solution" button at the top of the page. -/
+/-- Link from the static site to the authenticated production intake origin. -/
 private def ctaBlock : Block Page :=
   htmlBlob {{
     <a class="cta-button" href={{submitCtaUrl}}>
@@ -33,7 +33,7 @@ private def ctaBlock : Block Page :=
     </a>
   }}
 
-/-- Three-step TL;DR paragraph between the CTA and the lead. The HTML
+/-- Submission TL;DR paragraph between the CTA and the lead. The HTML
 weaves a `<code>` and an `<a>` mid-sentence so its prose is broken
 into chunks rather than authored as a single string. -/
 private def tldrBlock : Block Page :=

--- a/SiteTheme.lean
+++ b/SiteTheme.lean
@@ -40,6 +40,7 @@ def theme (_name : String) (siteName : String) : Theme := {
       path[0]? == some "problems" ||
       path[0]? == some "formalization-evaluation" ||
       path[0]? == some "software-verification" ||
+      path[0]? == some "open-problems" ||
       path[0]? == some "open-conjectures" ||
       path[0]? == some "recent"
     let isWide := isLifecycleAware || isLegacyFront

--- a/schemas/site-data-v2.schema.json
+++ b/schemas/site-data-v2.schema.json
@@ -13,7 +13,7 @@
     "timestamp": {"type": "string", "format": "date-time"},
     "limitations": {"type": "array", "items": {"$ref": "#/$defs/nonempty"}},
     "groupId": {
-      "enum": ["formalization-evaluation", "software-verification", "open-conjectures"]
+      "enum": ["formalization-evaluation", "software-verification", "open-problems"]
     },
     "groupInfo": {
       "type": "object",

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -180,7 +180,7 @@ def load_manifest(manifest_dir: pathlib.Path, benchmark_repo: pathlib.Path) -> l
         if raw["group"] not in {
             "formalization-evaluation",
             "software-verification",
-            "open-conjectures",
+            "open-problems",
         }:
             raise SystemExit(f"{path}: unsupported group {raw['group']!r}")
         if raw["status"] not in {"draft", "active", "archived"}:

--- a/scripts/lifecycle_site_data.py
+++ b/scripts/lifecycle_site_data.py
@@ -40,9 +40,9 @@ GROUPS: tuple[dict[str, str], ...] = (
         "policy": "Private-source submissions; draft standings are provisional until the first frozen set.",
     },
     {
-        "id": "open-conjectures",
-        "label": "Open conjectures",
-        "policy": "Public-source submissions; resolved statements retain their frozen-set history.",
+        "id": "open-problems",
+        "label": "Open problems",
+        "policy": "LeanEval-owned open problems, reviewed and published independently of external catalogs.",
     },
 )
 GROUP_BY_ID = {group["id"]: group for group in GROUPS}

--- a/scripts/validate_lifecycle_site_data.py
+++ b/scripts/validate_lifecycle_site_data.py
@@ -15,7 +15,7 @@ from typing import Any
 GROUPS = {
     "formalization-evaluation",
     "software-verification",
-    "open-conjectures",
+    "open-problems",
 }
 
 

--- a/static/lifecycle-preview.js
+++ b/static/lifecycle-preview.js
@@ -176,7 +176,10 @@
       var title = heading(2, data.group.label);
       var policy = node("p", { className: "lifecycle-policy", text: data.group.policy });
       if (!scope) {
-        var emptyChildren = [title, policy, node("p", { text: "No visible problems are published in this group yet." })];
+        var emptyText = data.group.id === "open-problems"
+          ? "No open problems are published in this group yet."
+          : "No visible problems are published in this group yet.";
+        var emptyChildren = [title, policy, node("p", { text: emptyText })];
         var emptyNote = limitations(data.data_limitations);
         if (emptyNote) emptyChildren.push(emptyNote);
         content.replaceChildren.apply(content, emptyChildren);
@@ -248,7 +251,7 @@
         node("option", { value: "all", text: "All groups" }),
         node("option", { value: "formalization-evaluation", text: "Formalization evaluation" }),
         node("option", { value: "software-verification", text: "Software verification" }),
-        node("option", { value: "open-conjectures", text: "Open conjectures" })
+        node("option", { value: "open-problems", text: "Open problems" })
       ]);
       select.value = selected;
       var list = node("ol", { className: "lifecycle-recent-list" });

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -209,6 +209,19 @@ class LifecycleProjectionTests(unittest.TestCase):
         files = self.build()
         formal = files["v2/groups/formalization-evaluation.json"]
         software = files["v2/groups/software-verification.json"]
+        open_problems = files["v2/groups/open-problems.json"]
+        index = files["v2/index.json"]
+
+        self.assertEqual(
+            [group["id"] for group in index["groups"]],
+            ["formalization-evaluation", "software-verification", "open-problems"],
+        )
+        self.assertEqual(open_problems["problems"], [])
+        self.assertEqual(open_problems["standings"], [])
+        self.assertIn(
+            "independently of external catalogs",
+            open_problems["group"]["policy"],
+        )
 
         self.assertEqual(formal["default_scope"], "v1")
         self.assertTrue(formal["scopes"][0]["flagship"])

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -16,7 +16,11 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn('Dir.page "preview"', site)
         self.assertIn('Dir.page "formalization-evaluation"', site)
         self.assertIn('Dir.page "software-verification"', site)
+        self.assertIn('Dir.page "open-problems"', site)
+        # The retired route is one documented compatibility alias, not a
+        # second group or preview surface.
         self.assertIn('Dir.page "open-conjectures"', site)
+        self.assertEqual(site.count('Dir.page "open-conjectures"'), 1)
         self.assertIn('Dir.page "recent"', site)
         self.assertIn("lifecycle_problem_pages%", site)
         self.assertIn("preview_problem_pages%", site)
@@ -28,6 +32,9 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("aria-label={{heading}}", page)
         self.assertNotIn('<h1 id="lifecycle-title">', page)
         self.assertIn('href="legacy/"', page)
+        self.assertIn('data-lifecycle-group-tab="open-problems"', page)
+        self.assertNotIn('data-lifecycle-group-tab="open-conjectures"', page)
+        self.assertNotIn("Open conjectures", page)
         self.assertNotIn("Local-only preview", page)
 
     def test_lifecycle_problem_pages_retain_the_complete_problem_statement(self) -> None:
@@ -60,6 +67,37 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn('tags:', client)
         self.assertIn('["unique", "first", "total"]', client)
         self.assertIn("recent-solutions.xml", client)
+        self.assertIn("No open problems are published in this group yet.", client)
+
+    def test_submit_page_hands_off_to_the_production_application(self) -> None:
+        copy = (REPO_ROOT / "LeaderboardSite/Copy.lean").read_text()
+        worker = "https://lean-eval-submission-server.lean-eval.workers.dev/"
+        self.assertIn(worker, copy)
+        self.assertIn("GitHub OAuth callbacks", copy)
+        self.assertIn("private encrypted archive", copy)
+        self.assertIn("two UTC calendar months after acceptance", copy)
+        self.assertIn("automatically publishes", copy)
+        self.assertIn("Apache License 2.0", copy)
+        self.assertIn("opt out at any time before release", copy)
+        self.assertIn("legacy GitHub issue form", copy)
+        self.assertIn("return to the leaderboard", copy)
+        self.assertIn(
+            "[return to the leaderboard](https://lean-lang.org/eval/)",
+            copy,
+        )
+        self.assertIn(
+            "https://github.com/apps/lean-eval-source-reader",
+            copy,
+        )
+        self.assertIn("exact 40-character source commit", copy)
+        self.assertIn("requires a private GitHub repository", copy)
+        self.assertNotIn("Public repositories need no extra setup", copy)
+        self.assertNotIn("https://github.com/apps/lean-eval-bot", copy)
+        self.assertNotIn("Secret (unlisted) gists", copy)
+        self.assertNotIn(
+            'def submitCtaUrl    : String :=\n  "https://github.com/',
+            copy,
+        )
 
     def test_client_renders_current_replay_measurement_fields(self) -> None:
         client = (REPO_ROOT / "static/lifecycle-preview.js").read_text()


### PR DESCRIPTION
## Summary

- make Open problems the canonical neutral group, route, tab, data identity, and empty state
- retain the former open-conjectures URL only as a neutral compatibility alias
- hand /eval/submit off to the production Worker and document its OAuth origin, private-only source intake, Source Reader App, encrypted archive, Apache-2.0 automatic two-calendar-month release, opt-out, temporary issue-form overlap, and canonical return URL
- strengthen generated-site and unit checks for the route, data, and submit-page contracts

This PR does not enable intake, deploy services, change DNS, or modify Cloudflare configuration.

## Validation

- python3 -m unittest discover -s tests (42 tests)
- exact-pin site-data generation and schema validation
- full benchmark snapshot build including every highlighted target (9340 jobs)
- full site compile and 919-page generation (248 targets)
- rendered route, alias, empty-data, Worker, App, policy, and return-link assertions
- python3 scripts/check_links.py --site-dir _site --prefix lean-eval-leaderboard (28,769 links)