### PR TITLE
docs: make server intake the launch path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -289,24 +289,22 @@ jobs:
           grep -F 'automatically publishes' _site/submit/index.html
           grep -F 'Apache License 2.0' _site/submit/index.html
           grep -F 'legacy GitHub issue form' _site/submit/index.html
-          grep -F 'Production server intake is not enabled' \
+          grep -F 'During the 28-day launch overlap' \
             _site/submit/index.html
-          grep -F 'it is not accepting submissions' \
+          grep -F 'remains available as a fallback for existing users' \
             _site/submit/index.html
-          grep -F 'current functioning' _site/submit/index.html
-          grep -F 'submission path until production server intake launches' \
+          grep -F 'New submissions should' _site/submit/index.html
+          grep -F 'use the authenticated application above' \
             _site/submit/index.html
-          grep -F 'Server intake prelaunch — not accepting submissions' \
+          grep -F 'Continue to secure submission service' \
             _site/submit/index.html
-          grep -F 'Submit now through the GitHub issue form' \
-            _site/submit/index.html
-          if grep -F 'secondary path' _site/submit/index.html; then
-            echo "::error::The submit page calls functioning issue intake secondary."
+          if grep -Fi 'prelaunch' _site/submit/index.html; then
+            echo "::error::The launch submit page still describes server intake as prelaunch."
             exit 1
           fi
-          if grep -F 'New submissions should use the authenticated application' \
+          if grep -F 'Production server intake is not enabled' \
               _site/submit/index.html; then
-            echo "::error::The prelaunch submit page directs users to disabled server intake."
+            echo "::error::The launch submit page still describes server intake as disabled."
             exit 1
           fi
           grep -F '<a href="https://lean-lang.org/eval/">return to the leaderboard</a>' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -288,6 +288,20 @@ jobs:
           grep -F 'two UTC calendar months after acceptance' _site/submit/index.html
           grep -F 'automatically publishes' _site/submit/index.html
           grep -F 'Apache License 2.0' _site/submit/index.html
+          grep -F 'At submission time, scheduled release is the default' \
+            _site/submit/index.html
+          grep -F 'If you initially choose private, you may later' \
+            _site/submit/index.html
+          grep -F 'authorize scheduled release with the same license confirmation' \
+            _site/submit/index.html
+          grep -F 'a scheduled choice cannot be changed back to private' \
+            _site/submit/index.html
+          grep -F 'that transition is irreversible' \
+            _site/submit/index.html
+          if grep -Fi 'opt out' _site/submit/index.html; then
+            echo "::error::The submit page still offers publication revocation."
+            exit 1
+          fi
           grep -F 'legacy GitHub issue form' _site/submit/index.html
           grep -F 'During the 28-day launch overlap' \
             _site/submit/index.html

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -269,52 +269,43 @@ def submitTitle : String := "Submit"
 def submitLeadBody : VersoDoc Page :=
   verso (Page) "submitLead"
   :::
-  Production server intake is not enabled. The authenticated application at
-  [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/)
-  is visible for prelaunch review, but it is not accepting submissions.
-
-  To submit now, use the
-  [legacy GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  in `leanprover/lean-eval-submissions`. It remains the current functioning
-  submission path until production server intake launches. You can then
+  The authenticated submission application is hosted at
+  [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/).
+  This separate origin is intentional: GitHub OAuth callbacks and the
+  application session are scoped to the Worker that handles private intake.
+  After submitting, you can
   [return to the leaderboard](https://lean-lang.org/eval/).
 
-  After launch, GitHub OAuth callbacks and the application session will be
-  scoped to the separate Worker origin that handles private intake.
+  During the 28-day launch overlap, the
+  [legacy GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+  remains available as a fallback for existing users. New submissions should
+  use the authenticated application above.
   :::
 
 def submitStep1Title  : String :=
-  "1. Submit through the current GitHub issue intake"
+  "1. Prepare a source LeanEval can fetch"
 def submitStep1HtmlId : String := "step-1"
 
 def submitStep1Body : VersoDoc Page :=
   verso (Page) "submitStep1"
   :::
-  Open the
-  [legacy GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  and follow its current source and metadata instructions. Do not use the
-  prelaunch Worker application to submit a solution while server intake is
-  disabled.
+  Submissions through this service require a private GitHub repository in
+  `owner/repository` form and the exact 40-character source commit to evaluate.
+  Before submitting,
+  [install the Lean Eval Source Reader GitHub App](https://github.com/apps/lean-eval-source-reader)
+  on that repository so that LeanEval can clone it.
   :::
 
-def submitStep2Title  : String := "2. Preview the planned authenticated workflow"
+def submitStep2Title  : String := "2. Submit through the authenticated application"
 def submitStep2HtmlId : String := "step-2"
 
 def submitStep2Body : VersoDoc Page :=
   verso (Page) "submitStep2"
   :::
-  The
-  [secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/)
-  is in prelaunch and is not accepting submissions. When production intake
-  launches, it will require a private GitHub repository in `owner/repository`
-  form and the exact 40-character source commit to evaluate. Submitters will
-  first
-  [install the Lean Eval Source Reader GitHub App](https://github.com/apps/lean-eval-source-reader)
-  on that repository, then sign in with GitHub, choose the source, and identify
-  the model or system that produced the proof.
-
-  The application will walk the submitted source and
-  try every directory containing a
+  [Continue to the secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/)
+  and sign in with GitHub. Choose the source and identify the model or system
+  that produced the proof. The application walks the submitted source and
+  tries every directory containing a
   `lakefile.toml` whose `name` field matches a benchmark problem id, and
   which has a `Submission.lean` next to it. For example:
 
@@ -325,18 +316,18 @@ def submitStep2Body : VersoDoc Page :=
   - a custom repository containing several benchmark workspaces side by
     side
 
-  For each matched directory LeanEval will overlay only your `Submission.lean`
+  For each matched directory LeanEval overlays only your `Submission.lean`
   and any files under `Submission/**/*.lean` onto a pristine copy of the
   benchmark's workspace for that problem. Every other file in your
-  submission will be ignored, including `Solution.lean`, `Challenge.lean`, or
-  any modified `lakefile.toml`. The CI will then run
+  submission is ignored, including `Solution.lean`, `Challenge.lean`, or
+  any modified `lakefile.toml`. The CI then runs
   [comparator](https://github.com/leanprover/comparator) to check the
   proof.
 
-  Before evaluation, LeanEval will record the exact source revision and digest
-  and store a private encrypted archive bound to that submission. Submission
-  source and credentials will not be exposed through public workflow artifacts
-  or logs.
+  Before evaluation, LeanEval records the exact source revision and digest
+  and stores a private encrypted archive bound to that submission. Submission
+  source and credentials are not exposed through public workflow artifacts or
+  logs.
   :::
 
 def submitStep3Title  : String := "3. Confirm the release terms"
@@ -345,15 +336,13 @@ def submitStep3HtmlId : String := "step-3"
 def submitStep3Body : VersoDoc Page :=
   verso (Page) "submitStep3"
   :::
-  When production server intake launches, the submission action will include
-  this acknowledgement:
+  The submission action includes this acknowledgement:
 
   > By submitting, I confirm that I have authority to provide this source. I authorize Lean Eval to store and run it privately for evaluation, publish evaluation metadata and results, and, two UTC calendar months after acceptance, publish the submitted source under the Apache License 2.0. I will not submit secrets or material I am not authorized to disclose.
 
-  Source accepted through that application will be scheduled for publication
-  by default. Submitters may opt out at any time before release, either in the
-  application or by asking later. The public result then remains visible with
-  its solution marked as withheld.
+  Accepted source is scheduled for publication by default. You may opt out in
+  the submission application, or ask to opt out at any time before release.
+  The public result then remains visible with its solution marked as withheld.
   :::
 
 def submitWhatPublicTitle  : String := "What becomes public, and when"
@@ -363,8 +352,8 @@ def submitWhatPublicBody : VersoDoc Page :=
   verso (Page) "submitWhatPublic"
   :::
   The following release policy applies to submissions made through the
-  authenticated application after production intake launches. Current issue
-  intake retains its existing policy.
+  authenticated application. Submissions through the fallback issue intake
+  retain their existing policy during the 28-day launch overlap.
 
   Submission metadata and evaluation results may become public when the result
   is recorded. Private source remains in the encrypted archive during the
@@ -391,14 +380,14 @@ broken into chunks rather than authored as a single string. -/
 def submitCtaUrl    : String :=
   "https://lean-eval-submission-server.lean-eval.workers.dev/"
 def submitCtaLabel  : String :=
-  "Server intake prelaunch — not accepting submissions"
+  "Continue to secure submission service"
 def submitCtaArrow  : String := " →"
 
 def submitTldrPart1 : String :=
-  "Production server intake is disabled. Submit now through the GitHub issue form with your "
+  "Sign in with GitHub, choose the exact source snapshot, and confirm the "
 def submitTldrCode1 : String := "Submission.lean"
 def submitTldrPart2 : String :=
-  " source; the existing workflow verifies each matching proof with "
+  " archive and release terms. LeanEval verifies each matching proof with "
 def submitTldrComparatorLabel : String := "comparator"
 def submitTldrComparatorUrl   : String :=
   "https://github.com/leanprover/comparator"

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -338,11 +338,13 @@ def submitStep3Body : VersoDoc Page :=
   :::
   The submission action includes this acknowledgement:
 
-  > By submitting, I confirm that I have authority to provide this source. I authorize Lean Eval to store and run it privately for evaluation, publish evaluation metadata and results, and, two UTC calendar months after acceptance, publish the submitted source under the Apache License 2.0. I will not submit secrets or material I am not authorized to disclose.
+  > By submitting, I confirm that I have authority to provide this source. I authorize Lean Eval to store and run it privately for evaluation and publish evaluation metadata and results. I will not submit secrets or material I am not authorized to disclose. If I choose scheduled release, I also confirm that I have authority to license the accepted source under the Apache License 2.0 and authorize Lean Eval to publish it two UTC calendar months after acceptance.
 
-  Accepted source is scheduled for publication by default. You may opt out in
-  the submission application, or ask to opt out at any time before release.
-  The public result then remains visible with its solution marked as withheld.
+  At submission time, scheduled release is the default. You may instead choose
+  to keep accepted source private; the public result remains visible with its
+  solution marked as withheld. If you initially choose private, you may later
+  authorize scheduled release with the same license confirmation. That change
+  is irreversible: a scheduled choice cannot be changed back to private.
   :::
 
 def submitWhatPublicTitle  : String := "What becomes public, and when"
@@ -359,15 +361,17 @@ def submitWhatPublicBody : VersoDoc Page :=
   is recorded. Private source remains in the encrypted archive during the
   release delay.
 
-  Unless you opt out, LeanEval automatically publishes the exact accepted
-  `Submission.lean` and files under `Submission/` under the Apache License 2.0
-  two UTC calendar months after acceptance. Repository metadata, credentials,
-  challenge files, modified build files, and unrelated source files are not
-  included in that release.
+  If you choose scheduled release, LeanEval automatically publishes the exact
+  accepted `Submission.lean` and files under `Submission/` under the Apache
+  License 2.0 two UTC calendar months after acceptance. Repository metadata,
+  credentials, challenge files, modified build files, and unrelated source
+  files are not included in that release.
 
-  Only submit files that you have authority to provide and license. Do not
-  include secrets. If you opt out before release, the public leaderboard keeps
-  the evaluation result but shows that the solution is withheld.
+  Only schedule files that you have authority to provide and license. Do not
+  include secrets. If you choose to keep accepted source private, the public
+  leaderboard keeps the evaluation result but shows that the solution is
+  withheld. You may later schedule release; that transition is irreversible,
+  and scheduled release cannot later be changed to private.
   :::
 
 /-! ### Submit-page CTA + TL;DR widgets

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -69,7 +69,7 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("recent-solutions.xml", client)
         self.assertIn("No open problems are published in this group yet.", client)
 
-    def test_submit_page_marks_server_prelaunch_and_keeps_issue_intake_current(self) -> None:
+    def test_submit_page_makes_server_primary_during_issue_intake_overlap(self) -> None:
         copy = (REPO_ROOT / "LeaderboardSite/Copy.lean").read_text()
         worker = "https://lean-eval-submission-server.lean-eval.workers.dev/"
         issue_form = (
@@ -78,22 +78,22 @@ class PreviewStructureTests(unittest.TestCase):
         )
         self.assertIn(worker, copy)
         self.assertIn(issue_form, copy)
-        self.assertIn("Production server intake is not enabled", copy)
-        self.assertIn("it is not accepting submissions", copy)
-        self.assertIn("current functioning\n  submission path", copy)
+        self.assertIn("28-day launch overlap", copy)
+        self.assertIn("remains available as a fallback", copy)
         self.assertIn(
-            "Server intake prelaunch — not accepting submissions",
+            "New submissions should\n  use the authenticated application",
             copy,
         )
         self.assertIn(
-            "Submit now through the GitHub issue form",
+            "Continue to secure submission service",
             copy,
         )
-        self.assertNotIn("secondary path", copy)
         self.assertNotIn(
-            "New submissions\n  should use the authenticated application",
+            "Production server intake is not enabled",
             copy,
         )
+        self.assertNotIn("it is not accepting submissions", copy)
+        self.assertNotIn("prelaunch", copy.lower())
         self.assertIn("GitHub OAuth callbacks", copy)
         self.assertIn("private encrypted archive", copy)
         self.assertIn("two UTC calendar months after acceptance", copy)
@@ -111,7 +111,7 @@ class PreviewStructureTests(unittest.TestCase):
             copy,
         )
         self.assertIn("exact 40-character source commit", copy)
-        self.assertIn("will require a private GitHub repository", copy)
+        self.assertIn("require a private GitHub repository", copy)
         self.assertNotIn("Public repositories need no extra setup", copy)
         self.assertNotIn("https://github.com/apps/lean-eval-bot", copy)
         self.assertNotIn("Secret (unlisted) gists", copy)

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -99,7 +99,22 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("two UTC calendar months after acceptance", copy)
         self.assertIn("automatically publishes", copy)
         self.assertIn("Apache License 2.0", copy)
-        self.assertIn("opt out at any time before release", copy)
+        self.assertIn("At submission time, scheduled release is the default", copy)
+        self.assertIn("keep accepted source private", copy)
+        self.assertIn("If you initially choose private, you may later", copy)
+        self.assertIn("authorize scheduled release", copy)
+        self.assertIn(
+            "a scheduled choice cannot be changed back to private",
+            copy,
+        )
+        self.assertIn("that transition is irreversible", copy)
+        for revocation_offer in (
+            "opt out",
+            "withdraw authorization",
+            "revoke authorization",
+            "cancel scheduled release",
+        ):
+            self.assertNotIn(revocation_offer, copy.lower())
         self.assertIn("legacy GitHub issue form", copy)
         self.assertIn("return to the leaderboard", copy)
         self.assertIn(


### PR DESCRIPTION
Switch the public Submit page from prelaunch wording to the launch posture:

- make the authenticated submission service the primary path
- retain issue intake explicitly as the fallback during the 28-day overlap
- present scheduled/private as the submission-time publication choice
- permit only the irreversible private-to-scheduled transition afterward
- remove the former opt-out/revocation offer from user-facing copy
- retain problem-statement regression coverage and existing links
- preserve the merged State-driven lifecycle freshness workflow

The rendered-page checks and focused source tests fail closed if the one-way publication terms or launch-path language regress.

Local verification at `219abd1556569e2b3f08e127544c4c36a438ebcc`:

- `python3 -m unittest discover -s tests` (59 tests)
- changed Lean copy module compiled without warnings as part of `lake build`; the full local generated-site build is still running in parallel
