### PR TITLE
docs: direct submissions to issue intake during pause

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -275,16 +275,15 @@ jobs:
             echo "::error::The compatibility route leaked into canonical group navigation."
             exit 1
           fi
-          grep -F 'https://lean-eval-submission-server.lean-eval.workers.dev/' \
+          grep -F 'https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml' \
             _site/submit/index.html
-          grep -F 'https://github.com/apps/lean-eval-source-reader' \
+          grep -F 'https://github.com/apps/lean-eval-bot' \
             _site/submit/index.html
-          if grep -F 'https://github.com/apps/lean-eval-bot' \
+          if grep -F 'https://github.com/apps/lean-eval-source-reader' \
               _site/submit/index.html; then
-            echo "::error::The server intake page points at the legacy issue-workflow App."
+            echo "::error::The paused page still asks for the inactive server App."
             exit 1
           fi
-          grep -F 'GitHub OAuth callbacks' _site/submit/index.html
           grep -F 'two UTC calendar months after acceptance' _site/submit/index.html
           grep -F 'automatically publishes' _site/submit/index.html
           grep -F 'Apache License 2.0' _site/submit/index.html
@@ -309,27 +308,27 @@ jobs:
             echo "::error::The submit page still offers publication revocation."
             exit 1
           fi
-          grep -F 'Production server intake is open' \
+          grep -F 'Production server intake is temporarily paused' \
             _site/submit/index.html
           grep -F '2026-09-02T06:57:10Z' _site/submit/index.html
           grep -F '2026-09-30T06:57:10Z' _site/submit/index.html
-          grep -F 'remains available as a fallback' \
+          grep -F 'remains available for submissions' \
             _site/submit/index.html
           grep -F 'no earlier than four weeks' _site/submit/index.html
           grep -F 'Any closure will be announced at least two' \
             _site/submit/index.html
           grep -F 'weeks in advance.' \
             _site/submit/index.html
-          grep -F 'Continue to secure submission service' \
+          grep -F 'Submit through the GitHub issue form' \
             _site/submit/index.html
-          if grep -F 'Production server intake is not enabled' \
+          if grep -F 'Production server intake is open' \
               _site/submit/index.html; then
-            echo "::error::The launch submit page still says server intake is disabled."
+            echo "::error::The submit page incorrectly says paused server intake is open."
             exit 1
           fi
-          if grep -F 'Submit using the current GitHub issue form' \
+          if grep -F 'Continue to secure submission service' \
               _site/submit/index.html; then
-            echo "::error::The launch submit page still makes issue intake primary."
+            echo "::error::The paused submit page still makes server intake primary."
             exit 1
           fi
           grep -F '<a href="https://lean-lang.org/eval/">return to the leaderboard</a>' \

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -269,15 +269,13 @@ def submitTitle : String := "Submit"
 def submitLeadBody : VersoDoc Page :=
   verso (Page) "submitLead"
   :::
-  Production server intake is open. Use this page to prepare your source, then
-  continue to the authenticated submission application at
-  [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/).
-  This separate origin is intentional: GitHub OAuth callbacks and the
-  application session are scoped to the Worker that handles private intake.
+  Production server intake is temporarily paused while its source-access
+  admission check is repaired. Do not use the authenticated submission
+  application until this notice is removed.
 
   The launch overlap starts at `2026-09-02T06:57:10Z`. The
   [GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  remains available as a fallback through at least
+  remains available for submissions through at least
   `2026-09-30T06:57:10Z`, no earlier than four weeks after the overlap
   begins, and may stay open longer. Any closure will be announced at least two
   weeks in advance.
@@ -294,21 +292,20 @@ def submitStep1Body : VersoDoc Page :=
   :::
   Authenticated submissions require a private GitHub repository in
   `owner/repository` form and the exact 40-character source commit to evaluate.
-  Before submitting,
-  [install the Lean Eval Source Reader GitHub App](https://github.com/apps/lean-eval-source-reader)
-  on that repository so LeanEval can clone it.
+  During the server pause, private issue-form submissions instead require the
+  [lean-eval-bot GitHub App](https://github.com/apps/lean-eval-bot)
+  on that repository so the existing issue workflow can clone it.
   :::
 
-def submitStep2Title  : String := "2. Submit through the authenticated application"
+def submitStep2Title  : String := "2. Submit through the issue form during the pause"
 def submitStep2HtmlId : String := "step-2"
 
 def submitStep2Body : VersoDoc Page :=
   verso (Page) "submitStep2"
   :::
-  [Continue to the secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/)
-  and sign in with GitHub. Choose the source and identify the model or system
-  that produced the proof. The application walks the submitted source and
-  tries every directory containing a
+  [Continue to the GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
+  and identify the model or system that produced the proof. LeanEval walks the
+  submitted source and tries every directory containing a
   `lakefile.toml` whose `name` field matches a benchmark problem id, and
   which has a `Submission.lean` next to it. For example:
 
@@ -386,16 +383,16 @@ paragraph splices a `<code>` and an `<a>` mid-sentence, so its prose is
 broken into chunks rather than authored as a single string. -/
 
 def submitCtaUrl    : String :=
-  "https://lean-eval-submission-server.lean-eval.workers.dev/"
+  "https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml"
 def submitCtaLabel  : String :=
-  "Continue to secure submission service"
+  "Submit through the GitHub issue form"
 def submitCtaArrow  : String := " →"
 
 def submitTldrPart1 : String :=
-  "Sign in with GitHub and choose the exact source snapshot containing each matching "
+  "Provide a source URL containing each matching "
 def submitTldrCode1 : String := "Submission.lean"
 def submitTldrPart2 : String :=
-  ". Confirm the archive and release terms. LeanEval verifies each proof with "
+  ". Complete the issue form's archive and publication choices. LeanEval verifies each proof with "
 def submitTldrComparatorLabel : String := "comparator"
 def submitTldrComparatorUrl   : String :=
   "https://github.com/leanprover/comparator"

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -69,7 +69,7 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("recent-solutions.xml", client)
         self.assertIn("No open problems are published in this group yet.", client)
 
-    def test_submit_page_makes_server_primary_and_keeps_issue_fallback(self) -> None:
+    def test_submit_page_reports_pause_and_makes_issue_intake_primary(self) -> None:
         copy = (REPO_ROOT / "LeaderboardSite/Copy.lean").read_text()
         worker = "https://lean-eval-submission-server.lean-eval.workers.dev/"
         issue_form = (
@@ -78,26 +78,24 @@ class PreviewStructureTests(unittest.TestCase):
         )
         submit_copy = copy[copy.index("/-! ## Submit page") :]
         normalized_copy = copy.replace("\n  ", " ")
-        self.assertIn(worker, copy)
         self.assertIn(issue_form, copy)
-        self.assertIn("Production server intake is open", copy)
+        self.assertIn("Production server intake is temporarily paused", copy)
         self.assertIn("2026-09-02T06:57:10Z", copy)
         self.assertIn("2026-09-30T06:57:10Z", copy)
-        self.assertIn("remains available as a fallback", copy)
+        self.assertIn("remains available for submissions", copy)
         self.assertIn("no earlier than four weeks", copy)
         self.assertIn("Any closure will be announced at least two", copy)
         self.assertIn("weeks in advance.", copy)
-        self.assertIn("Continue to secure submission service", copy)
+        self.assertIn("Submit through the GitHub issue form", copy)
         self.assertIn(
-            'def submitCtaUrl    : String :=\n  "' + worker + '"',
-            copy,
-        )
-        self.assertNotIn(
             'def submitCtaUrl    : String :=\n  "' + issue_form + '"',
             copy,
         )
+        self.assertNotIn(
+            'def submitCtaUrl    : String :=\n  "' + worker + '"',
+            copy,
+        )
         self.assertNotRegex(submit_copy, r"\b20\d{2}-\d{2}-\d{2}\b")
-        self.assertIn("GitHub OAuth callbacks", copy)
         self.assertIn("private encrypted archive", copy)
         self.assertIn("two UTC calendar months after acceptance", copy)
         self.assertIn("automatically publishes", copy)
@@ -132,13 +130,13 @@ class PreviewStructureTests(unittest.TestCase):
             copy,
         )
         self.assertIn(
-            "https://github.com/apps/lean-eval-source-reader",
+            "https://github.com/apps/lean-eval-bot",
             copy,
         )
         self.assertIn("40-character source commit", copy)
         self.assertIn("require a private GitHub repository", copy)
         self.assertNotIn("Public repositories need no extra setup", copy)
-        self.assertNotIn("https://github.com/apps/lean-eval-bot", copy)
+        self.assertNotIn("https://github.com/apps/lean-eval-source-reader", copy)
         self.assertNotIn("Secret (unlisted) gists", copy)
 
     def test_client_renders_current_replay_measurement_fields(self) -> None:
@@ -212,14 +210,14 @@ class PreviewStructureTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("grep -F 'private.'", workflow)
-        self.assertIn("Production server intake is open", workflow)
+        self.assertIn("Production server intake is temporarily paused", workflow)
         self.assertIn("2026-09-02T06:57:10Z", workflow)
         self.assertIn("2026-09-30T06:57:10Z", workflow)
         self.assertIn("no earlier than four weeks", workflow)
         self.assertIn("Any closure will be announced at least two", workflow)
         self.assertIn("weeks in advance.", workflow)
-        self.assertIn("launch submit page still says server intake is disabled", workflow)
-        self.assertIn("launch submit page still makes issue intake primary", workflow)
+        self.assertIn("submit page incorrectly says paused server intake is open", workflow)
+        self.assertIn("paused submit page still makes server intake primary", workflow)
         self.assertIn(".historical_replay_series | type == \"array\"", workflow)
         self.assertIn(".historical_replay_unavailability | type == \"array\"", workflow)
         self.assertIn("_site/site-data/public-state.json", workflow)


### PR DESCRIPTION
## Summary

- state plainly that production server intake is temporarily paused for the source-access admission repair
- make the still-open issue form the primary submission CTA during the pause
- describe the legacy workflow's `lean-eval-bot` installation requirement instead of the inactive server App
- update deployment guards so the temporary public status cannot drift

This is current-state copy only. The final server-launch change will restore the authenticated service CTA and both-App instructions.

## Validation

- 60 Python tests
- `lake env lean LeaderboardSite/Copy.lean`
- diff check
