### PR TITLE
Project real catalog lifecycle history

### DIFF
--- a/docs/site-data-v2.md
+++ b/docs/site-data-v2.md
@@ -49,6 +49,21 @@ order is unique, then first, then total.
 Standings are built and filtered inside one group payload. There is no
 cross-group score or ranking.
 
+## Catalog history
+
+Problem lifecycle history comes from the pinned benchmark manifest's
+append-only `status_history` and `revision_history` tables. The projection
+preserves each calendar date, reason category, and statement digest exactly.
+Revision rows are labeled `superseded` except for the terminal revision, which
+must equal the manifest's current `statement_revision` and is labeled
+`current`. The terminal status row must likewise equal `current_status`.
+
+The initial catalog migration intentionally has no synthetic history rows. If
+a problem manifest has no recorded history, its history arrays remain empty;
+the separately projected current status and statement revision remain visible,
+and the problem payload records the limitation. Presentation-only test fixtures
+are used only when the canonical manifest has no history.
+
 ## Scope and URLs
 
 The newest published frozen set is the group's flagship/default scope. Before

--- a/schemas/site-data-v2.schema.json
+++ b/schemas/site-data-v2.schema.json
@@ -11,6 +11,9 @@
   "$defs": {
     "nonempty": {"type": "string", "minLength": 1},
     "timestamp": {"type": "string", "format": "date-time"},
+    "catalogDate": {"type": "string", "format": "date", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+    "statementDigest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "catalogReason": {"enum": ["initial", "statement-change", "policy", "correction", "retraction", "restoration"]},
     "limitations": {"type": "array", "items": {"$ref": "#/$defs/nonempty"}},
     "groupId": {
       "enum": ["formalization-evaluation", "software-verification", "open-problems"]
@@ -129,7 +132,43 @@
         "schema_version": {"const": 2},
         "generated_at": {"$ref": "#/$defs/timestamp"},
         "problem": {"type": "object", "required": ["id", "title", "group", "current_status", "visible", "statement_revision", "tags", "stable_url", "preview_url"]},
-        "lifecycle": {"type": "object", "required": ["status_history", "statement_revisions"]},
+        "lifecycle": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status_history", "statement_revisions"],
+          "properties": {
+            "status_history": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["status", "effective_at", "reason", "source"],
+                "properties": {
+                  "status": {"enum": ["draft", "active", "archived", "resolved"]},
+                  "effective_at": {"$ref": "#/$defs/catalogDate"},
+                  "reason": {"$ref": "#/$defs/catalogReason"},
+                  "source": {"$ref": "#/$defs/nonempty"}
+                }
+              }
+            },
+            "statement_revisions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["revision", "status", "effective_at", "reason", "statement_digest", "source"],
+                "properties": {
+                  "revision": {"type": "integer", "minimum": 1},
+                  "status": {"enum": ["superseded", "current"]},
+                  "effective_at": {"$ref": "#/$defs/catalogDate"},
+                  "reason": {"$ref": "#/$defs/catalogReason"},
+                  "statement_digest": {"$ref": "#/$defs/statementDigest"},
+                  "source": {"$ref": "#/$defs/nonempty"}
+                }
+              }
+            }
+          }
+        },
         "sets": {"type": "array", "items": {"type": "object", "required": ["id", "title", "frozen", "published_at", "statement_revision"]}},
         "solutions": {"type": "array", "items": {"$ref": "#/$defs/solution"}},
         "data_limitations": {"$ref": "#/$defs/limitations"}

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -12,7 +12,7 @@ import time
 import urllib.request
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
 
 import tomllib
@@ -67,6 +67,15 @@ BENCHMARK_COMMIT_FILE = REPO_ROOT / "benchmark-snapshot" / ".benchmark-commit"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 PROBLEM_ID_RE = re.compile(r"^[A-Za-z0-9_]+$")
 TAG_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+STATEMENT_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+CATALOG_HISTORY_REASONS = {
+    "initial",
+    "statement-change",
+    "policy",
+    "correction",
+    "retraction",
+    "restoration",
+}
 RESULT_USER_RE = re.compile(
     r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"
 )
@@ -103,6 +112,8 @@ class Problem:
     holes: tuple[Hole, ...]
     challenge_path: str
     sort_index: int
+    status_history: tuple[dict[str, str], ...] = ()
+    revision_history: tuple[dict[str, Any], ...] = ()
 
 
 def run(cmd: list[str], cwd: pathlib.Path) -> str:
@@ -154,6 +165,109 @@ def load_holes(benchmark_repo: pathlib.Path, problem_id: str) -> tuple[Hole, ...
     return tuple(holes)
 
 
+def _catalog_effective_date(value: Any, path: pathlib.Path, label: str) -> str:
+    if not isinstance(value, str):
+        raise SystemExit(f"{path}: {label} must be an ISO calendar date")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as error:
+        raise SystemExit(f"{path}: {label} must be an ISO calendar date") from error
+    if parsed.isoformat() != value:
+        raise SystemExit(f"{path}: {label} must be an ISO calendar date")
+    return value
+
+
+def _catalog_reason(value: Any, path: pathlib.Path, label: str) -> str:
+    if not isinstance(value, str) or value not in CATALOG_HISTORY_REASONS:
+        raise SystemExit(f"{path}: {label} has an unsupported category")
+    return value
+
+
+def _load_status_history(
+    raw: dict[str, Any], path: pathlib.Path
+) -> tuple[dict[str, str], ...]:
+    rows = raw.get("status_history", [])
+    if not isinstance(rows, list):
+        raise SystemExit(f"{path}: status_history must be an array")
+    history: list[dict[str, str]] = []
+    previous_date = ""
+    for index, row in enumerate(rows):
+        label = f"status_history[{index}]"
+        if not isinstance(row, dict) or set(row) != {
+            "status",
+            "effective_date",
+            "reason",
+        }:
+            raise SystemExit(f"{path}: {label} has invalid fields")
+        status = row["status"]
+        if status not in {"draft", "active", "archived"}:
+            raise SystemExit(f"{path}: {label}.status has an unsupported value")
+        effective_date = _catalog_effective_date(
+            row["effective_date"], path, f"{label}.effective_date"
+        )
+        if effective_date <= previous_date:
+            raise SystemExit(f"{path}: status_history dates must increase strictly")
+        previous_date = effective_date
+        history.append(
+            {
+                "status": status,
+                "effective_date": effective_date,
+                "reason": _catalog_reason(row["reason"], path, f"{label}.reason"),
+            }
+        )
+    if history and history[-1]["status"] != raw["status"]:
+        raise SystemExit(f"{path}: final status_history entry must equal current status")
+    return tuple(history)
+
+
+def _load_revision_history(
+    raw: dict[str, Any], path: pathlib.Path
+) -> tuple[dict[str, Any], ...]:
+    rows = raw.get("revision_history", [])
+    if not isinstance(rows, list):
+        raise SystemExit(f"{path}: revision_history must be an array")
+    history: list[dict[str, Any]] = []
+    previous_date = ""
+    previous_revision = 0
+    for index, row in enumerate(rows):
+        label = f"revision_history[{index}]"
+        if not isinstance(row, dict) or set(row) != {
+            "revision",
+            "effective_date",
+            "reason",
+            "statement_digest",
+        }:
+            raise SystemExit(f"{path}: {label} has invalid fields")
+        revision = row["revision"]
+        if type(revision) is not int or revision <= previous_revision:
+            raise SystemExit(
+                f"{path}: revision_history revisions must increase strictly"
+            )
+        effective_date = _catalog_effective_date(
+            row["effective_date"], path, f"{label}.effective_date"
+        )
+        if effective_date <= previous_date:
+            raise SystemExit(f"{path}: revision_history dates must increase strictly")
+        digest = row["statement_digest"]
+        if not isinstance(digest, str) or STATEMENT_DIGEST_RE.fullmatch(digest) is None:
+            raise SystemExit(f"{path}: {label}.statement_digest is invalid")
+        previous_revision = revision
+        previous_date = effective_date
+        history.append(
+            {
+                "revision": revision,
+                "effective_date": effective_date,
+                "reason": _catalog_reason(row["reason"], path, f"{label}.reason"),
+                "statement_digest": digest,
+            }
+        )
+    if history and history[-1]["revision"] != raw["statement_revision"]:
+        raise SystemExit(
+            f"{path}: final revision_history entry must equal statement_revision"
+        )
+    return tuple(history)
+
+
 def load_manifest(manifest_dir: pathlib.Path, benchmark_repo: pathlib.Path) -> list[Problem]:
     """Load every `manifests/problems/<id>.toml` file as a `Problem`.
 
@@ -189,6 +303,8 @@ def load_manifest(manifest_dir: pathlib.Path, benchmark_repo: pathlib.Path) -> l
         if not PROBLEM_ID_RE.fullmatch(problem_id):
             raise SystemExit(f"{path}: invalid problem id {problem_id!r}")
         holes = load_holes(benchmark_repo, problem_id)
+        status_history = _load_status_history(raw, path)
+        revision_history = _load_revision_history(raw, path)
         problems.append(
             Problem(
                 id=problem_id,
@@ -206,6 +322,8 @@ def load_manifest(manifest_dir: pathlib.Path, benchmark_repo: pathlib.Path) -> l
                 holes=holes,
                 challenge_path=f"generated/{problem_id}",
                 sort_index=index,
+                status_history=status_history,
+                revision_history=revision_history,
             )
         )
     return problems

--- a/scripts/lifecycle_site_data.py
+++ b/scripts/lifecycle_site_data.py
@@ -799,20 +799,40 @@ def _standings(
 
 def _problem_lifecycle(problem: Any, fixture: dict[str, Any]) -> dict[str, Any]:
     override = fixture.get("problem_lifecycle", {}).get(problem.id, {})
-    history = override.get("status_history") or [
-        {
-            "status": problem.status,
-            "effective_at": None,
-            "source": "catalog-current-state",
-        }
-    ]
-    revisions = override.get("statement_revisions") or [
-        {
-            "revision": problem.statement_revision,
-            "status": "current",
-            "source": "catalog-current-state",
-        }
-    ]
+    catalog_status_history = getattr(problem, "status_history", ())
+    catalog_revision_history = getattr(problem, "revision_history", ())
+    history = (
+        [
+            {
+                "status": entry["status"],
+                "effective_at": entry["effective_date"],
+                "reason": entry["reason"],
+                "source": "catalog-manifest",
+            }
+            for entry in catalog_status_history
+        ]
+        if catalog_status_history
+        else [dict(entry) for entry in override.get("status_history", [])]
+    )
+    revisions = (
+        [
+            {
+                "revision": entry["revision"],
+                "status": (
+                    "current"
+                    if entry["revision"] == problem.statement_revision
+                    else "superseded"
+                ),
+                "effective_at": entry["effective_date"],
+                "reason": entry["reason"],
+                "statement_digest": entry["statement_digest"],
+                "source": "catalog-manifest",
+            }
+            for entry in catalog_revision_history
+        ]
+        if catalog_revision_history
+        else [dict(entry) for entry in override.get("statement_revisions", [])]
+    )
     return {"status_history": history, "statement_revisions": revisions}
 
 
@@ -886,6 +906,9 @@ def build_lifecycle_projection(
     solutions = [solution for solution in solutions if solution.problem_id in visible_ids]
     credits = _deduplicated_credits(solutions)
     first_ids = _first_result_ids(solutions)
+    problem_lifecycles = {
+        problem.id: _problem_lifecycle(problem, fixture) for problem in visible
+    }
     limitations: list[str] = []
     if not state_commit:
         limitations.append(
@@ -898,9 +921,12 @@ def build_lifecycle_projection(
         limitations.append(
             "Results not yet present in the public State projection were adapted from the immutable base-results store; their replay/release states are explicitly unavailable."
         )
-    if not fixture.get("problem_lifecycle"):
+    if not any(
+        lifecycle["status_history"] or lifecycle["statement_revisions"]
+        for lifecycle in problem_lifecycles.values()
+    ):
         limitations.append(
-            "Catalog lifecycle history beyond the current pinned manifest is unavailable; the site shows the current status as a one-entry history."
+            "The pinned catalog records no lifecycle history for any visible problem; current fields are reported separately and no history entry is fabricated."
         )
     published_model_aliases = list(model_aliases) or fixture.get(
         "model_aliases", []
@@ -1007,7 +1033,16 @@ def build_lifecycle_projection(
 
     for problem in visible:
         problem_solutions = [item for item in solutions if item.problem_id == problem.id]
-        lifecycle = _problem_lifecycle(problem, fixture)
+        lifecycle = problem_lifecycles[problem.id]
+        problem_limitations = list(limitations)
+        if not lifecycle["status_history"]:
+            problem_limitations.append(
+                "No status transition history is recorded for this problem; current_status is reported separately and no history entry is fabricated."
+            )
+        if not lifecycle["statement_revisions"]:
+            problem_limitations.append(
+                "No statement revision history is recorded for this problem; statement_revision is reported separately and no history entry is fabricated."
+            )
         files[f"v2/problems/{problem.id}.json"] = {
             "schema_version": 2,
             "generated_at": generated_at,
@@ -1042,7 +1077,7 @@ def build_lifecycle_projection(
                 _solution_payload(solution, first_ids)
                 for solution in sorted(problem_solutions, key=_acceptance_key)
             ],
-            "data_limitations": limitations,
+            "data_limitations": problem_limitations,
         }
 
     recent = sorted(solutions, key=_acceptance_key, reverse=True)

--- a/scripts/validate_lifecycle_site_data.py
+++ b/scripts/validate_lifecycle_site_data.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Validate lifecycle-aware site-data schema version 2 without dependencies."""
 
 from __future__ import annotations
@@ -6,16 +5,27 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import re
 import sys
 import xml.etree.ElementTree as ET
 from collections import defaultdict
+from datetime import date
 from typing import Any
-
 
 GROUPS = {
     "formalization-evaluation",
     "software-verification",
     "open-problems",
+}
+CATALOG_DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
+STATEMENT_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}")
+CATALOG_REASONS = {
+    "initial",
+    "statement-change",
+    "policy",
+    "correction",
+    "retraction",
+    "restoration",
 }
 
 
@@ -36,6 +46,19 @@ def load_json(path: pathlib.Path) -> dict[str, Any]:
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise ContractError(message)
+
+
+def catalog_date(value: Any, message: str) -> str:
+    require(
+        isinstance(value, str) and CATALOG_DATE_RE.fullmatch(value) is not None,
+        message,
+    )
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as error:
+        raise ContractError(message) from error
+    require(parsed.isoformat() == value, message)
+    return value
 
 
 def scope_ids(group: dict[str, Any]) -> set[tuple[str, int]]:
@@ -71,6 +94,103 @@ def recompute_counts(group: dict[str, Any]) -> dict[str, dict[str, int]]:
         current["unique"] += len(solvers[credit["problem_id"]]) == 1
         current["first"] += bool(credit["first_solve"])
     return dict(counts)
+
+
+def validate_problem_lifecycle(
+    path: pathlib.Path, problem: dict[str, Any], lifecycle: dict[str, Any]
+) -> None:
+    require(
+        set(lifecycle) == {"status_history", "statement_revisions"},
+        f"{path}: invalid lifecycle fields",
+    )
+    status_history = lifecycle["status_history"]
+    revisions = lifecycle["statement_revisions"]
+    require(isinstance(status_history, list), f"{path}: invalid status history")
+    require(isinstance(revisions, list), f"{path}: invalid revision history")
+
+    previous_date = ""
+    for entry in status_history:
+        require(
+            isinstance(entry, dict)
+            and set(entry) == {"status", "effective_at", "reason", "source"},
+            f"{path}: invalid status history entry",
+        )
+        require(
+            entry["status"] in {"draft", "active", "archived", "resolved"},
+            f"{path}: invalid historical status",
+        )
+        effective_at = catalog_date(
+            entry["effective_at"], f"{path}: status history date is invalid"
+        )
+        require(
+            effective_at > previous_date,
+            f"{path}: status history order is invalid",
+        )
+        require(
+            entry["reason"] in CATALOG_REASONS,
+            f"{path}: invalid status reason",
+        )
+        require(
+            isinstance(entry["source"], str) and bool(entry["source"]),
+            f"{path}: invalid status source",
+        )
+        previous_date = effective_at
+    if status_history:
+        require(
+            status_history[-1]["status"] == problem["current_status"],
+            f"{path}: terminal status history differs from current status",
+        )
+
+    previous_date = ""
+    previous_revision = 0
+    for index, entry in enumerate(revisions):
+        require(
+            isinstance(entry, dict)
+            and set(entry)
+            == {
+                "revision",
+                "status",
+                "effective_at",
+                "reason",
+                "statement_digest",
+                "source",
+            },
+            f"{path}: invalid revision history entry",
+        )
+        revision = entry["revision"]
+        effective_at = catalog_date(
+            entry["effective_at"], f"{path}: revision history date is invalid"
+        )
+        require(
+            type(revision) is int
+            and revision > previous_revision
+            and effective_at > previous_date,
+            f"{path}: revision history order is invalid",
+        )
+        expected_status = (
+            "current" if index == len(revisions) - 1 else "superseded"
+        )
+        require(entry["status"] == expected_status, f"{path}: invalid revision state")
+        require(
+            entry["reason"] in CATALOG_REASONS,
+            f"{path}: invalid revision reason",
+        )
+        require(
+            isinstance(entry["statement_digest"], str)
+            and STATEMENT_DIGEST_RE.fullmatch(entry["statement_digest"]) is not None,
+            f"{path}: invalid statement digest",
+        )
+        require(
+            isinstance(entry["source"], str) and bool(entry["source"]),
+            f"{path}: invalid revision source",
+        )
+        previous_revision = revision
+        previous_date = effective_at
+    if revisions:
+        require(
+            revisions[-1]["revision"] == problem["statement_revision"],
+            f"{path}: terminal revision history differs from current revision",
+        )
 
 
 def validate(root: pathlib.Path) -> None:
@@ -114,8 +234,8 @@ def validate(root: pathlib.Path) -> None:
         require(problem.get("group") == problem_group[problem_id], f"{path}: group mismatch")
         require(problem.get("visible") is True, f"{path}: hidden problem leaked")
         lifecycle = payload.get("lifecycle", {})
-        require(bool(lifecycle.get("status_history")), f"{path}: missing status history")
-        require(bool(lifecycle.get("statement_revisions")), f"{path}: missing revisions")
+        require(isinstance(lifecycle, dict), f"{path}: lifecycle must be an object")
+        validate_problem_lifecycle(path, problem, lifecycle)
         for solution in payload.get("solutions", []):
             require(solution.get("problem_id") == problem_id, f"{path}: solution problem mismatch")
             require("status" in solution.get("replay", {}), f"{path}: replay state omitted")

--- a/scripts/validate_lifecycle_site_data.py
+++ b/scripts/validate_lifecycle_site_data.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Validate lifecycle-aware site-data schema version 2 without dependencies."""
 
 from __future__ import annotations

--- a/static/lifecycle-preview.js
+++ b/static/lifecycle-preview.js
@@ -34,7 +34,10 @@
   }
 
   function formattedDate(value) {
-    var date = new Date(value);
+    var calendar = typeof value === "string" && /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    var date = calendar
+      ? new Date(Number(calendar[1]), Number(calendar[2]) - 1, Number(calendar[3]))
+      : new Date(value);
     return Number.isNaN(date.valueOf()) ? value : date.toLocaleDateString(undefined, {
       year: "numeric", month: "short", day: "numeric"
     });
@@ -296,9 +299,11 @@
       status.hidden = true;
       var problem = data.problem;
       markGroupTab(problem.group);
-      var history = node("ol", { className: "lifecycle-history" }, data.lifecycle.status_history.map(function (entry) {
-        return node("li", { text: entry.status + (entry.effective_at ? " · " + formattedDate(entry.effective_at) : " · date unavailable") });
-      }));
+      var historyEntries = data.lifecycle.status_history.map(function (entry) {
+        return node("li", { text: entry.status + (entry.effective_at ? " · " + formattedDate(entry.effective_at) : " · date unavailable") + (entry.reason ? " · " + entry.reason : "") });
+      });
+      if (!historyEntries.length) historyEntries.push(node("li", { text: "No recorded status transitions." }));
+      var history = node("ol", { className: "lifecycle-history" }, historyEntries);
       var sets = node("ul", {}, data.sets.length ? data.sets.map(function (set) {
         return node("li", { text: set.title + " · statement r" + set.statement_revision + (set.frozen ? " · frozen" : " · draft") });
       }) : [node("li", { text: "No named set membership." })]);

--- a/tests/fixtures/catalog-history/canonical/coc_strong_normalization.toml
+++ b/tests/fixtures/catalog-history/canonical/coc_strong_normalization.toml
@@ -1,0 +1,18 @@
+id = "coc_strong_normalization"
+title = "Strong normalization and consistency for the calculus of constructions with a universe hierarchy"
+group = "software-verification"
+status = "draft"
+visible = true
+statement_revision = 1
+tags = []
+module = "LeanEval.ProgramVerification.CoCStrongNormalization"
+holes = ["typing_polyId", "typing_polyId_app", "step_polyId_app", "subject_reduction", "strong_normalization", "consistency"]
+submitter = "Kim Morrison"
+source = "Coquand and Huet, 'The calculus of constructions' (1988); Zhaohui Luo, 'An Extended Calculus of Constructions' (1990); Bruno Barras, 'Sets in Coq, Coq in Sets' (2010)."
+notes = "Strong normalization requires Girard's reducibility candidates, and the impredicative `Prop` rule `(s, prop, prop)` is what makes a naive induction on types fail. The three anti-vacuity guards require a nonempty typing relation and exercise polymorphic typing, `Typing.app`, beta reduction, and substitution. Mathlib does not provide the requested Lean theorem; earlier Coq mechanizations and semantic models of CC and CCω are acknowledged in the module documentation."
+informal_solution = "Use reducibility candidates in the style of Girard, extended to dependent types and the predicative universe hierarchy. A smaller λC rehearsal replaces the hierarchy by `Prop` and a top sort `Type 0`; it is a different typing relation, not literally the restriction of this CCω syntax to two sorts."
+
+[[status_history]]
+status = "draft"
+effective_date = "2026-08-25"
+reason = "correction"

--- a/tests/fixtures/catalog-history/with-history/catalog_history_fixture.toml
+++ b/tests/fixtures/catalog-history/with-history/catalog_history_fixture.toml
@@ -1,0 +1,32 @@
+id = "catalog_history_fixture"
+title = "Catalog history fixture"
+group = "formalization-evaluation"
+status = "active"
+visible = true
+statement_revision = 3
+tags = []
+module = "LeanEval.CatalogHistoryFixture"
+holes = ["catalog_history_fixture"]
+submitter = "LeanEval maintainers"
+
+[[status_history]]
+status = "draft"
+effective_date = "2026-07-01"
+reason = "initial"
+
+[[status_history]]
+status = "active"
+effective_date = "2026-08-20"
+reason = "policy"
+
+[[revision_history]]
+revision = 2
+effective_date = "2026-07-15"
+reason = "statement-change"
+statement_digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+[[revision_history]]
+revision = 3
+effective_date = "2026-08-21"
+reason = "correction"
+statement_digest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/fixtures/catalog-history/without-history/catalog_current_only.toml
+++ b/tests/fixtures/catalog-history/without-history/catalog_current_only.toml
@@ -1,0 +1,10 @@
+id = "catalog_current_only"
+title = "Catalog current-state-only fixture"
+group = "formalization-evaluation"
+status = "draft"
+visible = true
+statement_revision = 1
+tags = []
+module = "LeanEval.CatalogCurrentOnly"
+holes = ["catalog_current_only"]
+submitter = "LeanEval maintainers"

--- a/tests/fixtures/preview-domain-schema-version-1.json
+++ b/tests/fixtures/preview-domain-schema-version-1.json
@@ -22,12 +22,14 @@
       "status_history": [
         {
           "status": "draft",
-          "effective_at": "2026-07-01T00:00:00Z",
+          "effective_at": "2026-07-01",
+          "reason": "initial",
           "source": "fixture-event-1"
         },
         {
           "status": "active",
-          "effective_at": "2026-08-01T00:00:00Z",
+          "effective_at": "2026-08-01",
+          "reason": "correction",
           "source": "fixture-event-2"
         }
       ],
@@ -35,6 +37,9 @@
         {
           "revision": 1,
           "status": "current",
+          "effective_at": "2026-08-01",
+          "reason": "correction",
+          "statement_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
           "source": "fixture-event-2"
         }
       ]

--- a/tests/test_catalog_history_projection.py
+++ b/tests/test_catalog_history_projection.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import pathlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from scripts.generate_site_data import load_manifest
+from scripts.lifecycle_site_data import build_lifecycle_projection
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+FIXTURES = ROOT / "tests" / "fixtures" / "catalog-history"
+
+
+def load_fixture(name: str):
+    with patch("scripts.generate_site_data.load_holes", return_value=()):
+        return load_manifest(FIXTURES / name, pathlib.Path("benchmark"))[0]
+
+
+def project(problem):
+    return build_lifecycle_projection(
+        problems=[problem],
+        solutions=[],
+        set_definitions=[],
+        tag_registry={},
+        fixture={},
+        generated_at="2026-08-26T00:00:00Z",
+        benchmark_commit="a" * 40,
+        state_commit=None,
+        state_metadata=None,
+        site_base_url="https://example.test/eval/",
+    )
+
+
+class CatalogHistoryProjectionTests(unittest.TestCase):
+    def test_client_handles_empty_history_and_calendar_dates(self) -> None:
+        client = (ROOT / "static" / "lifecycle-preview.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("No recorded status transitions.", client)
+        self.assertIn("Number(calendar[2]) - 1", client)
+
+    def test_current_canonical_status_fixture_projects_real_history(self) -> None:
+        problem = load_fixture("canonical")
+        payload = project(problem)[
+            "v2/problems/coc_strong_normalization.json"
+        ]
+
+        self.assertEqual(problem.status_history, (
+            {
+                "status": "draft",
+                "effective_date": "2026-08-25",
+                "reason": "correction",
+            },
+        ))
+        self.assertEqual(payload["lifecycle"]["status_history"], [
+            {
+                "status": "draft",
+                "effective_at": "2026-08-25",
+                "reason": "correction",
+                "source": "catalog-manifest",
+            }
+        ])
+        self.assertFalse(
+            any(
+                "status transition history is recorded" in limitation
+                for limitation in payload["data_limitations"]
+            )
+        )
+
+    def test_real_manifest_history_is_projected_without_losing_fields(self) -> None:
+        problem = load_fixture("with-history")
+        files = project(problem)
+        lifecycle = files[
+            "v2/problems/catalog_history_fixture.json"
+        ]["lifecycle"]
+
+        self.assertEqual(
+            lifecycle["status_history"],
+            [
+                {
+                    "status": "draft",
+                    "effective_at": "2026-07-01",
+                    "reason": "initial",
+                    "source": "catalog-manifest",
+                },
+                {
+                    "status": "active",
+                    "effective_at": "2026-08-20",
+                    "reason": "policy",
+                    "source": "catalog-manifest",
+                },
+            ],
+        )
+        self.assertEqual(
+            lifecycle["statement_revisions"],
+            [
+                {
+                    "revision": 2,
+                    "status": "superseded",
+                    "effective_at": "2026-07-15",
+                    "reason": "statement-change",
+                    "statement_digest": "sha256:" + "a" * 64,
+                    "source": "catalog-manifest",
+                },
+                {
+                    "revision": 3,
+                    "status": "current",
+                    "effective_at": "2026-08-21",
+                    "reason": "correction",
+                    "statement_digest": "sha256:" + "b" * 64,
+                    "source": "catalog-manifest",
+                },
+            ],
+        )
+        self.assertFalse(
+            any(
+                "Catalog lifecycle history beyond" in limitation
+                for limitation in files["v2/index.json"]["data_limitations"]
+            )
+        )
+
+    def test_manifest_history_order_is_enforced(self) -> None:
+        original = (
+            FIXTURES / "with-history" / "catalog_history_fixture.toml"
+        ).read_text(encoding="utf-8")
+        cases = {
+            "status": original.replace(
+                'effective_date = "2026-08-20"',
+                'effective_date = "2026-06-30"',
+            ),
+            "revision": original.replace("revision = 3", "revision = 1"),
+        }
+        for label, manifest in cases.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as raw:
+                root = pathlib.Path(raw)
+                (root / "catalog_history_fixture.toml").write_text(
+                    manifest, encoding="utf-8"
+                )
+                with (
+                    patch("scripts.generate_site_data.load_holes", return_value=()),
+                    self.assertRaisesRegex(SystemExit, "increase strictly"),
+                ):
+                    load_manifest(root, pathlib.Path("benchmark"))
+
+    def test_terminal_history_must_equal_current_manifest_state(self) -> None:
+        original = (
+            FIXTURES / "with-history" / "catalog_history_fixture.toml"
+        ).read_text(encoding="utf-8")
+        cases = {
+            "status": (
+                original.replace('status = "active"', 'status = "archived"', 1),
+                "current status",
+            ),
+            "revision": (
+                original.replace("statement_revision = 3", "statement_revision = 4"),
+                "statement_revision",
+            ),
+        }
+        for label, (manifest, message) in cases.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as raw:
+                root = pathlib.Path(raw)
+                (root / "catalog_history_fixture.toml").write_text(
+                    manifest, encoding="utf-8"
+                )
+                with (
+                    patch("scripts.generate_site_data.load_holes", return_value=()),
+                    self.assertRaisesRegex(SystemExit, message),
+                ):
+                    load_manifest(root, pathlib.Path("benchmark"))
+
+    def test_current_state_does_not_fabricate_history(self) -> None:
+        problem = load_fixture("without-history")
+        files = project(problem)
+        payload = files["v2/problems/catalog_current_only.json"]
+
+        self.assertEqual(payload["lifecycle"]["status_history"], [])
+        self.assertEqual(payload["lifecycle"]["statement_revisions"], [])
+        self.assertEqual(payload["problem"]["current_status"], "draft")
+        self.assertEqual(payload["problem"]["statement_revision"], 1)
+        self.assertTrue(
+            any(
+                "no lifecycle history for any visible problem" in limitation
+                for limitation in files["v2/index.json"]["data_limitations"]
+            )
+        )
+        history_limitations = [
+            limitation
+            for limitation in payload["data_limitations"]
+            if "history is recorded" in limitation
+        ]
+        self.assertEqual(len(history_limitations), 2)
+        self.assertTrue(
+            all(
+                "no history entry is fabricated" in limitation
+                for limitation in history_limitations
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- parse canonical `status_history` and `revision_history` from the pinned LeanEval problem manifests
- project recorded dates, reasons, statement digests, and derived current/superseded revision state without fabricating history rows
- replace the false global history-unavailable limitation when any visible canonical history exists, while keeping precise per-problem limitations for empty lanes
- validate the lifecycle contract and cover real fixture projection, ordering, terminal equality, and non-fabrication

Stable problem-statement generation and existing leaderboard routes/UI structure are unchanged.

## Checks

- `python3 -m unittest discover -v -s tests` (48 tests)
- `uvx ruff check scripts/generate_site_data.py scripts/lifecycle_site_data.py scripts/validate_lifecycle_site_data.py tests/test_catalog_history_projection.py`
- `python3 -m compileall -q scripts tests`
- `python3 -m json.tool schemas/site-data-v2.schema.json`
- `node --check static/lifecycle-preview.js`
- complete site-data generation from pinned LeanEval `16945dfb367f77eaffaf167bbf70d57796e1bf08`, followed by standalone lifecycle validation
- JSON Schema validation of all 306 generated JSON files