### PR TITLE
Expose historical replay state on the leaderboard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,7 +167,7 @@ jobs:
           python3 lean-eval-state/scripts/public_projection.py \
             --root lean-eval-state \
             --state-commit "$state_commit" \
-            --schema-version 4 \
+            --schema-version 6 \
             --output "$RUNNER_TEMP/public-state.json"
           python3 lean-eval-state/scripts/public_projection.py \
             --validate "$RUNNER_TEMP/public-state.json"
@@ -233,9 +233,9 @@ jobs:
           if [ "${{ github.ref }}" = 'refs/heads/main' ]; then
             test -f _site/site-data/public-state.json
             jq --exit-status \
-              '.schema_version == 4 and .environment == "production" and (.source_state_commit | test("^[0-9a-f]{40}$")) and (.model_identities | type == "array") and (.model_aliases | type == "array") and (.model_identity_history | type == "array")' \
+              '.schema_version == 6 and .environment == "production" and (.source_state_commit | test("^[0-9a-f]{40}$")) and (.model_identities | type == "array") and (.model_aliases | type == "array") and (.model_identity_history | type == "array") and (.historical_replay_series | type == "array") and (.historical_replay_unavailability | type == "array")' \
               _site/site-data/public-state.json
-            if rg -n 'source_repository|source_commit|archive_|submission_id|nonce_digest' \
+            if rg -n '"(source_repository|source_commit|source_ref|archive_[^"]*|submission_id|nonce_digest|[^"]*crosswalk[^"]*|plan_sha256|authority_[^"]*|evidence_[^"]*)"[[:space:]]*:' \
                 _site/site-data/public-state.json; then
               echo "::error::Private State fields leaked into the public projection."
               exit 1

--- a/README.md
+++ b/README.md
@@ -68,16 +68,19 @@ results data repository.
 
 Production deploys additionally check out private production State through the
 read-only `PRODUCTION_STATE_READ_KEY` deploy key. They generate State's strict,
-redacted `public-state-projection-v4` artifact before site generation and
+redacted `public-state-projection-v6` artifact before site generation and
 publish that exact artifact as `site-data/public-state.json`. Pull-request
 builds receive no State credential and exercise the explicitly labelled
-base-results fallback. Projection version 4 carries the public, owner-scoped
-model-identity review history and resolved aliases used for standings credit;
+base-results fallback. Projection version 6 cumulatively carries the public,
+owner-scoped model-identity review history, result amendments, and strictly
+redacted historical replay series or reviewed-unavailability dispositions;
 immutable result IDs and declared labels remain unchanged. Neither raw State
 events nor the internal materialized domain enters the Pages artifact. The
-vendored projection schemas through version 4 live in `schemas/`, and a
-State-generated transitive-consolidation artifact is pinned under
-`tests/fixtures/` as the producer/consumer compatibility vector.
+vendored projection schemas through version 6 live in `schemas/`, with
+State-generated producer/consumer compatibility vectors under `tests/fixtures/`.
+State schema v6 must land before the leaderboard starts requesting it; the
+leaderboard deploy otherwise fails closed rather than publishing a partial
+historical view.
 
 Benchmark catalog metadata is read from the required `group`, `status`,
 `visible`, `statement_revision`, and `tags` manifest fields. Problems marked

--- a/docs/site-data-v2.md
+++ b/docs/site-data-v2.md
@@ -6,17 +6,25 @@ files remain available to the preserved `/legacy/` surface and downstream
 consumers.
 
 The production generator reads State's redacted
-`public-state-projection-v4` artifact, never the private append-only events or
+`public-state-projection-v6` artifact, never the private append-only events or
 internal `materialized/domain.json`. The public artifact contains recorded
-results, public lifecycle evidence, and public model-identity review history
-only; it excludes pending/rejected submissions, submission IDs, source and
-archive locators, and authentication nonces. Its source State commit, canonical
-event digest, and event count make the bytes reproducible by an authorized
-auditor. Presentation-only catalog fields come from the pinned benchmark
-checkout. If no State projection is provided, immutable base results are
-adapted instead. Every fallback appears in each payload's `data_limitations`;
-missing replay and release data is emitted as an explicit `unavailable` state
-rather than omitted or guessed.
+results, public lifecycle evidence, result amendments, model-identity review
+history, and locator-free historical replay series or reviewed-unavailable
+dispositions only. It excludes pending/rejected submissions, submission IDs,
+source and archive locators, profile locators, credentials, and authentication
+nonces. Its source State commit, canonical event digest, and event count make
+the bytes reproducible by an authorized auditor. Presentation-only catalog
+fields come from the pinned benchmark checkout. If no State projection is
+provided, immutable base results are adapted instead. Every fallback appears
+in each payload's `data_limitations`; missing replay and release data is emitted
+as an explicit `unavailable` state rather than omitted or guessed.
+
+Historical entries join to immutable base Results by `result_id`. The adapter
+rejects unknown Results, source-visibility mismatches, duplicate series,
+cross-lane series, and any replay/disposition overlap. It displays the newest
+series status and retains every versioned measurement series with its exact
+measurement-configuration and execution-profile digests. Reviewed
+unavailability supplies a public reason and no fabricated measurement.
 
 The split files are:
 

--- a/schemas/public-state-projection-v5.schema.json
+++ b/schemas/public-state-projection-v5.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lean-lang.org/schemas/lean-eval/public-state-projection-v5.schema.json",
+  "title": "lean-eval public State projection schema version 5",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "environment", "source_state_commit", "source_event_count",
+    "source_digest", "results", "result_overlays", "model_identities",
+    "model_aliases", "model_identity_history", "result_amendment_history"
+  ],
+  "properties": {
+    "schema_version": { "const": 5 },
+    "environment": { "$ref": "public-state-projection-v4.schema.json#/properties/environment" },
+    "source_state_commit": { "$ref": "public-state-projection-v4.schema.json#/properties/source_state_commit" },
+    "source_event_count": { "$ref": "public-state-projection-v4.schema.json#/properties/source_event_count" },
+    "source_digest": { "$ref": "public-state-projection-v4.schema.json#/properties/source_digest" },
+    "results": { "type": "array", "items": { "$ref": "#/$defs/result" } },
+    "result_overlays": { "type": "array", "items": { "$ref": "#/$defs/overlay" } },
+    "model_identities": { "$ref": "public-state-projection-v4.schema.json#/properties/model_identities" },
+    "model_aliases": { "$ref": "public-state-projection-v4.schema.json#/properties/model_aliases" },
+    "model_identity_history": { "$ref": "public-state-projection-v4.schema.json#/properties/model_identity_history" },
+    "result_amendment_history": { "type": "array", "items": { "$ref": "#/$defs/amendmentHistory" } }
+  },
+  "$defs": {
+    "nullableEventId": {
+      "oneOf": [
+        { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        { "type": "null" }
+      ]
+    },
+    "nullableTimestamp": {
+      "oneOf": [
+        { "$ref": "public-state-projection-v4.schema.json#/$defs/timestamp" },
+        { "type": "null" }
+      ]
+    },
+    "nullableLogin": {
+      "oneOf": [
+        { "$ref": "public-state-projection-v4.schema.json#/$defs/login" },
+        { "type": "null" }
+      ]
+    },
+    "nullableReason": { "$ref": "public-state-projection-v4.schema.json#/$defs/nullableReason" },
+    "positive": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
+    "nullablePositive": { "oneOf": [{ "$ref": "#/$defs/positive" }, { "type": "null" }] },
+    "problemId": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$" },
+    "nullableProblemId": { "oneOf": [{ "$ref": "#/$defs/problemId" }, { "type": "null" }] },
+    "problemRepair": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object", "additionalProperties": false,
+          "required": [
+            "revision", "status", "request_event_id", "requested_at",
+            "corrected_problem_id", "corrected_statement_revision",
+            "decision_event_id", "decided_at", "reviewer_login", "reason_code"
+          ],
+          "properties": {
+            "revision": { "$ref": "#/$defs/positive" },
+            "status": { "enum": ["pending", "applied", "rejected"] },
+            "request_event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+            "requested_at": { "$ref": "public-state-projection-v4.schema.json#/$defs/timestamp" },
+            "corrected_problem_id": { "$ref": "#/$defs/problemId" },
+            "corrected_statement_revision": { "$ref": "#/$defs/positive" },
+            "decision_event_id": { "$ref": "#/$defs/nullableEventId" },
+            "decided_at": { "$ref": "#/$defs/nullableTimestamp" },
+            "reviewer_login": { "$ref": "#/$defs/nullableLogin" },
+            "reason_code": { "$ref": "#/$defs/nullableReason" }
+          }
+        }
+      ]
+    },
+    "appliedProblemRepair": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "allOf": [
+            { "$ref": "#/$defs/problemRepair" },
+            { "type": "object", "properties": { "status": { "const": "applied" } } }
+          ]
+        }
+      ]
+    },
+    "retraction": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object", "additionalProperties": false,
+          "required": [
+            "revision", "status", "request_event_id", "requested_at",
+            "decision_event_id", "decided_at", "retraction_event_id",
+            "retracted_at", "reviewer_login", "reason_code",
+            "release_disposition", "overridden"
+          ],
+          "properties": {
+            "revision": { "$ref": "#/$defs/positive" },
+            "status": { "enum": ["pending", "approved", "rejected", "retracted"] },
+            "request_event_id": { "$ref": "#/$defs/nullableEventId" },
+            "requested_at": { "$ref": "#/$defs/nullableTimestamp" },
+            "decision_event_id": { "$ref": "#/$defs/nullableEventId" },
+            "decided_at": { "$ref": "#/$defs/nullableTimestamp" },
+            "retraction_event_id": { "$ref": "#/$defs/nullableEventId" },
+            "retracted_at": { "$ref": "#/$defs/nullableTimestamp" },
+            "reviewer_login": { "$ref": "#/$defs/nullableLogin" },
+            "reason_code": { "$ref": "#/$defs/nullableReason" },
+            "release_disposition": {
+              "oneOf": [
+                { "enum": ["not_published", "removal_required", "already_removed"] },
+                { "type": "null" }
+              ]
+            },
+            "overridden": { "type": "boolean" }
+          }
+        }
+      ]
+    },
+    "result": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "result_id", "problem_id", "statement_revision", "declared_model", "submitter",
+        "accepted_at", "acceptance_event_id", "recorded_at", "record_event_id",
+        "benchmark_commit", "production_metadata", "replay", "release", "public_solution",
+        "model_id", "resolved_model_id", "effective_problem_id",
+        "effective_statement_revision", "problem_repair", "applied_problem_repair", "retraction",
+        "leaderboard_eligible"
+      ],
+      "properties": {
+        "result_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/result_id" },
+        "problem_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/problem_id" },
+        "statement_revision": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/statement_revision" },
+        "declared_model": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/declared_model" },
+        "submitter": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/submitter" },
+        "accepted_at": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/accepted_at" },
+        "acceptance_event_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/acceptance_event_id" },
+        "recorded_at": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/recorded_at" },
+        "record_event_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/record_event_id" },
+        "benchmark_commit": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/benchmark_commit" },
+        "production_metadata": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/production_metadata" },
+        "replay": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/replay" },
+        "release": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/release" },
+        "public_solution": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/public_solution" },
+        "model_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/model_id" },
+        "resolved_model_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/result/properties/resolved_model_id" },
+        "effective_problem_id": { "$ref": "#/$defs/problemId" },
+        "effective_statement_revision": { "$ref": "#/$defs/positive" },
+        "problem_repair": { "$ref": "#/$defs/problemRepair" },
+        "applied_problem_repair": { "$ref": "#/$defs/appliedProblemRepair" },
+        "retraction": { "$ref": "#/$defs/retraction" },
+        "leaderboard_eligible": { "type": "boolean" }
+      }
+    },
+    "overlay": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "result_id", "owner_login", "declared_model", "problem_id",
+        "statement_revision", "claim_event_id", "mutation_event_id", "claimed_at",
+        "metadata", "model_id", "resolved_model_id", "effective_problem_id",
+        "effective_statement_revision", "problem_repair", "applied_problem_repair", "retraction",
+        "leaderboard_eligible"
+      ],
+      "properties": {
+        "result_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/result_id" },
+        "owner_login": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/owner_login" },
+        "declared_model": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/declared_model" },
+        "problem_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/problem_id" },
+        "statement_revision": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/statement_revision" },
+        "claim_event_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/claim_event_id" },
+        "mutation_event_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/mutation_event_id" },
+        "claimed_at": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/claimed_at" },
+        "metadata": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/metadata" },
+        "model_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/model_id" },
+        "resolved_model_id": { "$ref": "public-state-projection-v4.schema.json#/$defs/overlay/properties/resolved_model_id" },
+        "effective_problem_id": { "$ref": "#/$defs/problemId" },
+        "effective_statement_revision": { "$ref": "#/$defs/positive" },
+        "problem_repair": { "$ref": "#/$defs/problemRepair" },
+        "applied_problem_repair": { "$ref": "#/$defs/appliedProblemRepair" },
+        "retraction": { "$ref": "#/$defs/retraction" },
+        "leaderboard_eligible": { "type": "boolean" }
+      }
+    },
+    "amendmentHistory": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "event_id", "event_type", "result_id", "occurred_at",
+        "causation_event_id", "actor_login", "reviewer_login", "repair_revision",
+        "retraction_revision", "corrected_problem_id",
+        "corrected_statement_revision", "decision", "reason_code",
+        "release_disposition"
+      ],
+      "properties": {
+        "event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        "event_type": {
+          "enum": [
+            "result.metadata_backfilled",
+            "result.problem_repair_requested", "result.problem_repaired",
+            "result.problem_repair_rejected", "result.retraction_requested",
+            "result.retraction_decided", "result.retraction_overridden",
+            "result.retracted"
+          ]
+        },
+        "result_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/result/properties/result_id" },
+        "occurred_at": { "$ref": "public-state-projection-v4.schema.json#/$defs/timestamp" },
+        "causation_event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        "actor_login": { "$ref": "#/$defs/nullableLogin" },
+        "reviewer_login": { "$ref": "#/$defs/nullableLogin" },
+        "repair_revision": { "$ref": "#/$defs/nullablePositive" },
+        "retraction_revision": { "$ref": "#/$defs/nullablePositive" },
+        "corrected_problem_id": { "$ref": "#/$defs/nullableProblemId" },
+        "corrected_statement_revision": { "$ref": "#/$defs/nullablePositive" },
+        "decision": { "oneOf": [{ "enum": ["approve", "reject"] }, { "type": "null" }] },
+        "reason_code": { "$ref": "#/$defs/nullableReason" },
+        "release_disposition": {
+          "oneOf": [
+            { "enum": ["not_published", "removal_required", "already_removed"] },
+            { "type": "null" }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/public-state-projection-v6.schema.json
+++ b/schemas/public-state-projection-v6.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lean-lang.org/schemas/lean-eval/public-state-projection-v6.schema.json",
+  "title": "lean-eval public State projection schema version 6",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "environment", "source_state_commit", "source_event_count",
+    "source_digest", "results", "result_overlays", "model_identities",
+    "model_aliases", "model_identity_history", "result_amendment_history",
+    "historical_replay_series", "historical_replay_unavailability"
+  ],
+  "properties": {
+    "schema_version": { "const": 6 },
+    "environment": { "$ref": "public-state-projection-v5.schema.json#/properties/environment" },
+    "source_state_commit": { "$ref": "public-state-projection-v5.schema.json#/properties/source_state_commit" },
+    "source_event_count": { "$ref": "public-state-projection-v5.schema.json#/properties/source_event_count" },
+    "source_digest": { "$ref": "public-state-projection-v5.schema.json#/properties/source_digest" },
+    "results": { "$ref": "public-state-projection-v5.schema.json#/properties/results" },
+    "result_overlays": { "$ref": "public-state-projection-v5.schema.json#/properties/result_overlays" },
+    "model_identities": { "$ref": "public-state-projection-v5.schema.json#/properties/model_identities" },
+    "model_aliases": { "$ref": "public-state-projection-v5.schema.json#/properties/model_aliases" },
+    "model_identity_history": { "$ref": "public-state-projection-v5.schema.json#/properties/model_identity_history" },
+    "result_amendment_history": { "$ref": "public-state-projection-v5.schema.json#/properties/result_amendment_history" },
+    "historical_replay_series": {
+      "type": "array", "items": { "$ref": "#/$defs/replaySeries" }
+    },
+    "historical_replay_unavailability": {
+      "type": "array", "items": { "$ref": "#/$defs/unavailability" }
+    }
+  },
+  "$defs": {
+    "historicalTimestamp": {
+      "type": "string", "format": "date-time",
+      "pattern": "^(?!0000-)[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "identityProperties": {
+      "result_id": { "$ref": "public-state-projection-v5.schema.json#/$defs/result/properties/result_id" },
+      "owner_login": { "$ref": "public-state-projection-v4.schema.json#/$defs/login" },
+      "declared_model": { "$ref": "public-state-projection-v4.schema.json#/$defs/label" },
+      "problem_id": { "$ref": "public-state-projection-v5.schema.json#/$defs/problemId" },
+      "statement_revision": { "$ref": "public-state-projection-v5.schema.json#/$defs/positive" },
+      "historical_accepted_at": { "$ref": "#/$defs/historicalTimestamp" },
+      "source_visibility": { "enum": ["public", "private"] }
+    },
+    "replaySeries": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "result_id", "owner_login", "declared_model", "problem_id",
+        "statement_revision", "historical_accepted_at", "source_visibility",
+        "replay_task_id", "measurement_config_digest", "execution_profile_digest",
+        "transition_event_id", "updated_at", "replay"
+      ],
+      "properties": {
+        "result_id": { "$ref": "#/$defs/identityProperties/result_id" },
+        "owner_login": { "$ref": "#/$defs/identityProperties/owner_login" },
+        "declared_model": { "$ref": "#/$defs/identityProperties/declared_model" },
+        "problem_id": { "$ref": "#/$defs/identityProperties/problem_id" },
+        "statement_revision": { "$ref": "#/$defs/identityProperties/statement_revision" },
+        "historical_accepted_at": { "$ref": "#/$defs/identityProperties/historical_accepted_at" },
+        "source_visibility": { "$ref": "#/$defs/identityProperties/source_visibility" },
+        "replay_task_id": { "type": "string", "pattern": "^rt1_[0-9a-f]{64}$" },
+        "measurement_config_digest": { "$ref": "public-state-projection-v1.schema.json#/$defs/digest" },
+        "execution_profile_digest": { "$ref": "public-state-projection-v1.schema.json#/$defs/digest" },
+        "transition_event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        "updated_at": { "$ref": "public-state-projection-v4.schema.json#/$defs/timestamp" },
+        "replay": { "$ref": "public-state-projection-v1.schema.json#/$defs/replay" }
+      }
+    },
+    "unavailability": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "result_id", "owner_login", "declared_model", "problem_id",
+        "statement_revision", "historical_accepted_at", "source_visibility",
+        "disposition_event_id", "disposed_at", "reason", "rationale"
+      ],
+      "properties": {
+        "result_id": { "$ref": "#/$defs/identityProperties/result_id" },
+        "owner_login": { "$ref": "#/$defs/identityProperties/owner_login" },
+        "declared_model": { "$ref": "#/$defs/identityProperties/declared_model" },
+        "problem_id": { "$ref": "#/$defs/identityProperties/problem_id" },
+        "statement_revision": { "$ref": "#/$defs/identityProperties/statement_revision" },
+        "historical_accepted_at": { "$ref": "#/$defs/identityProperties/historical_accepted_at" },
+        "source_visibility": { "$ref": "#/$defs/identityProperties/source_visibility" },
+        "disposition_event_id": { "$ref": "public-state-projection-v1.schema.json#/$defs/eventId" },
+        "disposed_at": { "$ref": "public-state-projection-v4.schema.json#/$defs/timestamp" },
+        "reason": {
+          "enum": ["source_ref_permanently_unavailable", "archive_not_found"]
+        },
+        "rationale": {
+          "oneOf": [
+            { "const": "accepted_immutable_source_ref_unavailable_without_archive" },
+            { "type": "null" }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "source_visibility": { "const": "public" } } },
+          "then": {
+            "properties": {
+              "reason": { "const": "source_ref_permanently_unavailable" },
+              "rationale": { "const": "accepted_immutable_source_ref_unavailable_without_archive" }
+            }
+          },
+          "else": {
+            "properties": {
+              "reason": { "const": "archive_not_found" },
+              "rationale": { "type": "null" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/site-data-v2.schema.json
+++ b/schemas/site-data-v2.schema.json
@@ -38,6 +38,66 @@
         "total": {"type": "integer", "minimum": 0}
       }
     },
+    "nullableNat": {
+      "oneOf": [{"type": "integer", "minimum": 0}, {"type": "null"}]
+    },
+    "nullableText": {
+      "oneOf": [{"$ref": "#/$defs/nonempty"}, {"type": "null"}]
+    },
+    "measurement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind", "replay_status", "replay_reason", "status", "checker",
+        "checker_wall_time_ms", "checker_retired_instructions",
+        "checker_retired_instructions_unavailable_reason", "build_wall_time_ms",
+        "build_retired_instructions", "build_retired_instructions_unavailable_reason",
+        "lines_of_code", "file_count", "unavailable_reason", "attempt"
+      ],
+      "properties": {
+        "kind": {"const": "checker-replay"},
+        "replay_status": {"enum": ["queued", "running", "accepted", "rejected", "declined", "crashed", "timed_out", "failed", "unavailable"]},
+        "replay_reason": {"$ref": "#/$defs/nullableText"},
+        "status": {"enum": ["available", "unavailable"]},
+        "checker": {"$ref": "#/$defs/nullableText"},
+        "checker_wall_time_ms": {"$ref": "#/$defs/nullableNat"},
+        "checker_retired_instructions": {"$ref": "#/$defs/nullableNat"},
+        "checker_retired_instructions_unavailable_reason": {"$ref": "#/$defs/nullableText"},
+        "build_wall_time_ms": {"$ref": "#/$defs/nullableNat"},
+        "build_retired_instructions": {"$ref": "#/$defs/nullableNat"},
+        "build_retired_instructions_unavailable_reason": {"$ref": "#/$defs/nullableText"},
+        "lines_of_code": {"$ref": "#/$defs/nullableNat"},
+        "file_count": {"$ref": "#/$defs/nullableNat"},
+        "unavailable_reason": {"$ref": "#/$defs/nullableText"},
+        "attempt": {"type": "integer", "minimum": 0},
+        "source_visibility": {"enum": ["public", "private"]},
+        "replay_task_id": {"type": "string", "pattern": "^rt1_[0-9a-f]{64}$"},
+        "measurement_config_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "execution_profile_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "updated_at": {"$ref": "#/$defs/timestamp"},
+        "transition_event_id": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"}
+      },
+      "oneOf": [
+        {
+          "not": {
+            "anyOf": [
+              {"required": ["source_visibility"]},
+              {"required": ["replay_task_id"]},
+              {"required": ["measurement_config_digest"]},
+              {"required": ["execution_profile_digest"]},
+              {"required": ["updated_at"]},
+              {"required": ["transition_event_id"]}
+            ]
+          }
+        },
+        {
+          "required": [
+            "source_visibility", "replay_task_id", "measurement_config_digest",
+            "execution_profile_digest", "updated_at", "transition_event_id"
+          ]
+        }
+      ]
+    },
     "index": {
       "type": "object",
       "additionalProperties": false,
@@ -120,7 +180,7 @@
         "provenance": {"type": "object"},
         "public_solution": {"type": "object", "required": ["available", "url"]},
         "replay": {"type": "object", "required": ["status"]},
-        "measurements": {"type": "array", "items": {"type": "object", "required": ["kind", "status"]}},
+        "measurements": {"type": "array", "items": {"$ref": "#/$defs/measurement"}},
         "release": {"type": "object", "required": ["status"]}
       }
     },

--- a/scripts/generate_site_data.py
+++ b/scripts/generate_site_data.py
@@ -21,6 +21,7 @@ try:
     from scripts.lifecycle_site_data import (
         adapt_results_store,
         adapt_state_projection,
+        apply_state_projection_overlays,
         build_lifecycle_projection,
         build_model_identity_index,
         load_preview_fixture,
@@ -35,6 +36,7 @@ except ModuleNotFoundError:
     from lifecycle_site_data import (
         adapt_results_store,
         adapt_state_projection,
+        apply_state_projection_overlays,
         build_lifecycle_projection,
         build_model_identity_index,
         load_preview_fixture,
@@ -1416,9 +1418,11 @@ def main() -> int:
     state_solutions = adapt_state_projection(
         state_projection, aliases, model_identities
     )
+    solutions = merge_solutions(state_solutions, fallback_solutions)
+    apply_state_projection_overlays(solutions, state_projection)
     lifecycle_files = build_lifecycle_projection(
         problems=problems,
-        solutions=merge_solutions(state_solutions, fallback_solutions),
+        solutions=solutions,
         set_definitions=load_set_definitions(benchmark_repo / "manifests" / "sets"),
         tag_registry=load_tag_registry(benchmark_repo / "manifests" / "tags.toml"),
         fixture=fixture,

--- a/scripts/lifecycle_site_data.py
+++ b/scripts/lifecycle_site_data.py
@@ -59,8 +59,59 @@ LOGIN_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?")
 EVENT_ID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
 )
+RESULT_ID_RE = re.compile(r"r2_[0-9a-f]{64}")
+REPLAY_TASK_ID_RE = re.compile(r"rt1_[0-9a-f]{64}")
+DIGEST_RE = re.compile(r"[0-9a-f]{64}")
+STATE_TIMESTAMP_RE = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{3}Z"
+)
 MODEL_ID_DOMAIN = b"lean-eval-model-identity-v1\0"
 ALIAS_KEY_DOMAIN = b"lean-eval-model-alias-v1\0"
+REPLAY_PROJECTION_FIELDS = {
+    "status", "reason", "attempt", "checker", "checker_wall_time_ms",
+    "checker_retired_instructions",
+    "checker_retired_instructions_unavailable_reason", "build_wall_time_ms",
+    "build_retired_instructions",
+    "build_retired_instructions_unavailable_reason", "lines_of_code",
+    "file_count",
+}
+REPLAY_STATUSES = {
+    "queued", "running", "accepted", "rejected", "declined", "crashed",
+    "timed_out", "failed", "unavailable",
+}
+HISTORICAL_FAILURE_REASONS = {
+    "benchmark_fetch_failed", "runner_lost", "runner_start_failed",
+    "source_fetch_failed", "toolchain_setup_failed", "verdict_invalid",
+}
+HISTORICAL_UNAVAILABLE_REASONS = {
+    "source_ref_permanently_unavailable",
+    "benchmark_ref_permanently_unavailable",
+    "execution_profile_permanently_unavailable",
+}
+COUNTER_UNAVAILABLE_REASONS = {
+    "counter_not_supported", "counter_permission_denied",
+}
+HISTORICAL_REPLAY_SERIES_FIELDS = {
+    "result_id", "owner_login", "declared_model", "problem_id",
+    "statement_revision", "historical_accepted_at", "source_visibility",
+    "replay_task_id", "measurement_config_digest", "execution_profile_digest",
+    "updated_at", "transition_event_id", "replay",
+}
+HISTORICAL_REPLAY_UNAVAILABILITY_FIELDS = {
+    "result_id", "owner_login", "declared_model", "problem_id",
+    "statement_revision", "historical_accepted_at", "source_visibility",
+    "disposed_at", "disposition_event_id", "reason", "rationale",
+}
+STATE_OVERLAY_FIELDS = {
+    "result_id", "owner_login", "declared_model", "problem_id",
+    "statement_revision", "claim_event_id", "mutation_event_id", "claimed_at",
+    "metadata", "model_id", "resolved_model_id",
+}
+STATE_AMENDMENT_FIELDS = {
+    "effective_problem_id", "effective_statement_revision", "problem_repair",
+    "applied_problem_repair", "retraction", "leaderboard_eligible",
+}
 
 
 def _slug(value: str) -> str:
@@ -74,6 +125,18 @@ def _normalized_model(value: str) -> str:
 def _stable_legacy_id(parts: Iterable[object]) -> str:
     encoded = "\0".join(str(part) for part in parts).encode("utf-8")
     return "legacy_" + hashlib.sha256(encoded).hexdigest()
+
+
+def _expected_replay_task_id(
+    result_id_value: str, measurement_config_digest: str
+) -> str:
+    payload = (
+        "lean-eval-replay-task-v1\0"
+        + result_id_value
+        + "\0"
+        + measurement_config_digest
+    ).encode("utf-8")
+    return "rt1_" + hashlib.sha256(payload).hexdigest()
 
 
 def _acceptance_key(solution: Solution) -> tuple[str, str, str]:
@@ -214,11 +277,11 @@ def _model_label(value: Any, label: str) -> str:
 
 
 def build_model_identity_index(raw: dict[str, Any] | None) -> ModelIdentityIndex:
-    """Validate and index the owner-scoped identity subset of projection v4."""
+    """Validate and index the owner-scoped identity subset of State projection."""
 
     if raw is None or raw.get("schema_version") == 1:
         return EMPTY_MODEL_IDENTITY_INDEX
-    if raw.get("schema_version") != 4:
+    if raw.get("schema_version") not in {4, 5, 6}:
         raise SystemExit("State domain: unsupported schema_version")
     identities: dict[str, dict[str, Any]] = {}
     identity_fields = {
@@ -453,17 +516,150 @@ def adapt_results_store(
     return out
 
 
+def _replay_projection_view(
+    replay: dict[str, Any],
+    *,
+    measurement_identity: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not isinstance(replay, dict) or set(replay) != REPLAY_PROJECTION_FIELDS:
+        raise SystemExit("State projection: invalid replay fields")
+    if (
+        replay["status"] not in REPLAY_STATUSES
+        or type(replay["attempt"]) is not int
+        or replay["attempt"] < 0
+        or (
+            replay["checker"] is not None
+            and (not isinstance(replay["checker"], str) or not replay["checker"])
+        )
+        or (
+            replay["reason"] is not None
+            and (not isinstance(replay["reason"], str) or not replay["reason"])
+        )
+    ):
+        raise SystemExit("State projection: invalid replay values")
+    for field in (
+        "checker_wall_time_ms", "checker_retired_instructions",
+        "build_wall_time_ms", "build_retired_instructions", "lines_of_code",
+        "file_count",
+    ):
+        if replay[field] is not None and (
+            type(replay[field]) is not int or replay[field] < 0
+        ):
+            raise SystemExit("State projection: invalid replay measurements")
+    if measurement_identity is not None:
+        status = replay["status"]
+        reason = replay["reason"]
+        expected_reasons = (
+            HISTORICAL_FAILURE_REASONS
+            if status == "failed"
+            else HISTORICAL_UNAVAILABLE_REASONS
+            if status == "unavailable"
+            else None
+        )
+        if (
+            replay["checker"] != "nanoda"
+            or (expected_reasons is None and reason is not None)
+            or (expected_reasons is not None and reason not in expected_reasons)
+            or (
+                status
+                in {
+                    "running", "failed", "accepted", "rejected", "declined",
+                    "crashed", "timed_out",
+                }
+                and replay["attempt"] < 1
+            )
+        ):
+            raise SystemExit("State projection: invalid historical replay values")
+        terminal_verdict = status in {
+            "accepted", "rejected", "declined", "crashed", "timed_out",
+        }
+        for field in (
+            "checker_wall_time_ms", "build_wall_time_ms", "lines_of_code",
+            "file_count",
+        ):
+            if terminal_verdict != (replay[field] is not None):
+                raise SystemExit(
+                    "State projection: incoherent historical replay measurements"
+                )
+        for counter, unavailable_reason in (
+            (
+                "checker_retired_instructions",
+                "checker_retired_instructions_unavailable_reason",
+            ),
+            (
+                "build_retired_instructions",
+                "build_retired_instructions_unavailable_reason",
+            ),
+        ):
+            counter_reason = replay[unavailable_reason]
+            if (
+                counter_reason is not None
+                and counter_reason not in COUNTER_UNAVAILABLE_REASONS
+            ):
+                raise SystemExit(
+                    "State projection: invalid historical counter evidence"
+                )
+            if terminal_verdict:
+                if (replay[counter] is None) == (counter_reason is None):
+                    raise SystemExit(
+                        "State projection: incoherent historical counter evidence"
+                    )
+            elif replay[counter] is not None or counter_reason is not None:
+                raise SystemExit(
+                    "State projection: incoherent historical counter evidence"
+                )
+    view = {
+        "status": replay["status"],
+        "reason": replay["reason"],
+        "attempt": replay["attempt"],
+        "checker": replay["checker"],
+    }
+    measurement = {
+        "kind": "checker-replay",
+        "replay_status": replay["status"],
+        "replay_reason": replay["reason"],
+        "status": (
+            "unavailable"
+            if replay["checker_retired_instructions"] is None
+            else "available"
+        ),
+        "checker": replay["checker"],
+        "checker_wall_time_ms": replay["checker_wall_time_ms"],
+        "checker_retired_instructions": replay[
+            "checker_retired_instructions"
+        ],
+        "checker_retired_instructions_unavailable_reason": replay[
+            "checker_retired_instructions_unavailable_reason"
+        ],
+        "build_wall_time_ms": replay["build_wall_time_ms"],
+        "build_retired_instructions": replay["build_retired_instructions"],
+        "build_retired_instructions_unavailable_reason": replay[
+            "build_retired_instructions_unavailable_reason"
+        ],
+        "lines_of_code": replay["lines_of_code"],
+        "file_count": replay["file_count"],
+        "unavailable_reason": (
+            "performance-counter-unavailable"
+            if replay["checker_retired_instructions"] is None
+            else None
+        ),
+        "attempt": replay["attempt"],
+        **(measurement_identity or {}),
+    }
+    return view, measurement
+
+
 def adapt_state_projection(
     raw: dict[str, Any] | None,
     aliases: dict[str, dict[str, str]],
     model_identities: ModelIdentityIndex | None = None,
 ) -> list[Solution]:
-    """Normalize redacted State projection v1 or identity-aware v4."""
+    """Normalize a supported cumulative redacted State projection."""
 
     if raw is None:
         return []
     version = raw.get("schema_version")
-    if version not in {1, 4}:
+    if version not in {1, 4, 5, 6}:
         raise SystemExit("State domain: unsupported schema_version")
     if raw.get("environment") not in {"production", "staging"}:
         raise SystemExit("State domain: invalid environment")
@@ -477,15 +673,18 @@ def adapt_state_projection(
         "schema_version", "environment", "source_state_commit",
         "source_event_count", "source_digest", "results",
     }
-    expected_top_fields = (
-        common_fields
-        if version == 1
-        else common_fields
-        | {
+    expected_top_fields = common_fields
+    if version in {4, 5, 6}:
+        expected_top_fields |= {
             "result_overlays", "model_identities", "model_aliases",
             "model_identity_history",
         }
-    )
+    if version in {5, 6}:
+        expected_top_fields.add("result_amendment_history")
+    if version == 6:
+        expected_top_fields |= {
+            "historical_replay_series", "historical_replay_unavailability",
+        }
     if set(raw) != expected_top_fields:
         raise SystemExit("State projection: invalid top-level fields")
     identity_index = (
@@ -501,8 +700,14 @@ def adapt_state_projection(
             "record_event_id", "benchmark_commit", "production_metadata", "replay",
             "release", "public_solution",
         }
-        if version == 4:
+        if version in {4, 5, 6}:
             required |= {"model_id", "resolved_model_id"}
+        if version in {5, 6}:
+            required |= {
+                "effective_problem_id", "effective_statement_revision",
+                "problem_repair", "applied_problem_repair", "retraction",
+                "leaderboard_eligible",
+            }
         if not isinstance(result, dict) or set(result) != required:
             raise SystemExit("State projection: invalid result fields")
         raw_declared = str(result["declared_model"])
@@ -520,7 +725,7 @@ def adapt_state_projection(
         state_resolution = identity_index.aliases.get(
             (str(result["submitter"]).lower(), raw_declared)
         )
-        if version == 4:
+        if version in {4, 5, 6}:
             projected_resolution = (
                 result["model_id"], result["resolved_model_id"]
             )
@@ -538,45 +743,8 @@ def adapt_state_projection(
             replay_view = {"status": "unavailable", "reason": "not-enqueued"}
             measurements: list[dict[str, Any]] = []
         else:
-            replay_view = {
-                "status": replay["status"],
-                "reason": replay.get("reason_code"),
-                "attempt": replay.get("attempt", 0),
-                "checker": replay.get("checker"),
-            }
-            measurements = [
-                {
-                    "kind": "checker-replay",
-                    "status": (
-                        "unavailable"
-                        if replay.get("checker_retired_instructions") is None
-                        else "available"
-                    ),
-                    "checker": replay.get("checker"),
-                    "checker_wall_time_ms": replay.get("checker_wall_time_ms"),
-                    "checker_retired_instructions": replay.get(
-                        "checker_retired_instructions"
-                    ),
-                    "checker_retired_instructions_unavailable_reason": replay.get(
-                        "checker_retired_instructions_unavailable_reason"
-                    ),
-                    "build_wall_time_ms": replay.get("build_wall_time_ms"),
-                    "build_retired_instructions": replay.get(
-                        "build_retired_instructions"
-                    ),
-                    "build_retired_instructions_unavailable_reason": replay.get(
-                        "build_retired_instructions_unavailable_reason"
-                    ),
-                    "lines_of_code": replay.get("lines_of_code"),
-                    "file_count": replay.get("file_count"),
-                    "unavailable_reason": (
-                        "performance-counter-unavailable"
-                        if replay.get("checker_retired_instructions") is None
-                        else None
-                    ),
-                    "attempt": replay.get("attempt", 0),
-                }
-            ]
+            replay_view, measurement = _replay_projection_view(replay)
+            measurements = [measurement]
         release = result["release"]
         release_url = result["public_solution"]["url"]
         release_view = (
@@ -592,15 +760,27 @@ def adapt_state_projection(
         solutions.append(
             Solution(
                 result_id=result["result_id"],
-                problem_id=result["problem_id"],
-                statement_revision=result["statement_revision"],
+                problem_id=(
+                    result["effective_problem_id"]
+                    if version in {5, 6}
+                    else result["problem_id"]
+                ),
+                statement_revision=(
+                    result["effective_statement_revision"]
+                    if version in {5, 6}
+                    else result["statement_revision"]
+                ),
                 declared_model=declared,
                 canonical_model_id=canonical_id,
                 canonical_model_label=canonical_label,
                 submitter=result["submitter"],
                 accepted_at=result["accepted_at"],
                 acceptance_event_id=result["acceptance_event_id"],
-                retracted=bool(result.get("retracted", False)),
+                retracted=(
+                    not result["leaderboard_eligible"]
+                    if version in {5, 6}
+                    else False
+                ),
                 metadata=_metadata_fields(
                     result.get("production_metadata", {}),
                     "declared-at-submission",
@@ -649,6 +829,250 @@ def merge_solutions(primary: list[Solution], fallback: list[Solution]) -> list[S
     for solution in primary:
         merged[solution.result_id] = solution
     return sorted(merged.values(), key=_acceptance_key)
+
+
+def apply_state_projection_overlays(
+    solutions: list[Solution], raw: dict[str, Any] | None
+) -> list[Solution]:
+    """Apply redacted legacy overlays and historical replay series in place."""
+
+    if raw is None or raw.get("schema_version") == 1:
+        return solutions
+    version = raw.get("schema_version")
+    if version not in {4, 5, 6}:
+        raise SystemExit("State domain: unsupported schema_version")
+    by_result = {solution.result_id: solution for solution in solutions}
+    if len(by_result) != len(solutions):
+        raise SystemExit("State projection: duplicate materialized result_id")
+
+    seen_overlays: set[str] = set()
+    expected_overlay_fields = STATE_OVERLAY_FIELDS | (
+        STATE_AMENDMENT_FIELDS if version in {5, 6} else set()
+    )
+    for overlay in raw["result_overlays"]:
+        if not isinstance(overlay, dict) or set(overlay) != expected_overlay_fields:
+            raise SystemExit("State projection: invalid result overlay fields")
+        result_id_value = overlay["result_id"]
+        solution = by_result.get(result_id_value)
+        if solution is None or result_id_value in seen_overlays:
+            raise SystemExit("State projection: unknown or duplicate result overlay")
+        seen_overlays.add(result_id_value)
+        if (
+            overlay["owner_login"] != solution.submitter.lower()
+            or overlay["declared_model"] != solution.declared_model
+            or overlay["problem_id"] != solution.problem_id
+            or overlay["statement_revision"] != solution.statement_revision
+            or not isinstance(overlay["metadata"], dict)
+        ):
+            raise SystemExit("State projection: result overlay identity mismatch")
+        solution.metadata = dict(overlay["metadata"])
+        solution.provenance["state_claim_event_id"] = overlay["claim_event_id"]
+        solution.provenance["state_mutation_event_id"] = overlay[
+            "mutation_event_id"
+        ]
+        if version in {5, 6}:
+            if (
+                not isinstance(overlay["effective_problem_id"], str)
+                or type(overlay["effective_statement_revision"]) is not int
+                or overlay["effective_statement_revision"] < 1
+                or not isinstance(overlay["leaderboard_eligible"], bool)
+            ):
+                raise SystemExit("State projection: invalid overlay amendment")
+            solution.problem_id = overlay["effective_problem_id"]
+            solution.statement_revision = overlay[
+                "effective_statement_revision"
+            ]
+            solution.retracted = not overlay["leaderboard_eligible"]
+
+    if version != 6:
+        return solutions
+
+    def expected_historical_visibility(result_id_value: str) -> str:
+        solution = by_result[result_id_value]
+        submission = solution.provenance.get("submission")
+        if (
+            solution.provenance.get("source") != "base-results-store"
+            or not isinstance(submission, dict)
+            or not isinstance(submission.get("public"), bool)
+        ):
+            raise SystemExit(
+                "State projection: historical replay does not target a base result"
+            )
+        return "public" if submission["public"] else "private"
+
+    def validate_historical_identity(
+        item: dict[str, Any], result_id_value: str
+    ) -> None:
+        solution = by_result[result_id_value]
+        if (
+            not isinstance(item["owner_login"], str)
+            or not LOGIN_RE.fullmatch(item["owner_login"])
+            or not isinstance(item["declared_model"], str)
+            or not item["declared_model"]
+            or not isinstance(item["problem_id"], str)
+            or not item["problem_id"]
+            or type(item["statement_revision"]) is not int
+            or item["statement_revision"] < 1
+            or not isinstance(item["historical_accepted_at"], str)
+            or not re.fullmatch(
+                r"(?!0000-)[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+                r"[0-9]{2}:[0-9]{2}:[0-9]{2}Z",
+                item["historical_accepted_at"],
+            )
+            or expected_result_id(
+                item["owner_login"],
+                item["declared_model"],
+                item["problem_id"],
+                item["statement_revision"],
+            )
+            != result_id_value
+            or item["owner_login"] != solution.submitter.lower()
+            or item["declared_model"] != solution.declared_model
+            or item["historical_accepted_at"] != solution.accepted_at
+        ):
+            raise SystemExit("State projection: historical result identity mismatch")
+
+    series_by_result: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    seen_series: set[tuple[str, str]] = set()
+    transition_event_ids: set[str] = set()
+    series_order: list[tuple[str, str, str, str]] = []
+    for series in raw["historical_replay_series"]:
+        if not isinstance(series, dict) or set(series) != HISTORICAL_REPLAY_SERIES_FIELDS:
+            raise SystemExit("State projection: invalid historical replay series fields")
+        result_id_value = series["result_id"]
+        replay_task_id = series["replay_task_id"]
+        identity = (result_id_value, replay_task_id)
+        if (
+            not isinstance(result_id_value, str)
+            or RESULT_ID_RE.fullmatch(result_id_value) is None
+            or result_id_value not in by_result
+            or not isinstance(replay_task_id, str)
+            or REPLAY_TASK_ID_RE.fullmatch(replay_task_id) is None
+            or identity in seen_series
+            or series["source_visibility"] not in {"public", "private"}
+            or series["source_visibility"]
+            != expected_historical_visibility(result_id_value)
+            or not isinstance(series["measurement_config_digest"], str)
+            or DIGEST_RE.fullmatch(series["measurement_config_digest"]) is None
+            or not isinstance(series["execution_profile_digest"], str)
+            or DIGEST_RE.fullmatch(series["execution_profile_digest"]) is None
+            or not isinstance(series["updated_at"], str)
+            or STATE_TIMESTAMP_RE.fullmatch(series["updated_at"]) is None
+            or not isinstance(series["transition_event_id"], str)
+            or EVENT_ID_RE.fullmatch(series["transition_event_id"]) is None
+            or series["transition_event_id"] in transition_event_ids
+            or replay_task_id
+            != _expected_replay_task_id(
+                result_id_value, series["measurement_config_digest"]
+            )
+        ):
+            raise SystemExit("State projection: invalid historical replay series")
+        validate_historical_identity(series, result_id_value)
+        seen_series.add(identity)
+        transition_event_ids.add(series["transition_event_id"])
+        series_order.append(
+            (
+                result_id_value,
+                replay_task_id,
+                series["measurement_config_digest"],
+                series["execution_profile_digest"],
+            )
+        )
+        series_by_result[result_id_value].append(series)
+    if series_order != sorted(series_order):
+        raise SystemExit("State projection: historical replay series are not sorted")
+
+    dispositions: dict[str, dict[str, Any]] = {}
+    disposition_order: list[str] = []
+    for disposition in raw["historical_replay_unavailability"]:
+        if (
+            not isinstance(disposition, dict)
+            or set(disposition) != HISTORICAL_REPLAY_UNAVAILABILITY_FIELDS
+        ):
+            raise SystemExit("State projection: invalid historical disposition fields")
+        result_id_value = disposition["result_id"]
+        if (
+            not isinstance(result_id_value, str)
+            or RESULT_ID_RE.fullmatch(result_id_value) is None
+            or result_id_value not in by_result
+            or result_id_value in dispositions
+            or result_id_value in series_by_result
+            or disposition["source_visibility"] not in {"public", "private"}
+            or disposition["source_visibility"]
+            != expected_historical_visibility(result_id_value)
+            or not isinstance(disposition["disposed_at"], str)
+            or STATE_TIMESTAMP_RE.fullmatch(disposition["disposed_at"]) is None
+            or not isinstance(disposition["disposition_event_id"], str)
+            or EVENT_ID_RE.fullmatch(disposition["disposition_event_id"]) is None
+            or disposition["disposition_event_id"] in transition_event_ids
+            or not isinstance(disposition["reason"], str)
+            or not disposition["reason"]
+            or (
+                disposition["rationale"] is not None
+                and (
+                    not isinstance(disposition["rationale"], str)
+                    or not disposition["rationale"]
+                )
+            )
+        ):
+            raise SystemExit("State projection: invalid historical disposition")
+        validate_historical_identity(disposition, result_id_value)
+        expected_disposition = (
+            (
+                "source_ref_permanently_unavailable",
+                "accepted_immutable_source_ref_unavailable_without_archive",
+            )
+            if disposition["source_visibility"] == "public"
+            else ("archive_not_found", None)
+        )
+        if (disposition["reason"], disposition["rationale"]) != expected_disposition:
+            raise SystemExit("State projection: invalid historical disposition")
+        disposition_order.append(result_id_value)
+        transition_event_ids.add(disposition["disposition_event_id"])
+        dispositions[result_id_value] = disposition
+    if disposition_order != sorted(disposition_order):
+        raise SystemExit("State projection: historical dispositions are not sorted")
+
+    for result_id_value, series_items in series_by_result.items():
+        lanes = {item["source_visibility"] for item in series_items}
+        if len(lanes) != 1:
+            raise SystemExit("State projection: historical replay lane changed")
+        solution = by_result[result_id_value]
+        measurements: list[dict[str, Any]] = []
+        summaries: list[tuple[tuple[str, str, str], dict[str, Any]]] = []
+        for series in series_items:
+            summary, measurement = _replay_projection_view(
+                series["replay"],
+                measurement_identity={
+                    key: series[key]
+                    for key in (
+                        "source_visibility", "replay_task_id",
+                        "measurement_config_digest", "execution_profile_digest",
+                        "updated_at", "transition_event_id",
+                    )
+                },
+            )
+            measurements.append(measurement)
+            summaries.append(
+                (
+                    (
+                        series["updated_at"], series["transition_event_id"],
+                        series["replay_task_id"],
+                    ),
+                    summary,
+                )
+            )
+        solution.measurements = measurements
+        solution.replay = max(summaries, key=lambda item: item[0])[1]
+
+    for result_id_value, disposition in dispositions.items():
+        solution = by_result[result_id_value]
+        solution.replay = {
+            "status": "unavailable",
+            "reason": disposition["reason"],
+        }
+        solution.measurements = []
+    return solutions
 
 
 def _scope_problem_ids(
@@ -912,7 +1336,7 @@ def build_lifecycle_projection(
         for solution in solutions
     ):
         limitations.append(
-            "Results not yet present in the public State projection were adapted from the immutable base-results store; their replay/release states are explicitly unavailable."
+            "Results absent from modern State result materialization were adapted from the immutable base-results store. Historical replay or disposition evidence is applied where State supplies it; otherwise replay is explicitly unavailable, and release remains unavailable."
         )
     if not any(
         lifecycle["status_history"] or lifecycle["statement_revisions"]

--- a/scripts/validate_lifecycle_site_data.py
+++ b/scripts/validate_lifecycle_site_data.py
@@ -20,6 +20,29 @@ GROUPS = {
 }
 CATALOG_DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
 STATEMENT_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}")
+REPLAY_TASK_ID_RE = re.compile(r"rt1_[0-9a-f]{64}")
+DIGEST_RE = re.compile(r"[0-9a-f]{64}")
+EVENT_ID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+)
+STATE_TIMESTAMP_RE = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z"
+)
+REPLAY_STATUSES = {
+    "queued", "running", "accepted", "rejected", "declined", "crashed",
+    "timed_out", "failed", "unavailable",
+}
+MEASUREMENT_CORE_FIELDS = {
+    "kind", "replay_status", "replay_reason", "status", "checker",
+    "checker_wall_time_ms", "checker_retired_instructions",
+    "checker_retired_instructions_unavailable_reason", "build_wall_time_ms",
+    "build_retired_instructions", "build_retired_instructions_unavailable_reason",
+    "lines_of_code", "file_count", "unavailable_reason", "attempt",
+}
+MEASUREMENT_SERIES_FIELDS = {
+    "source_visibility", "replay_task_id", "measurement_config_digest",
+    "execution_profile_digest", "updated_at", "transition_event_id",
+}
 CATALOG_REASONS = {
     "initial",
     "statement-change",
@@ -60,6 +83,111 @@ def catalog_date(value: Any, message: str) -> str:
         raise ContractError(message) from error
     require(parsed.isoformat() == value, message)
     return value
+
+
+def validate_measurements(path: pathlib.Path, solution: dict[str, Any]) -> None:
+    measurements = solution.get("measurements")
+    require(isinstance(measurements, list), f"{path}: measurements must be an array")
+    series_order: list[tuple[str, str, str]] = []
+    replay_task_ids: set[str] = set()
+    transition_event_ids: set[str] = set()
+    for index, measurement in enumerate(measurements):
+        label = f"{path}: measurement {index}"
+        require(isinstance(measurement, dict), f"{label} must be an object")
+        fields = set(measurement)
+        require(
+            fields == MEASUREMENT_CORE_FIELDS
+            or fields == MEASUREMENT_CORE_FIELDS | MEASUREMENT_SERIES_FIELDS,
+            f"{label} fields are invalid",
+        )
+        require(measurement["kind"] == "checker-replay", f"{label} kind is invalid")
+        require(
+            measurement["replay_status"] in REPLAY_STATUSES,
+            f"{label} replay status is invalid",
+        )
+        require(
+            measurement["replay_reason"] is None
+            or isinstance(measurement["replay_reason"], str)
+            and bool(measurement["replay_reason"]),
+            f"{label} replay reason is invalid",
+        )
+        require(
+            measurement["status"] in {"available", "unavailable"},
+            f"{label} counter status is invalid",
+        )
+        require(
+            measurement["checker"] is None
+            or isinstance(measurement["checker"], str)
+            and bool(measurement["checker"]),
+            f"{label} checker is invalid",
+        )
+        require(
+            type(measurement["attempt"]) is int and measurement["attempt"] >= 0,
+            f"{label} attempt is invalid",
+        )
+        for field in (
+            "checker_wall_time_ms", "checker_retired_instructions",
+            "build_wall_time_ms", "build_retired_instructions", "lines_of_code",
+            "file_count",
+        ):
+            value = measurement[field]
+            require(
+                value is None or type(value) is int and value >= 0,
+                f"{label} {field} is invalid",
+            )
+        for field in (
+            "checker_retired_instructions_unavailable_reason",
+            "build_retired_instructions_unavailable_reason", "unavailable_reason",
+        ):
+            value = measurement[field]
+            require(
+                value is None or isinstance(value, str) and bool(value),
+                f"{label} {field} is invalid",
+            )
+        if fields == MEASUREMENT_CORE_FIELDS:
+            continue
+        require(
+            measurement["source_visibility"] in {"public", "private"},
+            f"{label} source visibility is invalid",
+        )
+        replay_task_id = measurement["replay_task_id"]
+        transition_event_id = measurement["transition_event_id"]
+        require(
+            isinstance(replay_task_id, str)
+            and REPLAY_TASK_ID_RE.fullmatch(replay_task_id) is not None,
+            f"{label} replay task is invalid",
+        )
+        require(
+            isinstance(transition_event_id, str)
+            and EVENT_ID_RE.fullmatch(transition_event_id) is not None,
+            f"{label} transition event is invalid",
+        )
+        require(replay_task_id not in replay_task_ids, f"{label} replay task is duplicated")
+        require(
+            transition_event_id not in transition_event_ids,
+            f"{label} transition event is duplicated",
+        )
+        replay_task_ids.add(replay_task_id)
+        transition_event_ids.add(transition_event_id)
+        for field in ("measurement_config_digest", "execution_profile_digest"):
+            value = measurement[field]
+            require(
+                isinstance(value, str) and DIGEST_RE.fullmatch(value) is not None,
+                f"{label} {field} is invalid",
+            )
+        require(
+            isinstance(measurement["updated_at"], str)
+            and STATE_TIMESTAMP_RE.fullmatch(measurement["updated_at"]) is not None,
+            f"{label} updated_at is invalid",
+        )
+        series_order.append(
+            (
+                replay_task_id,
+                measurement["measurement_config_digest"],
+                measurement["execution_profile_digest"],
+            )
+        )
+    require(series_order == sorted(series_order), f"{path}: measurement series order is invalid")
 
 
 def scope_ids(group: dict[str, Any]) -> set[tuple[str, int]]:
@@ -241,6 +369,7 @@ def validate(root: pathlib.Path) -> None:
             require(solution.get("problem_id") == problem_id, f"{path}: solution problem mismatch")
             require("status" in solution.get("replay", {}), f"{path}: replay state omitted")
             require("status" in solution.get("release", {}), f"{path}: release state omitted")
+            validate_measurements(path, solution)
             result_id = solution["result_id"]
             require(result_id not in problem_result_ids, f"{path}: duplicate base result")
             problem_result_ids.add(result_id)

--- a/static/lifecycle-preview.js
+++ b/static/lifecycle-preview.js
@@ -336,8 +336,16 @@
         if (solution.measurements.length) {
           card.appendChild(heading(5, "Measurements"));
           solution.measurements.forEach(function (measurement) {
-            card.appendChild(definitionList([
-              ["Checker", measurement.checker], ["Status", measurement.status],
+            var measurementFields = [
+              ["Checker", measurement.checker],
+              ["Replay outcome", measurement.replay_status],
+              ["Performance counters", measurement.status]
+            ];
+            if (measurement.replay_reason) measurementFields.push(["Replay reason", measurement.replay_reason]);
+            if (measurement.measurement_config_digest) measurementFields.push(["Measurement series", measurement.measurement_config_digest]);
+            if (measurement.execution_profile_digest) measurementFields.push(["Execution profile", measurement.execution_profile_digest]);
+            if (measurement.updated_at) measurementFields.push(["Replay updated", formattedDate(measurement.updated_at)]);
+            measurementFields.push(
               ["Checker wall time (ms)", measurement.checker_wall_time_ms],
               ["Checker retired instructions", measurement.checker_retired_instructions],
               ["Checker counter unavailable reason", measurement.checker_retired_instructions_unavailable_reason],
@@ -345,7 +353,8 @@
               ["Build retired instructions", measurement.build_retired_instructions],
               ["Build counter unavailable reason", measurement.build_retired_instructions_unavailable_reason],
               ["Lines of code", measurement.lines_of_code], ["File count", measurement.file_count]
-            ]));
+            );
+            card.appendChild(definitionList(measurementFields));
           });
         } else {
           card.appendChild(node("p", { className: "lifecycle-unavailable", text: "Replay measurements unavailable." }));

--- a/tests/fixtures/public-state-projection-v6-historical.json
+++ b/tests/fixtures/public-state-projection-v6-historical.json
@@ -1,0 +1,86 @@
+{
+  "environment": "production",
+  "historical_replay_series": [
+    {
+      "declared_model": "Historical Model",
+      "execution_profile_digest": "2222222222222222222222222222222222222222222222222222222222222222",
+      "historical_accepted_at": "2025-02-03T04:05:06Z",
+      "measurement_config_digest": "1111111111111111111111111111111111111111111111111111111111111111",
+      "owner_login": "a-m-berns",
+      "problem_id": "two_plus_two",
+      "replay": {
+        "attempt": 0,
+        "build_retired_instructions": null,
+        "build_retired_instructions_unavailable_reason": null,
+        "build_wall_time_ms": null,
+        "checker": "nanoda",
+        "checker_retired_instructions": null,
+        "checker_retired_instructions_unavailable_reason": null,
+        "checker_wall_time_ms": null,
+        "file_count": null,
+        "lines_of_code": null,
+        "reason": null,
+        "status": "queued"
+      },
+      "replay_task_id": "rt1_65508db251b118fb71793d07ca3fb4930a18bbccee9d1e2fe4df95184cbbfff5",
+      "result_id": "r2_ffb75ab57160fb4a272ad11c7caf9c812d547f5b8fa1384ce4ea55e4ab0f884f",
+      "source_visibility": "public",
+      "statement_revision": 1,
+      "transition_event_id": "0198abcd-0000-7000-8000-00000000001a",
+      "updated_at": "2026-10-20T06:08:26.000Z"
+    },
+    {
+      "declared_model": "Historical Model",
+      "execution_profile_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "historical_accepted_at": "2025-02-03T04:05:06Z",
+      "measurement_config_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "owner_login": "a-m-berns",
+      "problem_id": "two_plus_two",
+      "replay": {
+        "attempt": 0,
+        "build_retired_instructions": null,
+        "build_retired_instructions_unavailable_reason": null,
+        "build_wall_time_ms": null,
+        "checker": "nanoda",
+        "checker_retired_instructions": null,
+        "checker_retired_instructions_unavailable_reason": null,
+        "checker_wall_time_ms": null,
+        "file_count": null,
+        "lines_of_code": null,
+        "reason": null,
+        "status": "queued"
+      },
+      "replay_task_id": "rt1_d2bdd51b202de8d1b422326c4ca2d44857fa2b36240941aafb35e8e5afcd6b1e",
+      "result_id": "r2_ffb75ab57160fb4a272ad11c7caf9c812d547f5b8fa1384ce4ea55e4ab0f884f",
+      "source_visibility": "public",
+      "statement_revision": 1,
+      "transition_event_id": "0198abcd-0000-7000-8000-000000000016",
+      "updated_at": "2026-10-20T06:08:22.000Z"
+    }
+  ],
+  "historical_replay_unavailability": [
+    {
+      "declared_model": "Unavailable Private Model",
+      "disposed_at": "2026-10-22T06:08:41.000Z",
+      "disposition_event_id": "0198abcd-0000-7000-8000-000000000029",
+      "historical_accepted_at": "2025-02-03T04:05:06Z",
+      "owner_login": "private-owner",
+      "problem_id": "private_problem",
+      "rationale": null,
+      "reason": "archive_not_found",
+      "result_id": "r2_4f3bdb6031dd0444f73a5dd39b1c60c2289b380a3720f561277e010a68f1e900",
+      "source_visibility": "private",
+      "statement_revision": 1
+    }
+  ],
+  "model_aliases": [],
+  "model_identities": [],
+  "model_identity_history": [],
+  "result_amendment_history": [],
+  "result_overlays": [],
+  "results": [],
+  "schema_version": 6,
+  "source_digest": "19f0a288ad8954a1fee30f3c46688c8e28f6d11f9049a9180e101426ef1d2252",
+  "source_event_count": 7,
+  "source_state_commit": "0000000000000000000000000000000000000000"
+}

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -10,8 +10,10 @@ from types import SimpleNamespace
 from scripts.lifecycle_site_data import (
     SetDefinition,
     Solution,
+    _expected_replay_task_id,
     adapt_results_store,
     adapt_state_projection,
+    apply_state_projection_overlays,
     build_lifecycle_projection,
     build_model_identity_index,
     load_preview_fixture,
@@ -328,6 +330,8 @@ class LifecycleProjectionTests(unittest.TestCase):
         self.assertEqual(adapted[0].replay["status"], "accepted")
         expected_measurement = {
             "kind": "checker-replay",
+            "replay_status": "accepted",
+            "replay_reason": None,
             "status": "unavailable",
             "checker": "lean4lean",
             "checker_wall_time_ms": 20,
@@ -348,6 +352,12 @@ class LifecycleProjectionTests(unittest.TestCase):
             expected_measurement,
         )
         self.assertEqual(adapted[0].release["status"], "scheduled")
+        nullable_checker = copy.deepcopy(raw)
+        nullable_checker["results"][0]["replay"]["checker"] = None
+        self.assertIsNone(
+            adapt_state_projection(nullable_checker, aliases)[0]
+            .measurements[0]["checker"]
+        )
         files = build_lifecycle_projection(
             problems=[problem("alpha")],
             solutions=adapted,
@@ -695,6 +705,316 @@ class LifecycleProjectionTests(unittest.TestCase):
         merged = merge_solutions([state], [legacy])
 
         self.assertEqual([item.result_id for item in merged], ["r2_a"])
+
+
+class HistoricalReplayProjectionTests(unittest.TestCase):
+    RESULT_ID = result_id("alice", "Example Model", "alpha", 1)
+
+    def base_record(self, *, public: bool = True) -> dict:
+        return {
+            "result_id": self.RESULT_ID,
+            "problem_id": "alpha",
+            "statement_revision": 1,
+            "declared_model": "Example Model",
+            "accepted_at": "2026-08-20T00:00:00Z",
+            "benchmark_commit": "a" * 40,
+            "intake": {"kind": "issue", "issue_number": 1},
+            "submission": {
+                "kind": "github_repo",
+                "repo": "alice/proofs",
+                "ref": "b" * 40,
+                "public": public,
+            },
+            "production_metadata": {},
+        }
+
+    def replay(self, status: str) -> dict:
+        return {
+            "status": status,
+            "reason": None,
+            "attempt": 1,
+            "checker": "nanoda",
+            "checker_wall_time_ms": 20,
+            "checker_retired_instructions": 200,
+            "checker_retired_instructions_unavailable_reason": None,
+            "build_wall_time_ms": 40,
+            "build_retired_instructions": 400,
+            "build_retired_instructions_unavailable_reason": None,
+            "lines_of_code": 12,
+            "file_count": 1,
+        }
+
+    def projection(self) -> dict:
+        return {
+            "schema_version": 6,
+            "environment": "production",
+            "source_state_commit": "e" * 40,
+            "source_event_count": 8,
+            "source_digest": "f" * 64,
+            "results": [],
+            "result_overlays": [],
+            "model_identities": [],
+            "model_aliases": [],
+            "model_identity_history": [],
+            "result_amendment_history": [],
+            "historical_replay_series": [],
+            "historical_replay_unavailability": [],
+        }
+
+    def series(self, sequence: int, status: str) -> dict:
+        measurement_config_digest = f"{sequence:064x}"
+        return {
+            "result_id": self.RESULT_ID,
+            "owner_login": "alice",
+            "declared_model": "Example Model",
+            "problem_id": "alpha",
+            "statement_revision": 1,
+            "historical_accepted_at": "2026-08-20T00:00:00Z",
+            "source_visibility": "public",
+            "replay_task_id": _expected_replay_task_id(
+                self.RESULT_ID, measurement_config_digest
+            ),
+            "measurement_config_digest": measurement_config_digest,
+            "execution_profile_digest": f"{sequence + 10:064x}",
+            "updated_at": f"2026-10-20T06:08:{sequence:02d}.000Z",
+            "transition_event_id": (
+                f"0198abcd-0000-7000-8000-{sequence:012x}"
+            ),
+            "replay": self.replay(status),
+        }
+
+    def test_v6_applies_every_series_and_selects_latest_summary(self) -> None:
+        raw = self.projection()
+        raw["historical_replay_series"] = [
+            self.series(1, "rejected"),
+            self.series(2, "accepted"),
+        ]
+        raw["historical_replay_series"].sort(
+            key=lambda item: (
+                item["result_id"], item["replay_task_id"],
+                item["measurement_config_digest"],
+                item["execution_profile_digest"],
+            )
+        )
+        fallback = adapt_results_store(
+            [("alice", [self.base_record()])], {}, build_model_identity_index(raw)
+        )
+        state = adapt_state_projection(raw, {}, build_model_identity_index(raw))
+        solutions = merge_solutions(state, fallback)
+
+        apply_state_projection_overlays(solutions, raw)
+
+        self.assertEqual(solutions[0].replay["status"], "accepted")
+        self.assertEqual(len(solutions[0].measurements), 2)
+        self.assertEqual(
+            {
+                measurement["execution_profile_digest"]
+                for measurement in solutions[0].measurements
+            },
+            {f"{11:064x}", f"{12:064x}"},
+        )
+        self.assertTrue(
+            all(
+                measurement["checker"] == "nanoda"
+                for measurement in solutions[0].measurements
+            )
+        )
+
+    def test_state_generated_v6_fixture_joins_series_and_disposition(self) -> None:
+        raw = json.loads(
+            (
+                ROOT
+                / "tests/fixtures/public-state-projection-v6-historical.json"
+            ).read_text()
+        )
+        identities = [
+            raw["historical_replay_series"][0],
+            raw["historical_replay_unavailability"][0],
+        ]
+        normalized = []
+        for sequence, identity in enumerate(identities, start=1):
+            normalized.append(
+                (
+                    identity["owner_login"],
+                    [{
+                        "result_id": identity["result_id"],
+                        "problem_id": identity["problem_id"],
+                        "statement_revision": identity["statement_revision"],
+                        "declared_model": identity["declared_model"],
+                        "accepted_at": identity["historical_accepted_at"],
+                        "benchmark_commit": "a" * 40,
+                        "intake": {"kind": "issue", "issue_number": sequence},
+                        "submission": {
+                            "kind": "github_repo",
+                            "repo": f"{identity['owner_login']}/proofs",
+                            "ref": "b" * 40,
+                            "public": identity["source_visibility"] == "public",
+                        },
+                        "production_metadata": {},
+                    }],
+                )
+            )
+        identity_index = build_model_identity_index(raw)
+        solutions = adapt_results_store(normalized, {}, identity_index)
+
+        apply_state_projection_overlays(solutions, raw)
+
+        by_result = {solution.result_id: solution for solution in solutions}
+        series_result = raw["historical_replay_series"][0]["result_id"]
+        unavailable_result = raw["historical_replay_unavailability"][0][
+            "result_id"
+        ]
+        self.assertEqual(len(by_result[series_result].measurements), 2)
+        self.assertEqual(by_result[series_result].replay["status"], "queued")
+        self.assertEqual(
+            by_result[unavailable_result].replay,
+            {"status": "unavailable", "reason": "archive_not_found"},
+        )
+
+    def test_v6_rejects_invalid_replay_values_and_duplicate_transitions(self) -> None:
+        solutions = adapt_results_store(
+            [("alice", [self.base_record()])], {},
+            build_model_identity_index(self.projection()),
+        )
+        for mutation in ("status", "checker", "measurements"):
+            with self.subTest(mutation=mutation):
+                raw = self.projection()
+                series = self.series(1, "accepted")
+                if mutation == "status":
+                    series["replay"]["status"] = "invented"
+                elif mutation == "checker":
+                    series["replay"]["checker"] = "experimental"
+                else:
+                    series["replay"]["checker_wall_time_ms"] = None
+                raw["historical_replay_series"] = [series]
+                with self.assertRaisesRegex(SystemExit, "replay"):
+                    apply_state_projection_overlays(copy.deepcopy(solutions), raw)
+
+        raw = self.projection()
+        first = self.series(1, "accepted")
+        second = self.series(2, "accepted")
+        second["transition_event_id"] = first["transition_event_id"]
+        raw["historical_replay_series"] = sorted(
+            [first, second],
+            key=lambda item: (
+                item["result_id"], item["replay_task_id"],
+                item["measurement_config_digest"],
+                item["execution_profile_digest"],
+            ),
+        )
+        with self.assertRaisesRegex(SystemExit, "historical replay series"):
+            apply_state_projection_overlays(copy.deepcopy(solutions), raw)
+
+    def test_cumulative_v5_overlay_updates_legacy_result(self) -> None:
+        raw = self.projection()
+        raw["schema_version"] = 5
+        raw.pop("historical_replay_series")
+        raw.pop("historical_replay_unavailability")
+        raw["result_overlays"] = [{
+            "result_id": self.RESULT_ID,
+            "owner_login": "alice",
+            "declared_model": "Example Model",
+            "problem_id": "alpha",
+            "statement_revision": 1,
+            "claim_event_id": "0198abcd-0000-7000-8000-000000000010",
+            "mutation_event_id": "0198abcd-0000-7000-8000-000000000011",
+            "claimed_at": "2026-10-20T06:08:10.000Z",
+            "metadata": {
+                "notes": {
+                    "value": "Corrected metadata.",
+                    "provenance": "backfilled",
+                    "event_id": "0198abcd-0000-7000-8000-000000000011",
+                    "recorded_at": "2026-10-20T06:08:11.000Z",
+                }
+            },
+            "model_id": None,
+            "resolved_model_id": None,
+            "effective_problem_id": "beta",
+            "effective_statement_revision": 2,
+            "problem_repair": None,
+            "applied_problem_repair": None,
+            "retraction": None,
+            "leaderboard_eligible": False,
+        }]
+        fallback = adapt_results_store(
+            [("alice", [self.base_record()])], {}, build_model_identity_index(raw)
+        )
+        state = adapt_state_projection(raw, {}, build_model_identity_index(raw))
+        solutions = merge_solutions(state, fallback)
+
+        apply_state_projection_overlays(solutions, raw)
+
+        self.assertEqual(solutions[0].problem_id, "beta")
+        self.assertEqual(solutions[0].statement_revision, 2)
+        self.assertTrue(solutions[0].retracted)
+        self.assertEqual(
+            solutions[0].metadata["notes"]["provenance"], "backfilled"
+        )
+
+    def test_v6_applies_reviewed_unavailability_without_measurement(self) -> None:
+        raw = self.projection()
+        raw["historical_replay_unavailability"] = [{
+            "result_id": self.RESULT_ID,
+            "owner_login": "alice",
+            "declared_model": "Example Model",
+            "problem_id": "alpha",
+            "statement_revision": 1,
+            "historical_accepted_at": "2026-08-20T00:00:00Z",
+            "source_visibility": "public",
+            "disposed_at": "2026-10-20T06:08:40.000Z",
+            "disposition_event_id": "0198abcd-0000-7000-8000-000000000040",
+            "reason": "source_ref_permanently_unavailable",
+            "rationale": (
+                "accepted_immutable_source_ref_unavailable_without_archive"
+            ),
+        }]
+        solutions = adapt_results_store(
+            [("alice", [self.base_record()])], {}, build_model_identity_index(raw)
+        )
+
+        apply_state_projection_overlays(solutions, raw)
+
+        self.assertEqual(solutions[0].replay, {
+            "status": "unavailable",
+            "reason": "source_ref_permanently_unavailable",
+        })
+        self.assertEqual(solutions[0].measurements, [])
+
+    def test_v6_rejects_overlap_private_fields_and_lane_mismatch(self) -> None:
+        raw = self.projection()
+        raw["historical_replay_series"] = [self.series(1, "accepted")]
+        raw["historical_replay_unavailability"] = [{
+            "result_id": self.RESULT_ID,
+            "owner_login": "alice",
+            "declared_model": "Example Model",
+            "problem_id": "alpha",
+            "statement_revision": 1,
+            "historical_accepted_at": "2026-08-20T00:00:00Z",
+            "source_visibility": "public",
+            "disposed_at": "2026-10-20T06:08:40.000Z",
+            "disposition_event_id": "0198abcd-0000-7000-8000-000000000040",
+            "reason": "source_ref_permanently_unavailable",
+            "rationale": None,
+        }]
+        solutions = adapt_results_store(
+            [("alice", [self.base_record()])], {}, build_model_identity_index(raw)
+        )
+        with self.assertRaisesRegex(SystemExit, "historical disposition"):
+            apply_state_projection_overlays(solutions, raw)
+
+        raw = self.projection()
+        series = self.series(1, "accepted")
+        series["archive_path"] = "private/archive.tar.age"
+        raw["historical_replay_series"] = [series]
+        with self.assertRaisesRegex(SystemExit, "series fields"):
+            apply_state_projection_overlays(solutions, raw)
+
+        raw = self.projection()
+        series = self.series(1, "accepted")
+        series["source_visibility"] = "private"
+        raw["historical_replay_series"] = [series]
+        with self.assertRaisesRegex(SystemExit, "invalid historical replay series"):
+            apply_state_projection_overlays(solutions, raw)
 
 
 if __name__ == "__main__":

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -166,6 +166,10 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("Checkout private production State for its redacted projection", workflow)
         self.assertIn("persist-credentials: false", workflow)
         self.assertIn("--state-projection", workflow)
+        self.assertIn("--schema-version 6", workflow)
+        self.assertIn(".schema_version == 6", workflow)
+        self.assertIn(".historical_replay_series | type == \"array\"", workflow)
+        self.assertIn(".historical_replay_unavailability | type == \"array\"", workflow)
         self.assertIn("_site/site-data/public-state.json", workflow)
         self.assertIn("Private State fields leaked", workflow)
 


### PR DESCRIPTION
## Summary

- consume merged State public projection v6 and vendor the exact v5/v6 schemas
- join strictly redacted historical replay series and reviewed dispositions to immutable base Results
- retain every replay measurement series while selecting the newest status summary
- close the site-data measurement schema and independent validator, with strict task, lane, identity, transition, verdict, and measurement checks
- render per-series replay outcomes and identities without adding noise to modern replay rows
- strengthen deploy redaction checks and preserve the credential-free PR fallback

## Validation

- `python3 -m unittest discover -s tests -v` (55 tests)
- State-generated v6 multi-series/disposition compatibility fixture
- real production-like v6 join: 489 State events, 488 dispositions, 1,551 current base results
- full generated site-data validated by the independent validator and `schemas/site-data-v2.schema.json`
- Python compileall, Node syntax check, JSON parsing, and `git diff --check`
- full `lake build` running locally; CI independently rebuilds the complete Pages artifact

State v6 landed first in leanprover/lean-eval-state#32, so the production-only schema-v6 path is available before this PR can deploy.
