### PR TITLE
Show automatic release date on problem pages

### DIFF
--- a/static/lifecycle-preview.js
+++ b/static/lifecycle-preview.js
@@ -294,6 +294,16 @@
     return list;
   }
 
+  function releaseFields(release) {
+    var fields = [["Release", release.status + (release.reason ? " · " + release.reason : "")]];
+    if (release.status === "scheduled") {
+      fields.push(["Automatic release", release.release_at
+        ? formattedDate(release.release_at) + " · " + release.release_at
+        : null]);
+    }
+    return fields;
+  }
+
   function renderProblem(content, status, problemId) {
     fetchJson("site-data/v2/problems/" + encodeURIComponent(problemId) + ".json").then(function (data) {
       status.hidden = true;
@@ -309,15 +319,15 @@
       }) : [node("li", { text: "No named set membership." })]);
       var solutions = node("div", { className: "lifecycle-solution-grid" });
       data.solutions.forEach(function (solution) {
+        var solutionFields = [
+          ["Submitter", "@" + solution.submitter], ["Accepted", formattedDate(solution.accepted_at)],
+          ["Credit", solution.first_solve ? "First solve" : "Accepted solve"],
+          ["Declared label", solution.canonical_credit.declared_label],
+          ["Replay", solution.replay.status + (solution.replay.reason ? " · " + solution.replay.reason : "")]
+        ].concat(releaseFields(solution.release));
         var card = node("article", { className: "lifecycle-solution-card" }, [
           heading(4, solution.canonical_credit.label),
-          definitionList([
-            ["Submitter", "@" + solution.submitter], ["Accepted", formattedDate(solution.accepted_at)],
-            ["Credit", solution.first_solve ? "First solve" : "Accepted solve"],
-            ["Declared label", solution.canonical_credit.declared_label],
-            ["Replay", solution.replay.status + (solution.replay.reason ? " · " + solution.replay.reason : "")],
-            ["Release", solution.release.status + (solution.release.reason ? " · " + solution.release.reason : "")]
-          ])
+          definitionList(solutionFields)
         ]);
         if (solution.public_solution.available && solution.public_solution.url) {
           card.appendChild(node("p", {}, [node("a", { href: solution.public_solution.url, rel: "noopener", text: "Released solution" })]));

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -351,7 +351,15 @@ class LifecycleProjectionTests(unittest.TestCase):
             adapted[0].measurements[0],
             expected_measurement,
         )
-        self.assertEqual(adapted[0].release["status"], "scheduled")
+        self.assertEqual(
+            adapted[0].release,
+            {
+                "status": "scheduled",
+                "release_at": "2026-10-20T00:00:00Z",
+                "reason": None,
+                "url": None,
+            },
+        )
         nullable_checker = copy.deepcopy(raw)
         nullable_checker["results"][0]["replay"]["checker"] = None
         self.assertIsNone(
@@ -372,6 +380,7 @@ class LifecycleProjectionTests(unittest.TestCase):
         )
         published = files["v2/problems/alpha.json"]["solutions"][0]
         self.assertEqual(published["measurements"], [expected_measurement])
+        self.assertEqual(published["release"], adapted[0].release)
 
         raw["results"][0]["replay"]["checker_retired_instructions"] = 200
         raw["results"][0]["replay"][

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -152,6 +152,16 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertNotIn("measurement.wall_time_ms", client)
         self.assertNotIn("measurement.retired_instructions", client)
 
+    def test_problem_page_shows_the_exact_scheduled_release_time(self) -> None:
+        client = (REPO_ROOT / "static/lifecycle-preview.js").read_text()
+
+        self.assertIn('release.status === "scheduled"', client)
+        self.assertIn('["Automatic release", release.release_at', client)
+        self.assertIn(
+            'formattedDate(release.release_at) + " · " + release.release_at',
+            client,
+        )
+
     def test_product_ui_uses_lifecycle_not_schema_terminology(self) -> None:
         sources = [
             REPO_ROOT / "LeaderboardSite/Pages/Preview.lean",


### PR DESCRIPTION
Problem pages currently show that an accepted solution is scheduled, but omit its actual automatic-release time even though the public State projection carries the authoritative `release_at`.

This adds a scheduled-only “Automatic release” row with a readable date and the exact UTC timestamp. It also verifies that the timestamp survives State adaptation and problem-payload generation. The existing server-rendered problem statement is unchanged.

Validation:
- `python3 -m unittest discover -s tests`
- `node --check static/lifecycle-preview.js`
- `git diff --check`