### PR TITLE
fix: keep issue intake primary before server launch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,6 +304,8 @@ jobs:
             _site/submit/index.html
           grep -F 'release with the same license confirmation' \
             _site/submit/index.html
+          grep -F 'That change is irreversible: a' \
+            _site/submit/index.html
           grep -F 'scheduled choice cannot be changed back to private' \
             _site/submit/index.html
           grep -F 'that transition is irreversible' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -299,7 +299,10 @@ jobs:
             echo "::error::The prelaunch submit page presents future release controls as current."
             exit 1
           fi
-          grep -F 'authorize scheduled release with the same license confirmation' \
+          # Verso preserves the source line break between these clauses.
+          grep -F 'authorize scheduled' \
+            _site/submit/index.html
+          grep -F 'release with the same license confirmation' \
             _site/submit/index.html
           grep -F 'a scheduled choice cannot be changed back to private' \
             _site/submit/index.html

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -288,10 +288,17 @@ jobs:
           grep -F 'two UTC calendar months after acceptance' _site/submit/index.html
           grep -F 'automatically publishes' _site/submit/index.html
           grep -F 'Apache License 2.0' _site/submit/index.html
-          grep -F 'At submission time, scheduled release is the default' \
+          grep -F 'For authenticated submissions after launch' \
             _site/submit/index.html
-          grep -F 'If you initially choose private, you may later' \
+          grep -F 'initial choice is private' \
             _site/submit/index.html
+          if grep -F 'At submission time, scheduled release is the default' \
+              _site/submit/index.html || \
+             grep -F 'If you initially choose private, you may later' \
+              _site/submit/index.html; then
+            echo "::error::The prelaunch submit page presents future release controls as current."
+            exit 1
+          fi
           grep -F 'authorize scheduled release with the same license confirmation' \
             _site/submit/index.html
           grep -F 'a scheduled choice cannot be changed back to private' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -302,23 +302,27 @@ jobs:
             echo "::error::The submit page still offers publication revocation."
             exit 1
           fi
-          grep -F 'legacy GitHub issue form' _site/submit/index.html
-          grep -F 'During the 28-day launch overlap' \
+          grep -F 'Production server intake is not enabled yet' \
             _site/submit/index.html
-          grep -F 'remains available as a fallback for existing users' \
+          grep -F 'current GitHub issue form' _site/submit/index.html
+          grep -F 'Until production server launch' _site/submit/index.html
+          grep -F 'At launch, the authenticated submission application will be hosted' \
             _site/submit/index.html
-          grep -F 'New submissions should' _site/submit/index.html
-          grep -F 'use the authenticated application above' \
+          grep -F 'The launch overlap will begin only after server intake launches' \
             _site/submit/index.html
-          grep -F 'Continue to secure submission service' \
+          grep -F 'at least four weeks' _site/submit/index.html
+          grep -F 'Submit using the current GitHub issue form' \
             _site/submit/index.html
-          if grep -Fi 'prelaunch' _site/submit/index.html; then
-            echo "::error::The launch submit page still describes server intake as prelaunch."
+          grep -F 'continue to the secure submission service' \
+            _site/submit/index.html
+          if grep -F 'During the 28-day launch overlap' \
+              _site/submit/index.html; then
+            echo "::error::The prelaunch submit page claims the overlap has already begun."
             exit 1
           fi
-          if grep -F 'Production server intake is not enabled' \
+          if grep -F 'New submissions should use the authenticated application' \
               _site/submit/index.html; then
-            echo "::error::The launch submit page still describes server intake as disabled."
+            echo "::error::The prelaunch submit page treats disabled server intake as primary."
             exit 1
           fi
           grep -F '<a href="https://lean-lang.org/eval/">return to the leaderboard</a>' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,7 +304,7 @@ jobs:
             _site/submit/index.html
           grep -F 'release with the same license confirmation' \
             _site/submit/index.html
-          grep -F 'a scheduled choice cannot be changed back to private' \
+          grep -F 'scheduled choice cannot be changed back to private' \
             _site/submit/index.html
           grep -F 'that transition is irreversible' \
             _site/submit/index.html

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -276,6 +276,9 @@ def submitLeadBody : VersoDoc Page :=
   [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/).
   This separate origin is intentional: GitHub OAuth callbacks and the
   application session are scoped to the Worker that handles private intake.
+  The launch overlap will begin only after server intake launches, will last
+  at least four weeks, and will keep the current GitHub issue form available
+  as a fallback.
   After submitting, you can
   [return to the leaderboard](https://lean-lang.org/eval/).
   :::

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -269,43 +269,45 @@ def submitTitle : String := "Submit"
 def submitLeadBody : VersoDoc Page :=
   verso (Page) "submitLead"
   :::
-  The authenticated submission application is hosted at
+  Production server intake is not enabled yet. Until launch, submit through the
+  [current GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml).
+
+  At launch, the authenticated submission application will be hosted at
   [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/).
   This separate origin is intentional: GitHub OAuth callbacks and the
   application session are scoped to the Worker that handles private intake.
   After submitting, you can
   [return to the leaderboard](https://lean-lang.org/eval/).
-
-  During the 28-day launch overlap, the
-  [legacy GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  remains available as a fallback for existing users. New submissions should
-  use the authenticated application above.
   :::
 
 def submitStep1Title  : String :=
-  "1. Prepare a source LeanEval can fetch"
+  "1. Submit through the current issue-intake path"
 def submitStep1HtmlId : String := "step-1"
 
 def submitStep1Body : VersoDoc Page :=
   verso (Page) "submitStep1"
   :::
-  Submissions through this service require a private GitHub repository in
-  `owner/repository` form and the exact 40-character source commit to evaluate.
-  Before submitting,
-  [install the Lean Eval Source Reader GitHub App](https://github.com/apps/lean-eval-source-reader)
-  on that repository so that LeanEval can clone it.
+  Until production server launch, use the
+  [current GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+  and follow the instructions there. It is the working submission path while
+  server intake remains disabled.
   :::
 
-def submitStep2Title  : String := "2. Submit through the authenticated application"
+def submitStep2Title  : String := "2. Prepare for authenticated intake at launch"
 def submitStep2HtmlId : String := "step-2"
 
 def submitStep2Body : VersoDoc Page :=
   verso (Page) "submitStep2"
   :::
-  [Continue to the secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/)
-  and sign in with GitHub. Choose the source and identify the model or system
-  that produced the proof. The application walks the submitted source and
-  tries every directory containing a
+  At launch, submissions through the authenticated service will
+  require a private GitHub repository in `owner/repository` form and the exact
+  40-character source commit to evaluate. Before using it,
+  [install the Lean Eval Source Reader GitHub App](https://github.com/apps/lean-eval-source-reader)
+  on that repository so that LeanEval can clone it. You will then
+  [continue to the secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/),
+  sign in with GitHub, choose the source, and identify the model or system that
+  produced the proof. The application will walk the submitted source and
+  try every directory containing a
   `lakefile.toml` whose `name` field matches a benchmark problem id, and
   which has a `Submission.lean` next to it. For example:
 
@@ -353,9 +355,9 @@ def submitWhatPublicHtmlId : String := "what-becomes-public"
 def submitWhatPublicBody : VersoDoc Page :=
   verso (Page) "submitWhatPublic"
   :::
-  The following release policy applies to submissions made through the
-  authenticated application. Submissions through the fallback issue intake
-  retain their existing policy during the 28-day launch overlap.
+  The following release policy will apply to submissions made through the
+  authenticated application after launch. Submissions through the current
+  issue-intake path retain their existing policy.
 
   Submission metadata and evaluation results may become public when the result
   is recorded. Private source remains in the encrypted archive during the
@@ -382,16 +384,16 @@ paragraph splices a `<code>` and an `<a>` mid-sentence, so its prose is
 broken into chunks rather than authored as a single string. -/
 
 def submitCtaUrl    : String :=
-  "https://lean-eval-submission-server.lean-eval.workers.dev/"
+  "https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml"
 def submitCtaLabel  : String :=
-  "Continue to secure submission service"
+  "Submit using the current GitHub issue form"
 def submitCtaArrow  : String := " →"
 
 def submitTldrPart1 : String :=
-  "Sign in with GitHub, choose the exact source snapshot, and confirm the "
+  "Until production server launch, use the GitHub issue form to submit each matching "
 def submitTldrCode1 : String := "Submission.lean"
 def submitTldrPart2 : String :=
-  " archive and release terms. LeanEval verifies each matching proof with "
+  ". LeanEval verifies each proof with "
 def submitTldrComparatorLabel : String := "comparator"
 def submitTldrComparatorUrl   : String :=
   "https://github.com/leanprover/comparator"

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -335,21 +335,23 @@ def submitStep2Body : VersoDoc Page :=
   logs.
   :::
 
-def submitStep3Title  : String := "3. Confirm the release terms"
+def submitStep3Title  : String := "3. Review authenticated-intake release terms"
 def submitStep3HtmlId : String := "step-3"
 
 def submitStep3Body : VersoDoc Page :=
   verso (Page) "submitStep3"
   :::
-  The submission action includes this acknowledgement:
+  After server launch, the authenticated submission action will include this
+  acknowledgement:
 
   > By submitting, I confirm that I have authority to provide this source. I authorize Lean Eval to store and run it privately for evaluation and publish evaluation metadata and results. I will not submit secrets or material I am not authorized to disclose. If I choose scheduled release, I also confirm that I have authority to license the accepted source under the Apache License 2.0 and authorize Lean Eval to publish it two UTC calendar months after acceptance.
 
-  At submission time, scheduled release is the default. You may instead choose
-  to keep accepted source private; the public result remains visible with its
-  solution marked as withheld. If you initially choose private, you may later
-  authorize scheduled release with the same license confirmation. That change
-  is irreversible: a scheduled choice cannot be changed back to private.
+  For authenticated submissions after launch, scheduled release will be the
+  default. A submitter may instead choose to keep accepted source private; the
+  public result remains visible with its solution marked as withheld. If the
+  initial choice is private, the submitter may later authorize scheduled
+  release with the same license confirmation. That change is irreversible: a
+  scheduled choice cannot be changed back to private.
   :::
 
 def submitWhatPublicTitle  : String := "What becomes public, and when"

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -78,7 +78,12 @@ class PreviewStructureTests(unittest.TestCase):
         )
         self.assertIn(worker, copy)
         self.assertIn(issue_form, copy)
-        self.assertNotIn("launch overlap", copy.lower())
+        self.assertIn(
+            "The launch overlap will begin only after server intake launches",
+            copy,
+        )
+        self.assertIn("will last\n  at least four weeks", copy)
+        self.assertNotIn("During the 28-day launch overlap", copy)
         self.assertIn(
             "Production server intake is not enabled yet",
             copy,

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -218,6 +218,10 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("grep -F 'authorize scheduled'", workflow)
         self.assertIn("grep -F 'release with the same license confirmation'", workflow)
         self.assertIn(
+            "grep -F 'scheduled choice cannot be changed back to private'",
+            workflow,
+        )
+        self.assertIn(
             "The prelaunch submit page presents future release controls as current",
             workflow,
         )

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -213,6 +213,12 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("--state-projection", workflow)
         self.assertIn("--schema-version 6", workflow)
         self.assertIn(".schema_version == 6", workflow)
+        self.assertIn("For authenticated submissions after launch", workflow)
+        self.assertIn("initial choice is private", workflow)
+        self.assertIn(
+            "The prelaunch submit page presents future release controls as current",
+            workflow,
+        )
         self.assertIn("Production server intake is not enabled yet", workflow)
         self.assertIn("Submit using the current GitHub issue form", workflow)
         self.assertIn(

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -69,7 +69,7 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("recent-solutions.xml", client)
         self.assertIn("No open problems are published in this group yet.", client)
 
-    def test_submit_page_makes_server_primary_during_issue_intake_overlap(self) -> None:
+    def test_submit_page_keeps_issue_intake_primary_before_server_launch(self) -> None:
         copy = (REPO_ROOT / "LeaderboardSite/Copy.lean").read_text()
         worker = "https://lean-eval-submission-server.lean-eval.workers.dev/"
         issue_form = (
@@ -78,22 +78,30 @@ class PreviewStructureTests(unittest.TestCase):
         )
         self.assertIn(worker, copy)
         self.assertIn(issue_form, copy)
-        self.assertIn("28-day launch overlap", copy)
-        self.assertIn("remains available as a fallback", copy)
+        self.assertNotIn("launch overlap", copy.lower())
         self.assertIn(
-            "New submissions should\n  use the authenticated application",
+            "Production server intake is not enabled yet",
             copy,
         )
         self.assertIn(
-            "Continue to secure submission service",
+            "Until launch, submit through the",
+            copy,
+        )
+        self.assertIn(
+            "At launch, the authenticated submission application will be hosted",
+            copy,
+        )
+        self.assertIn("Submit using the current GitHub issue form", copy)
+        self.assertIn(
+            'def submitCtaUrl    : String :=\n  "' + issue_form + '"',
             copy,
         )
         self.assertNotIn(
-            "Production server intake is not enabled",
+            'def submitCtaUrl    : String :=\n  "' + worker + '"',
             copy,
         )
-        self.assertNotIn("it is not accepting submissions", copy)
-        self.assertNotIn("prelaunch", copy.lower())
+        submit_copy = copy[copy.index("/-! ## Submit page") :]
+        self.assertNotRegex(submit_copy, r"\b20\d{2}-\d{2}-\d{2}\b")
         self.assertIn("GitHub OAuth callbacks", copy)
         self.assertIn("private encrypted archive", copy)
         self.assertIn("two UTC calendar months after acceptance", copy)
@@ -115,7 +123,7 @@ class PreviewStructureTests(unittest.TestCase):
             "cancel scheduled release",
         ):
             self.assertNotIn(revocation_offer, copy.lower())
-        self.assertIn("legacy GitHub issue form", copy)
+        self.assertIn("current GitHub issue form", copy)
         self.assertIn("return to the leaderboard", copy)
         self.assertIn(
             "[return to the leaderboard](https://lean-lang.org/eval/)",
@@ -125,15 +133,11 @@ class PreviewStructureTests(unittest.TestCase):
             "https://github.com/apps/lean-eval-source-reader",
             copy,
         )
-        self.assertIn("exact 40-character source commit", copy)
+        self.assertIn("40-character source commit", copy)
         self.assertIn("require a private GitHub repository", copy)
         self.assertNotIn("Public repositories need no extra setup", copy)
         self.assertNotIn("https://github.com/apps/lean-eval-bot", copy)
         self.assertNotIn("Secret (unlisted) gists", copy)
-        self.assertNotIn(
-            'def submitCtaUrl    : String :=\n  "https://github.com/',
-            copy,
-        )
 
     def test_client_renders_current_replay_measurement_fields(self) -> None:
         client = (REPO_ROOT / "static/lifecycle-preview.js").read_text()

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -106,19 +106,30 @@ class PreviewStructureTests(unittest.TestCase):
             copy,
         )
         submit_copy = copy[copy.index("/-! ## Submit page") :]
+        normalized_copy = copy.replace("\n  ", " ")
         self.assertNotRegex(submit_copy, r"\b20\d{2}-\d{2}-\d{2}\b")
         self.assertIn("GitHub OAuth callbacks", copy)
         self.assertIn("private encrypted archive", copy)
         self.assertIn("two UTC calendar months after acceptance", copy)
         self.assertIn("automatically publishes", copy)
         self.assertIn("Apache License 2.0", copy)
-        self.assertIn("At submission time, scheduled release is the default", copy)
+        self.assertIn("3. Review authenticated-intake release terms", copy)
+        self.assertIn(
+            "After server launch, the authenticated submission action will include",
+            normalized_copy,
+        )
+        self.assertIn(
+            "For authenticated submissions after launch, scheduled release will be the",
+            normalized_copy,
+        )
+        self.assertNotIn("The submission action includes", submit_copy)
+        self.assertNotIn("At submission time", submit_copy)
         self.assertIn("keep accepted source private", copy)
-        self.assertIn("If you initially choose private, you may later", copy)
-        self.assertIn("authorize scheduled release", copy)
+        self.assertIn("If the\n  initial choice is private", copy)
+        self.assertIn("authorize scheduled release", normalized_copy)
         self.assertIn(
             "a scheduled choice cannot be changed back to private",
-            copy,
+            normalized_copy,
         )
         self.assertIn("that transition is irreversible", copy)
         for revocation_offer in (

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -215,6 +215,8 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn(".schema_version == 6", workflow)
         self.assertIn("For authenticated submissions after launch", workflow)
         self.assertIn("initial choice is private", workflow)
+        self.assertIn("grep -F 'authorize scheduled'", workflow)
+        self.assertIn("grep -F 'release with the same license confirmation'", workflow)
         self.assertIn(
             "The prelaunch submit page presents future release controls as current",
             workflow,

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -217,6 +217,7 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("initial choice is private", workflow)
         self.assertIn("grep -F 'authorize scheduled'", workflow)
         self.assertIn("grep -F 'release with the same license confirmation'", workflow)
+        self.assertIn("grep -F 'That change is irreversible: a'", workflow)
         self.assertIn(
             "grep -F 'scheduled choice cannot be changed back to private'",
             workflow,

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -213,6 +213,12 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("--state-projection", workflow)
         self.assertIn("--schema-version 6", workflow)
         self.assertIn(".schema_version == 6", workflow)
+        self.assertIn("Production server intake is not enabled yet", workflow)
+        self.assertIn("Submit using the current GitHub issue form", workflow)
+        self.assertIn(
+            "The launch overlap will begin only after server intake launches",
+            workflow,
+        )
         self.assertIn(".historical_replay_series | type == \"array\"", workflow)
         self.assertIn(".historical_replay_unavailability | type == \"array\"", workflow)
         self.assertIn("_site/site-data/public-state.json", workflow)


### PR DESCRIPTION
Production server intake is still disabled, but the live submit page currently directs new users to it and describes the overlap as already active.

This two-file copy-only correction restores the functioning issue form as the current CTA, scopes the Worker/OAuth/archive/release contract to post-launch authenticated intake, and states that the at-least-four-week overlap starts only after server launch.

Validation: 60 Python tests, `lake build LeaderboardSite.Copy`, `lake build LeaderboardSite.Pages.Submit`, and `git diff --check`. Independent review: GO on exact head `ad0f99aad6b09d659731facf459e93700d2ed83b`.