### PR TITLE
fix: refresh leaderboard after State-only changes

### DIFF
--- a/.github/workflows/refresh-state.yml
+++ b/.github/workflows/refresh-state.yml
@@ -1,0 +1,76 @@
+name: Refresh leaderboard after State changes
+
+on:
+  schedule:
+    - cron: "7,22,37,52 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: leaderboard-state-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh-if-stale:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      # The deploy key is read-only and scoped to private production State.
+      - name: Read current production State head
+        # actions/checkout pinned to 3d3c42e5 (= refs/tags/v7.0.1 as of 2026-07-30).
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: leanprover/lean-eval-state
+          path: lean-eval-state
+          ssh-key: ${{ secrets.PRODUCTION_STATE_READ_KEY }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Dispatch one refresh when the deployed projection is stale
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          current_state="$(git -C lean-eval-state rev-parse HEAD)"
+          if [[ ! "$current_state" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "current State head is not a full commit" >&2
+            exit 1
+          fi
+
+          deployed_state="$(
+            curl --fail --silent --show-error --location \
+              --proto '=https' --max-redirs 2 --max-time 30 \
+              --retry 3 --retry-all-errors --retry-max-time 90 \
+              https://lean-lang.org/eval/site-data/v2/index.json \
+              | jq --exit-status --raw-output '
+                  select(.schema_version == 2) |
+                  select(.state.repo == "leanprover/lean-eval-state") |
+                  select(.state.materialized == true) |
+                  .state.commit |
+                  select(type == "string" and test("^[0-9a-f]{40}$"))
+                '
+          )"
+          if [ "$deployed_state" = "$current_state" ]; then
+            echo "Leaderboard already materializes production State $current_state."
+            exit 0
+          fi
+
+          active="$(
+            gh api "repos/$REPOSITORY/actions/workflows/deploy.yml/runs?per_page=100" \
+              --jq '[.workflow_runs[] | select(.head_branch == "main") | select(.status == "queued" or .status == "in_progress")] | length'
+          )"
+          if [[ ! "$active" =~ ^[0-9]+$ ]]; then
+            echo "could not establish the active deployment count" >&2
+            exit 1
+          fi
+          if [ "$active" != 0 ]; then
+            echo "A Pages deployment is already queued or running; it will be checked by the next bounded refresh."
+            exit 0
+          fi
+
+          gh workflow run deploy.yml --repo "$REPOSITORY" --ref main
+          echo "Dispatched a Pages refresh for production State $current_state."

--- a/.github/workflows/refresh-state.yml
+++ b/.github/workflows/refresh-state.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: leanprover/lean-eval-state
+          ref: main
           path: lean-eval-state
           ssh-key: ${{ secrets.PRODUCTION_STATE_READ_KEY }}
           persist-credentials: false
@@ -61,14 +62,14 @@ jobs:
 
           active="$(
             gh api "repos/$REPOSITORY/actions/workflows/deploy.yml/runs?per_page=100" \
-              --jq '[.workflow_runs[] | select(.head_branch == "main") | select(.status == "queued" or .status == "in_progress")] | length'
+              --jq '[.workflow_runs[] | select(.head_branch == "main") | select(.status != "completed")] | length'
           )"
           if [[ ! "$active" =~ ^[0-9]+$ ]]; then
             echo "could not establish the active deployment count" >&2
             exit 1
           fi
           if [ "$active" != 0 ]; then
-            echo "A Pages deployment is already queued or running; it will be checked by the next bounded refresh."
+            echo "A Pages deployment is already active; it will be checked by the next bounded refresh."
             exit 0
           fi
 

--- a/tests/test_state_refresh_workflow.py
+++ b/tests/test_state_refresh_workflow.py
@@ -12,6 +12,7 @@ class StateRefreshWorkflowTests(unittest.TestCase):
         self.assertIn("timeout-minutes: 5", WORKFLOW)
         self.assertIn("cancel-in-progress: false", WORKFLOW)
         self.assertIn("PRODUCTION_STATE_READ_KEY", WORKFLOW)
+        self.assertIn("ref: main", WORKFLOW)
         self.assertIn("persist-credentials: false", WORKFLOW)
         self.assertIn("fetch-depth: 1", WORKFLOW)
 
@@ -26,7 +27,7 @@ class StateRefreshWorkflowTests(unittest.TestCase):
     def test_refresh_does_not_queue_behind_an_active_pages_build(self) -> None:
         self.assertIn("actions/workflows/deploy.yml/runs?per_page=100", WORKFLOW)
         self.assertIn('.head_branch == "main"', WORKFLOW)
-        self.assertIn('.status == "queued" or .status == "in_progress"', WORKFLOW)
+        self.assertIn('.status != "completed"', WORKFLOW)
         self.assertIn('if [ "$active" != 0 ]', WORKFLOW)
         self.assertIn('gh workflow run deploy.yml --repo "$REPOSITORY" --ref main', WORKFLOW)
 

--- a/tests/test_state_refresh_workflow.py
+++ b/tests/test_state_refresh_workflow.py
@@ -1,0 +1,40 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW = (ROOT / ".github/workflows/refresh-state.yml").read_text(encoding="utf-8")
+
+
+class StateRefreshWorkflowTests(unittest.TestCase):
+    def test_refresh_is_bounded_and_uses_existing_read_only_state_key(self) -> None:
+        self.assertIn('cron: "7,22,37,52 * * * *"', WORKFLOW)
+        self.assertIn("timeout-minutes: 5", WORKFLOW)
+        self.assertIn("cancel-in-progress: false", WORKFLOW)
+        self.assertIn("PRODUCTION_STATE_READ_KEY", WORKFLOW)
+        self.assertIn("persist-credentials: false", WORKFLOW)
+        self.assertIn("fetch-depth: 1", WORKFLOW)
+
+    def test_refresh_binds_live_and_private_state_before_dispatch(self) -> None:
+        self.assertIn("https://lean-lang.org/eval/site-data/v2/index.json", WORKFLOW)
+        self.assertIn('select(.schema_version == 2)', WORKFLOW)
+        self.assertIn('select(.state.repo == "leanprover/lean-eval-state")', WORKFLOW)
+        self.assertIn('select(.state.materialized == true)', WORKFLOW)
+        self.assertIn('git -C lean-eval-state rev-parse HEAD', WORKFLOW)
+        self.assertIn('if [ "$deployed_state" = "$current_state" ]', WORKFLOW)
+
+    def test_refresh_does_not_queue_behind_an_active_pages_build(self) -> None:
+        self.assertIn("actions/workflows/deploy.yml/runs?per_page=100", WORKFLOW)
+        self.assertIn('.head_branch == "main"', WORKFLOW)
+        self.assertIn('.status == "queued" or .status == "in_progress"', WORKFLOW)
+        self.assertIn('if [ "$active" != 0 ]', WORKFLOW)
+        self.assertIn('gh workflow run deploy.yml --repo "$REPOSITORY" --ref main', WORKFLOW)
+
+    def test_refresh_permissions_are_minimal_for_same_repo_dispatch(self) -> None:
+        self.assertIn("permissions:\n  actions: write\n  contents: read", WORKFLOW)
+        self.assertNotIn("pages: write", WORKFLOW)
+        self.assertNotIn("id-token: write", WORKFLOW)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The lifecycle leaderboard currently redeploys after a new Result, but not after State-only owner or maintainer mutations. That can leave release opt-out, metadata, repairs/retractions, and model identity changes stale indefinitely when no later result arrives.

This adds one bounded, read-only State drift check every 15 minutes. It compares the exact State commit published in `site-data/v2/index.json` with private production State `main`, skips when a main Pages build is already queued/running, and dispatches the existing protected-main Pages workflow only when the deployed projection is stale. It reuses the existing read-only State deploy key; it has no State write, Pages write, or ID-token permission.

This is isolated from the launch-copy and intake changes. It is a production freshness fix, not a qualification or evidence service.

Validation:
- 59 Python tests passed
- workflow YAML parses
- shell block parses with `bash -n`
- `git diff --check` clean