### PR TITLE
Fail closed on unmaterialized release links

### DIFF
--- a/docs/site-data-schema.md
+++ b/docs/site-data-schema.md
@@ -251,6 +251,11 @@ The website should show one row per `model_id`, not one row per user.
 - `public_solution.url`: final website-ready URL, if public
 - `provenance`: first-success audit information used for this row/problem pair
 
+The compatibility payload has no State release evidence, so base Results emit
+`public_solution.available = false` even when their source was public at intake.
+Release links appear only in lifecycle data backed by a materialized State
+release record.
+
 ## Aggregation rules
 
 These rules resolve the mismatch between the raw append-only user records and

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -955,16 +955,6 @@ def write_benchmark_snapshot(benchmark_repo: pathlib.Path, problems: list[Proble
     write_text(BENCHMARK_SNAPSHOT_ROOT / ".benchmark-commit", git_head(benchmark_repo) + "\n")
 
 
-def public_solution_url(
-    kind: str, repo: str, ref: str, problem_id: str, public: bool
-) -> str | None:
-    if not public:
-        return None
-    if kind == "gist":
-        return f"https://gist.github.com/{repo}/{ref}"
-    return f"https://github.com/{repo}/tree/{ref}/generated/{problem_id}"
-
-
 def timestamp_key(value: str) -> float:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
 
@@ -1078,22 +1068,18 @@ def build_leaderboard_payload(
                 provenance["result_id"] = record["result_id"]
             if intake["kind"] == "issue":
                 provenance["issue_number"] = intake["issue_number"]
+            # Compatibility data has no State release evidence. Intake-time
+            # source visibility is provenance, not proof of a durable release.
             candidate = {
                 "problem_id": problem_id,
                 "solved_at": record["accepted_at"],
                 "provenance": provenance,
                 "public_solution": {
-                    "available": submission["public"],
-                    "kind": submission_kind if submission["public"] else None,
-                    "repo": submission["repo"] if submission["public"] else None,
-                    "ref": submission["ref"] if submission["public"] else None,
-                    "url": public_solution_url(
-                        submission_kind,
-                        submission["repo"],
-                        submission["ref"],
-                        problem_id,
-                        submission["public"],
-                    ),
+                    "available": False,
+                    "kind": None,
+                    "repo": None,
+                    "ref": None,
+                    "url": None,
                 },
                 "production_description": production_description,
             }

--- a/scripts/lifecycle_site_data.py
+++ b/scripts/lifecycle_site_data.py
@@ -412,20 +412,13 @@ def adapt_results_store(
                     intake,
                 )
             )
-            public = bool(submission.get("public"))
-            url = None
-            if public and submission.get("kind") == "gist":
-                url = f"https://gist.github.com/{submission['repo']}/{submission['ref']}"
-            elif public:
-                url = (
-                    f"https://github.com/{submission['repo']}/tree/"
-                    f"{submission['ref']}/generated/{record['problem_id']}"
-                )
             order_id = (
                 f"issue-{intake['issue_number']:010d}"
                 if intake.get("kind") == "issue"
                 else str(intake.get("submission_id", result_id))
             )
+            # `submission.public` records source visibility at intake, not a
+            # durable release. Only State supplies materialized release evidence.
             out.append(
                 Solution(
                     result_id=result_id,
@@ -447,12 +440,12 @@ def adapt_results_store(
                         "intake": intake,
                         "submission": submission,
                     },
-                    public_solution={"available": public, "url": url},
+                    public_solution={"available": False, "url": None},
                     replay={"status": "unavailable", "reason": "not-materialized"},
                     release={
-                        "status": "released" if public else "unavailable",
-                        "url": url,
-                        "reason": None if public else "not-materialized",
+                        "status": "unavailable",
+                        "url": None,
+                        "reason": "not-materialized",
                     },
                     model_identity_reviewed=reviewed,
                 )

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -371,6 +371,24 @@ class LifecycleProjectionTests(unittest.TestCase):
         self.assertEqual(available["status"], "available")
         self.assertIsNone(available["unavailable_reason"])
 
+        release_url = "https://releases.example.test/result/alpha"
+        raw["results"][0]["release"] = {
+            "status": "released",
+            "release_at": "2026-10-20T00:00:00Z",
+            "reason": None,
+        }
+        raw["results"][0]["public_solution"] = {
+            "available": True,
+            "url": release_url,
+        }
+        released = adapt_state_projection(raw, aliases)[0]
+        self.assertEqual(
+            released.public_solution,
+            {"available": True, "url": release_url},
+        )
+        self.assertEqual(released.release["status"], "released")
+        self.assertEqual(released.release["url"], release_url)
+
     def test_public_state_projection_rejects_private_internal_fields(self) -> None:
         raw = {
             "schema_version": 1,
@@ -618,6 +636,42 @@ class LifecycleProjectionTests(unittest.TestCase):
             raw["model_identities"][1]["model_id"],
         )
         self.assertEqual(adapted[0].declared_model, record["declared_model"])
+
+    def test_base_result_public_source_does_not_claim_materialized_release(self) -> None:
+        record = {
+            "result_id": result_id("alice", "Example Model", "alpha", 1),
+            "problem_id": "alpha",
+            "statement_revision": 1,
+            "declared_model": "Example Model",
+            "accepted_at": "2026-08-20T00:00:00Z",
+            "benchmark_commit": "a" * 40,
+            "intake": {"kind": "issue", "issue_number": 1},
+            "submission": {
+                "kind": "github_repo",
+                "repo": "alice/proofs",
+                "ref": "b" * 40,
+                "public": True,
+            },
+            "production_metadata": {
+                "solution_publication_status": "published",
+                "solution_publication_date": "2026-08-20",
+            },
+        }
+
+        adapted = adapt_results_store([("alice", [record])], {})
+
+        self.assertEqual(
+            adapted[0].public_solution,
+            {"available": False, "url": None},
+        )
+        self.assertEqual(
+            adapted[0].release,
+            {
+                "status": "unavailable",
+                "url": None,
+                "reason": "not-materialized",
+            },
+        )
 
     def test_verbatim_alias_mismatch_stays_visible_and_falls_back(self) -> None:
         raw = identity_projection_v4()

--- a/tests/test_results_compatibility.py
+++ b/tests/test_results_compatibility.py
@@ -122,7 +122,16 @@ class ResultsCompatibilityTests(unittest.TestCase):
             solved = entry["solved_problems"][0]
             self.assertEqual(solved["problem_id"], "two_plus_two")
             self.assertEqual(solved["production_description"], "Agent harness.")
-            self.assertTrue(solved["public_solution"]["available"])
+            self.assertEqual(
+                solved["public_solution"],
+                {
+                    "available": False,
+                    "kind": None,
+                    "repo": None,
+                    "ref": None,
+                    "url": None,
+                },
+            )
 
     def test_revision_records_do_not_double_count_current_problem_view(self) -> None:
         document = schema_version_2_document()


### PR DESCRIPTION
## Summary

- stop treating acceptance-time `submission.public` provenance as durable release evidence
- expose release links only from materialized public State records
- make lifecycle and compatibility payloads fail closed together
- add regression coverage for public base Results and positive State-backed releases

## Why

The lifecycle contract already says base Results have unavailable replay/release state. Production nevertheless synthesized `released` links from legacy source visibility; many have since become inaccessible. This preserves the immutable provenance while making the public presentation truthful.

## Verification

- `python3 -m unittest tests.test_lifecycle_site_data tests.test_results_compatibility` (21 passed)
- `python3 -m unittest discover -s tests` (49 passed)
- generated base-fallback lifecycle schema validation
- generated compatibility and lifecycle payloads contain zero synthesized release links
- `python3 -m compileall -q scripts tests`
- `git diff --check`
- full local Lean build running; required PR build will exercise the exact CI path
