### PR TITLE
chore: bump toolchain to v4.33.1

### DIFF
--- a/LeaderboardSite/Data.lean
+++ b/LeaderboardSite/Data.lean
@@ -349,7 +349,7 @@ def anchorSourceText (snapshotModule : String) (fileText : String)
 def runPageDocElab (act : DocElabM α) : TermElabM α := do
   let ctx ← DocElabContext.fromGenreTerm (← `(Page))
   let initDocState : DocElabM.State := { highlightDeduplicationTable := .some {} }
-  let initPartState : PartElabM.State := .init (Syntax.mkStrLit "Page")
+  let initPartState : PartElabM.State := .init (Syntax.mkStrLit "Page") (Syntax.mkStrLit "Page")
   let (result, _) ← DocElabM.run ctx initDocState initPartState act
   pure result
 

--- a/benchmark-snapshot/lakefile.toml
+++ b/benchmark-snapshot/lakefile.toml
@@ -4,7 +4,7 @@ defaultTargets = ["BenchmarkProblems"]
 [[require]]
 name = "mathlib"
 git = "https://github.com/leanprover-community/mathlib4.git"
-rev = "6f1ef4e5dd604a435bddba4747b13970cd65d2a1"
+rev = "v4.33.1"
 
 [[require]]
 name = "subverso"
@@ -12,7 +12,7 @@ git = "https://github.com/leanprover/subverso"
 # Pinned to the SubVerso revision Verso pulls into LeaderboardSite, so the
 # highlighted JSON this snapshot emits stays decodable by the site. Derived
 # from the site lakefile's Verso pin by scripts/generate_site_data.py.
-rev = "ce893b9042128037e2d3c0158b9567fab9fae268"
+rev = "3a75ede05278806fd3249bb0c97a6fb5777a4f7d"
 
 [[lean_lib]]
 name = "BenchmarkProblems"

--- a/benchmark-snapshot/lean-toolchain
+++ b/benchmark-snapshot/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.33.0
+leanprover/lean4:v4.33.1

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,8 +1,8 @@
 import Lake
 open Lake DSL
 
-require std from git "https://github.com/leanprover/std4" @ "v4.30.0-rc2"
-require verso from git "https://github.com/leanprover/verso" @ "v4.30.0-rc2"
+require std from git "https://github.com/leanprover/std4" @ "v4.33.0"
+require verso from git "https://github.com/leanprover/verso" @ "v4.33.0"
 
 package «lean-eval-leaderboard» where
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.30.0-rc2
+leanprover/lean4:v4.33.1


### PR DESCRIPTION
This PR bumps the Lean toolchain from `v4.30.0-rc2` to `v4.33.1` and refreshes the Lake manifest.

Verso and Std move from `v4.30.0-rc2` to `v4.33.0`, their most recent tags.

🤖 Prepared with Claude Code