### PR TITLE
docs: mark submission server as prelaunch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -289,6 +289,26 @@ jobs:
           grep -F 'automatically publishes' _site/submit/index.html
           grep -F 'Apache License 2.0' _site/submit/index.html
           grep -F 'legacy GitHub issue form' _site/submit/index.html
+          grep -F 'Production server intake is not enabled' \
+            _site/submit/index.html
+          grep -F 'it is not accepting submissions' \
+            _site/submit/index.html
+          grep -F 'current functioning' _site/submit/index.html
+          grep -F 'submission path until production server intake launches' \
+            _site/submit/index.html
+          grep -F 'Server intake prelaunch — not accepting submissions' \
+            _site/submit/index.html
+          grep -F 'Submit now through the GitHub issue form' \
+            _site/submit/index.html
+          if grep -F 'secondary path' _site/submit/index.html; then
+            echo "::error::The submit page calls functioning issue intake secondary."
+            exit 1
+          fi
+          if grep -F 'New submissions should use the authenticated application' \
+              _site/submit/index.html; then
+            echo "::error::The prelaunch submit page directs users to disabled server intake."
+            exit 1
+          fi
           grep -F '<a href="https://lean-lang.org/eval/">return to the leaderboard</a>' \
             _site/submit/index.html
           jq --exit-status '.preview.kind == "results-v2-compatibility"' \

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -269,42 +269,52 @@ def submitTitle : String := "Submit"
 def submitLeadBody : VersoDoc Page :=
   verso (Page) "submitLead"
   :::
-  The authenticated submission application is hosted at
-  [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/).
-  This separate origin is intentional: GitHub OAuth callbacks and the
-  application session are scoped to the Worker that handles private intake.
-  After submitting, you can
+  Production server intake is not enabled. The authenticated application at
+  [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/)
+  is visible for prelaunch review, but it is not accepting submissions.
+
+  To submit now, use the
+  [legacy GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+  in `leanprover/lean-eval-submissions`. It remains the current functioning
+  submission path until production server intake launches. You can then
   [return to the leaderboard](https://lean-lang.org/eval/).
 
-  During the temporary transition, the
-  [legacy GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  remains available as a secondary path for existing users. New submissions
-  should use the authenticated application above.
+  After launch, GitHub OAuth callbacks and the application session will be
+  scoped to the separate Worker origin that handles private intake.
   :::
 
 def submitStep1Title  : String :=
-  "1. Prepare a source LeanEval can fetch"
+  "1. Submit through the current GitHub issue intake"
 def submitStep1HtmlId : String := "step-1"
 
 def submitStep1Body : VersoDoc Page :=
   verso (Page) "submitStep1"
   :::
-  Launch intake requires a private GitHub repository in `owner/repository`
-  form and the exact 40-character source commit to evaluate. Before submitting,
-  [install the Lean Eval Source Reader GitHub App](https://github.com/apps/lean-eval-source-reader)
-  on that repository so that LeanEval can clone it.
+  Open the
+  [legacy GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+  and follow its current source and metadata instructions. Do not use the
+  prelaunch Worker application to submit a solution while server intake is
+  disabled.
   :::
 
-def submitStep2Title  : String := "2. Submit through the authenticated application"
+def submitStep2Title  : String := "2. Preview the planned authenticated workflow"
 def submitStep2HtmlId : String := "step-2"
 
 def submitStep2Body : VersoDoc Page :=
   verso (Page) "submitStep2"
   :::
-  [Continue to the secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/)
-  and sign in with GitHub. Choose the source and identify the model or system
-  that produced the proof. The application walks the submitted source and
-  tries every directory containing a
+  The
+  [secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/)
+  is in prelaunch and is not accepting submissions. When production intake
+  launches, it will require a private GitHub repository in `owner/repository`
+  form and the exact 40-character source commit to evaluate. Submitters will
+  first
+  [install the Lean Eval Source Reader GitHub App](https://github.com/apps/lean-eval-source-reader)
+  on that repository, then sign in with GitHub, choose the source, and identify
+  the model or system that produced the proof.
+
+  The application will walk the submitted source and
+  try every directory containing a
   `lakefile.toml` whose `name` field matches a benchmark problem id, and
   which has a `Submission.lean` next to it. For example:
 
@@ -315,18 +325,18 @@ def submitStep2Body : VersoDoc Page :=
   - a custom repository containing several benchmark workspaces side by
     side
 
-  For each matched directory LeanEval overlays only your `Submission.lean`
+  For each matched directory LeanEval will overlay only your `Submission.lean`
   and any files under `Submission/**/*.lean` onto a pristine copy of the
   benchmark's workspace for that problem. Every other file in your
-  submission is ignored, including `Solution.lean`, `Challenge.lean`, or
-  any modified `lakefile.toml`. The CI then runs
+  submission will be ignored, including `Solution.lean`, `Challenge.lean`, or
+  any modified `lakefile.toml`. The CI will then run
   [comparator](https://github.com/leanprover/comparator) to check the
   proof.
 
-  Before evaluation, LeanEval records the exact source revision and digest
-  and stores a private encrypted archive bound to that submission. Submission
-  source and credentials are not exposed through public workflow artifacts or
-  logs.
+  Before evaluation, LeanEval will record the exact source revision and digest
+  and store a private encrypted archive bound to that submission. Submission
+  source and credentials will not be exposed through public workflow artifacts
+  or logs.
   :::
 
 def submitStep3Title  : String := "3. Confirm the release terms"
@@ -335,13 +345,15 @@ def submitStep3HtmlId : String := "step-3"
 def submitStep3Body : VersoDoc Page :=
   verso (Page) "submitStep3"
   :::
-  The submission action includes this acknowledgement:
+  When production server intake launches, the submission action will include
+  this acknowledgement:
 
   > By submitting, I confirm that I have authority to provide this source. I authorize Lean Eval to store and run it privately for evaluation, publish evaluation metadata and results, and, two UTC calendar months after acceptance, publish the submitted source under the Apache License 2.0. I will not submit secrets or material I am not authorized to disclose.
 
-  Accepted source is scheduled for publication by default. You may opt out in
-  the submission application, or ask to opt out at any time before release.
-  The public result then remains visible with its solution marked as withheld.
+  Source accepted through that application will be scheduled for publication
+  by default. Submitters may opt out at any time before release, either in the
+  application or by asking later. The public result then remains visible with
+  its solution marked as withheld.
   :::
 
 def submitWhatPublicTitle  : String := "What becomes public, and when"
@@ -350,9 +362,13 @@ def submitWhatPublicHtmlId : String := "what-becomes-public"
 def submitWhatPublicBody : VersoDoc Page :=
   verso (Page) "submitWhatPublic"
   :::
-  Submission metadata and evaluation results may become public when the
-  result is recorded. Private source remains in the encrypted archive during
-  the release delay.
+  The following release policy applies to submissions made through the
+  authenticated application after production intake launches. Current issue
+  intake retains its existing policy.
+
+  Submission metadata and evaluation results may become public when the result
+  is recorded. Private source remains in the encrypted archive during the
+  release delay.
 
   Unless you opt out, LeanEval automatically publishes the exact accepted
   `Submission.lean` and files under `Submission/` under the Apache License 2.0
@@ -374,14 +390,15 @@ broken into chunks rather than authored as a single string. -/
 
 def submitCtaUrl    : String :=
   "https://lean-eval-submission-server.lean-eval.workers.dev/"
-def submitCtaLabel  : String := "Continue to secure submission service"
+def submitCtaLabel  : String :=
+  "Server intake prelaunch — not accepting submissions"
 def submitCtaArrow  : String := " →"
 
 def submitTldrPart1 : String :=
-  "Sign in with GitHub, choose the exact source snapshot, and confirm the "
+  "Production server intake is disabled. Submit now through the GitHub issue form with your "
 def submitTldrCode1 : String := "Submission.lean"
 def submitTldrPart2 : String :=
-  " archive and release terms. LeanEval verifies each matching proof with "
+  " source; the existing workflow verifies each matching proof with "
 def submitTldrComparatorLabel : String := "comparator"
 def submitTldrComparatorUrl   : String :=
   "https://github.com/leanprover/comparator"

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -69,10 +69,31 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("recent-solutions.xml", client)
         self.assertIn("No open problems are published in this group yet.", client)
 
-    def test_submit_page_hands_off_to_the_production_application(self) -> None:
+    def test_submit_page_marks_server_prelaunch_and_keeps_issue_intake_current(self) -> None:
         copy = (REPO_ROOT / "LeaderboardSite/Copy.lean").read_text()
         worker = "https://lean-eval-submission-server.lean-eval.workers.dev/"
+        issue_form = (
+            "https://github.com/leanprover/lean-eval-submissions/"
+            "issues/new?template=submit.yml"
+        )
         self.assertIn(worker, copy)
+        self.assertIn(issue_form, copy)
+        self.assertIn("Production server intake is not enabled", copy)
+        self.assertIn("it is not accepting submissions", copy)
+        self.assertIn("current functioning\n  submission path", copy)
+        self.assertIn(
+            "Server intake prelaunch — not accepting submissions",
+            copy,
+        )
+        self.assertIn(
+            "Submit now through the GitHub issue form",
+            copy,
+        )
+        self.assertNotIn("secondary path", copy)
+        self.assertNotIn(
+            "New submissions\n  should use the authenticated application",
+            copy,
+        )
         self.assertIn("GitHub OAuth callbacks", copy)
         self.assertIn("private encrypted archive", copy)
         self.assertIn("two UTC calendar months after acceptance", copy)
@@ -90,7 +111,7 @@ class PreviewStructureTests(unittest.TestCase):
             copy,
         )
         self.assertIn("exact 40-character source commit", copy)
-        self.assertIn("requires a private GitHub repository", copy)
+        self.assertIn("will require a private GitHub repository", copy)
         self.assertNotIn("Public repositories need no extra setup", copy)
         self.assertNotIn("https://github.com/apps/lean-eval-bot", copy)
         self.assertNotIn("Secret (unlisted) gists", copy)


### PR DESCRIPTION
## Summary

- state clearly that production server intake is disabled and not accepting submissions
- direct submitters to the functioning legacy GitHub issue form while preserving the Worker CTA as an unavailable prelaunch preview
- future-scope the authenticated workflow and release-policy copy without changing endpoint URLs or runtime flags
- add exact source and rendered-page assertions that prevent the stale production-intake wording from returning

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v` (42 tests passed)
- `git diff --check`

The hosted Pages job is the authoritative clean render and link-check validation.