### PR TITLE
docs: restore dual-App submission entry at launch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -275,15 +275,13 @@ jobs:
             echo "::error::The compatibility route leaked into canonical group navigation."
             exit 1
           fi
-          grep -F 'https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml' \
+          grep -F 'https://lean-eval-submission-server.lean-eval.workers.dev/' \
+            _site/submit/index.html
+          grep -F 'https://github.com/apps/lean-eval-source-reader' \
             _site/submit/index.html
           grep -F 'https://github.com/apps/lean-eval-bot' \
             _site/submit/index.html
-          if grep -F 'https://github.com/apps/lean-eval-source-reader' \
-              _site/submit/index.html; then
-            echo "::error::The paused page still asks for the inactive server App."
-            exit 1
-          fi
+          grep -F 'GitHub OAuth callbacks' _site/submit/index.html
           grep -F 'two UTC calendar months after acceptance' _site/submit/index.html
           grep -F 'automatically publishes' _site/submit/index.html
           grep -F 'Apache License 2.0' _site/submit/index.html
@@ -308,27 +306,27 @@ jobs:
             echo "::error::The submit page still offers publication revocation."
             exit 1
           fi
-          grep -F 'Production server intake is temporarily paused' \
+          grep -F 'Production server intake is open' \
             _site/submit/index.html
           grep -F '2026-09-02T06:57:10Z' _site/submit/index.html
           grep -F '2026-09-30T06:57:10Z' _site/submit/index.html
-          grep -F 'remains available for submissions' \
+          grep -F 'remains available as a fallback' \
             _site/submit/index.html
           grep -F 'no earlier than four weeks' _site/submit/index.html
           grep -F 'Any closure will be announced at least two' \
             _site/submit/index.html
           grep -F 'weeks in advance.' \
             _site/submit/index.html
-          grep -F 'Submit through the GitHub issue form' \
+          grep -F 'Continue to secure submission service' \
             _site/submit/index.html
-          if grep -F 'Production server intake is open' \
+          if grep -F 'Production server intake is temporarily paused' \
               _site/submit/index.html; then
-            echo "::error::The submit page incorrectly says paused server intake is open."
+            echo "::error::The launch submit page still says server intake is paused."
             exit 1
           fi
-          if grep -F 'Continue to secure submission service' \
+          if grep -F 'Submit through the GitHub issue form' \
               _site/submit/index.html; then
-            echo "::error::The paused submit page still makes server intake primary."
+            echo "::error::The launch submit page still makes issue intake primary."
             exit 1
           fi
           grep -F '<a href="https://lean-lang.org/eval/">return to the leaderboard</a>' \

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -269,13 +269,15 @@ def submitTitle : String := "Submit"
 def submitLeadBody : VersoDoc Page :=
   verso (Page) "submitLead"
   :::
-  Production server intake is temporarily paused while its source-access
-  admission check is repaired. Do not use the authenticated submission
-  application until this notice is removed.
+  Production server intake is open. Use this page to prepare your source, then
+  continue to the authenticated submission application at
+  [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/).
+  This separate origin is intentional: GitHub OAuth callbacks and the
+  application session are scoped to the Worker that handles private intake.
 
   The launch overlap starts at `2026-09-02T06:57:10Z`. The
   [GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  remains available for submissions through at least
+  remains available as a fallback through at least
   `2026-09-30T06:57:10Z`, no earlier than four weeks after the overlap
   begins, and may stay open longer. Any closure will be announced at least two
   weeks in advance.
@@ -292,20 +294,24 @@ def submitStep1Body : VersoDoc Page :=
   :::
   Authenticated submissions require a private GitHub repository in
   `owner/repository` form and the exact 40-character source commit to evaluate.
-  During the server pause, private issue-form submissions instead require the
-  [lean-eval-bot GitHub App](https://github.com/apps/lean-eval-bot)
-  on that repository so the existing issue workflow can clone it.
+  Before submitting, install both read-only GitHub Apps on that one repository:
+
+  - [Lean Eval Source Reader](https://github.com/apps/lean-eval-source-reader/installations/new),
+    so authenticated intake can verify the repository and exact commit
+  - [lean-eval-bot](https://github.com/apps/lean-eval-bot/installations/new), so the archive and
+    evaluation workflow can clone that same immutable commit
   :::
 
-def submitStep2Title  : String := "2. Submit through the issue form during the pause"
+def submitStep2Title  : String := "2. Submit through the authenticated application"
 def submitStep2HtmlId : String := "step-2"
 
 def submitStep2Body : VersoDoc Page :=
   verso (Page) "submitStep2"
   :::
-  [Continue to the GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  and identify the model or system that produced the proof. LeanEval walks the
-  submitted source and tries every directory containing a
+  [Continue to the secure submission service](https://lean-eval-submission-server.lean-eval.workers.dev/)
+  and sign in with GitHub. Choose the source and identify the model or system
+  that produced the proof. The application walks the submitted source and
+  tries every directory containing a
   `lakefile.toml` whose `name` field matches a benchmark problem id, and
   which has a `Submission.lean` next to it. For example:
 
@@ -383,16 +389,16 @@ paragraph splices a `<code>` and an `<a>` mid-sentence, so its prose is
 broken into chunks rather than authored as a single string. -/
 
 def submitCtaUrl    : String :=
-  "https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml"
+  "https://lean-eval-submission-server.lean-eval.workers.dev/"
 def submitCtaLabel  : String :=
-  "Submit through the GitHub issue form"
+  "Continue to secure submission service"
 def submitCtaArrow  : String := " →"
 
 def submitTldrPart1 : String :=
-  "Provide a source URL containing each matching "
+  "Sign in with GitHub and choose the exact source snapshot containing each matching "
 def submitTldrCode1 : String := "Submission.lean"
 def submitTldrPart2 : String :=
-  ". Complete the issue form's archive and publication choices. LeanEval verifies each proof with "
+  ". Confirm the archive and release terms. LeanEval verifies each proof with "
 def submitTldrComparatorLabel : String := "comparator"
 def submitTldrComparatorUrl   : String :=
   "https://github.com/leanprover/comparator"

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -69,7 +69,7 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("recent-solutions.xml", client)
         self.assertIn("No open problems are published in this group yet.", client)
 
-    def test_submit_page_reports_pause_and_makes_issue_intake_primary(self) -> None:
+    def test_submit_page_makes_server_primary_and_requires_both_apps(self) -> None:
         copy = (REPO_ROOT / "LeaderboardSite/Copy.lean").read_text()
         worker = "https://lean-eval-submission-server.lean-eval.workers.dev/"
         issue_form = (
@@ -78,21 +78,22 @@ class PreviewStructureTests(unittest.TestCase):
         )
         submit_copy = copy[copy.index("/-! ## Submit page") :]
         normalized_copy = copy.replace("\n  ", " ")
+        self.assertIn(worker, copy)
         self.assertIn(issue_form, copy)
-        self.assertIn("Production server intake is temporarily paused", copy)
+        self.assertIn("Production server intake is open", copy)
         self.assertIn("2026-09-02T06:57:10Z", copy)
         self.assertIn("2026-09-30T06:57:10Z", copy)
-        self.assertIn("remains available for submissions", copy)
+        self.assertIn("remains available as a fallback", copy)
         self.assertIn("no earlier than four weeks", copy)
         self.assertIn("Any closure will be announced at least two", copy)
         self.assertIn("weeks in advance.", copy)
-        self.assertIn("Submit through the GitHub issue form", copy)
+        self.assertIn("Continue to secure submission service", copy)
         self.assertIn(
-            'def submitCtaUrl    : String :=\n  "' + issue_form + '"',
+            'def submitCtaUrl    : String :=\n  "' + worker + '"',
             copy,
         )
         self.assertNotIn(
-            'def submitCtaUrl    : String :=\n  "' + worker + '"',
+            'def submitCtaUrl    : String :=\n  "' + issue_form + '"',
             copy,
         )
         self.assertNotRegex(submit_copy, r"\b20\d{2}-\d{2}-\d{2}\b")
@@ -130,13 +131,13 @@ class PreviewStructureTests(unittest.TestCase):
             copy,
         )
         self.assertIn(
-            "https://github.com/apps/lean-eval-bot",
+            "https://github.com/apps/lean-eval-source-reader",
             copy,
         )
+        self.assertIn("https://github.com/apps/lean-eval-bot", copy)
         self.assertIn("40-character source commit", copy)
         self.assertIn("require a private GitHub repository", copy)
         self.assertNotIn("Public repositories need no extra setup", copy)
-        self.assertNotIn("https://github.com/apps/lean-eval-source-reader", copy)
         self.assertNotIn("Secret (unlisted) gists", copy)
 
     def test_client_renders_current_replay_measurement_fields(self) -> None:
@@ -216,8 +217,8 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("no earlier than four weeks", workflow)
         self.assertIn("Any closure will be announced at least two", workflow)
         self.assertIn("weeks in advance.", workflow)
-        self.assertIn("submit page incorrectly says paused server intake is open", workflow)
-        self.assertIn("paused submit page still makes server intake primary", workflow)
+        self.assertIn("launch submit page still says server intake is paused", workflow)
+        self.assertIn("launch submit page still makes issue intake primary", workflow)
         self.assertIn(".historical_replay_series | type == \"array\"", workflow)
         self.assertIn(".historical_replay_unavailability | type == \"array\"", workflow)
         self.assertIn("_site/site-data/public-state.json", workflow)


### PR DESCRIPTION
## Summary

- restore production server intake as the primary submission-page action after the admission repair
- require direct installation of both read-only source Apps on the submitted repository
- keep issue intake available as the announced overlap fallback
- retain scheduled-publication as the recommended default and document only irreversible private-to-scheduled opt-in
- strengthen Pages verification so paused copy cannot survive launch

Do not merge until leanprover/lean-eval-submissions#1657 has deployed durable production intake and live health has been verified.

## Validation

- 60 Python tests passed
- `lake build VersoBlog` passed
- `lake env lean LeaderboardSite/Copy.lean` passed
- `git diff --check` passed
