### PR TITLE
Show initially withheld releases accurately

### DIFF
--- a/scripts/lifecycle_site_data.py
+++ b/scripts/lifecycle_site_data.py
@@ -755,7 +755,10 @@ def adapt_state_projection(
                 "reason": release.get("reason_code"),
             }
             if release is not None
-            else {"status": "unavailable", "reason": "not-scheduled", "url": None}
+            # Modern State records a scheduled choice atomically with its
+            # release task. A recorded Result with no task is therefore the
+            # submitter's initial withheld choice, not missing release data.
+            else {"status": "withheld", "reason": None, "url": None}
         )
         solutions.append(
             Solution(

--- a/tests/test_lifecycle_site_data.py
+++ b/tests/test_lifecycle_site_data.py
@@ -360,6 +360,12 @@ class LifecycleProjectionTests(unittest.TestCase):
                 "url": None,
             },
         )
+        withheld = copy.deepcopy(raw)
+        withheld["results"][0]["release"] = None
+        self.assertEqual(
+            adapt_state_projection(withheld, aliases)[0].release,
+            {"status": "withheld", "reason": None, "url": None},
+        )
         nullable_checker = copy.deepcopy(raw)
         nullable_checker["results"][0]["replay"]["checker"] = None
         self.assertIsNone(


### PR DESCRIPTION
Modern State records a scheduled publication choice atomically with its release task. For an accepted modern submission, `release: null` therefore means the submitter initially withheld publication; it is not missing release data. Render that state as **Release withheld**.

The legacy base-Results fallback keeps its existing unavailable semantics.

This PR is temporarily stacked on #89 so both site builds can run in parallel. Merge #89 first, then recheck that this PR reduces to the two-file withheld-state adapter before merging.

Validation: 60 unit tests pass after a clean rebase onto exact #89 head `6c0ed515206c282ca6cf3a26e88ae89c58e537ce`; diff check is clean. Independent review returned GO for the unchanged two-file semantic delta.