### PR TITLE
cleanup: retire issue-intake fallback copy after cutoff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -308,15 +308,6 @@ jobs:
           fi
           grep -F 'Production server intake is open' \
             _site/submit/index.html
-          grep -F '2026-09-02T06:57:10Z' _site/submit/index.html
-          grep -F '2026-09-30T06:57:10Z' _site/submit/index.html
-          grep -F 'remains available as a fallback' \
-            _site/submit/index.html
-          grep -F 'no earlier than four weeks' _site/submit/index.html
-          grep -F 'Any closure will be announced at least two' \
-            _site/submit/index.html
-          grep -F 'weeks in advance.' \
-            _site/submit/index.html
           grep -F 'Continue to secure submission service' \
             _site/submit/index.html
           if grep -F 'Production server intake is temporarily paused' \
@@ -324,11 +315,17 @@ jobs:
             echo "::error::The launch submit page still says server intake is paused."
             exit 1
           fi
-          if grep -F 'Submit through the GitHub issue form' \
-              _site/submit/index.html; then
-            echo "::error::The launch submit page still makes issue intake primary."
-            exit 1
-          fi
+          for retired_copy in \
+              'issues/new?template=submit.yml' \
+              'remains available as a fallback' \
+              'fallback issue-intake' \
+              '2026-09-02T06:57:10Z' \
+              '2026-09-30T06:57:10Z'; do
+            if grep -F "$retired_copy" _site/submit/index.html; then
+              echo "::error::The submit page still contains retired issue-intake copy: $retired_copy"
+              exit 1
+            fi
+          done
           grep -F '<a href="https://lean-lang.org/eval/">return to the leaderboard</a>' \
             _site/submit/index.html
           jq --exit-status '.preview.kind == "results-v2-compatibility"' \

--- a/LeaderboardSite/Copy.lean
+++ b/LeaderboardSite/Copy.lean
@@ -274,13 +274,6 @@ def submitLeadBody : VersoDoc Page :=
   [lean-eval-submission-server.lean-eval.workers.dev](https://lean-eval-submission-server.lean-eval.workers.dev/).
   This separate origin is intentional: GitHub OAuth callbacks and the
   application session are scoped to the Worker that handles private intake.
-
-  The launch overlap starts at `2026-09-02T06:57:10Z`. The
-  [GitHub issue form](https://github.com/leanprover/lean-eval-submissions/issues/new?template=submit.yml)
-  remains available as a fallback through at least
-  `2026-09-30T06:57:10Z`, no earlier than four weeks after the overlap
-  begins, and may stay open longer. Any closure will be announced at least two
-  weeks in advance.
   After submitting, you can
   [return to the leaderboard](https://lean-lang.org/eval/).
   :::
@@ -360,10 +353,6 @@ def submitWhatPublicHtmlId : String := "what-becomes-public"
 def submitWhatPublicBody : VersoDoc Page :=
   verso (Page) "submitWhatPublic"
   :::
-  The following release policy applies to submissions made through the
-  authenticated application. Submissions through the fallback issue-intake
-  path retain their existing policy.
-
   Submission metadata and evaluation results may become public when the result
   is recorded. Private source remains in the encrypted archive during the
   release delay.

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ key of the surrounding bucket.
 When the lean-eval CI records a successful submission:
 
 1. It reads `results/<login>.json`, or starts from an empty `solved` map.
-2. The submission carries one model name (the value of the issue form's
-   `Model` field). The CI uses that as the bucket key.
+2. The submission carries one declared model name. The CI uses that as the
+   bucket key.
 3. For each problem that passed in the submission:
    - If `solved[<model>][<problem_id>]` already exists, **do nothing** (sticky no-op).
    - Otherwise, create the model bucket if needed, and add a new record with

--- a/tests/test_preview_structure.py
+++ b/tests/test_preview_structure.py
@@ -69,7 +69,7 @@ class PreviewStructureTests(unittest.TestCase):
         self.assertIn("recent-solutions.xml", client)
         self.assertIn("No open problems are published in this group yet.", client)
 
-    def test_submit_page_makes_server_primary_and_requires_both_apps(self) -> None:
+    def test_submit_page_uses_only_server_intake_and_requires_both_apps(self) -> None:
         copy = (REPO_ROOT / "LeaderboardSite/Copy.lean").read_text()
         worker = "https://lean-eval-submission-server.lean-eval.workers.dev/"
         issue_form = (
@@ -79,14 +79,14 @@ class PreviewStructureTests(unittest.TestCase):
         submit_copy = copy[copy.index("/-! ## Submit page") :]
         normalized_copy = copy.replace("\n  ", " ")
         self.assertIn(worker, copy)
-        self.assertIn(issue_form, copy)
+        self.assertNotIn(issue_form, copy)
         self.assertIn("Production server intake is open", copy)
-        self.assertIn("2026-09-02T06:57:10Z", copy)
-        self.assertIn("2026-09-30T06:57:10Z", copy)
-        self.assertIn("remains available as a fallback", copy)
-        self.assertIn("no earlier than four weeks", copy)
-        self.assertIn("Any closure will be announced at least two", copy)
-        self.assertIn("weeks in advance.", copy)
+        self.assertNotIn("2026-09-02T06:57:10Z", copy)
+        self.assertNotIn("2026-09-30T06:57:10Z", copy)
+        self.assertNotIn("remains available as a fallback", copy)
+        self.assertNotIn("no earlier than four weeks", copy)
+        self.assertNotIn("Any closure will be announced", copy)
+        self.assertNotIn("fallback issue-intake", copy)
         self.assertIn("Continue to secure submission service", copy)
         self.assertIn(
             'def submitCtaUrl    : String :=\n  "' + worker + '"',
@@ -212,13 +212,13 @@ class PreviewStructureTests(unittest.TestCase):
         )
         self.assertIn("grep -F 'private.'", workflow)
         self.assertIn("Production server intake is temporarily paused", workflow)
+        self.assertIn("issues/new?template=submit.yml", workflow)
+        self.assertIn("remains available as a fallback", workflow)
+        self.assertIn("fallback issue-intake", workflow)
         self.assertIn("2026-09-02T06:57:10Z", workflow)
         self.assertIn("2026-09-30T06:57:10Z", workflow)
-        self.assertIn("no earlier than four weeks", workflow)
-        self.assertIn("Any closure will be announced at least two", workflow)
-        self.assertIn("weeks in advance.", workflow)
         self.assertIn("launch submit page still says server intake is paused", workflow)
-        self.assertIn("launch submit page still makes issue intake primary", workflow)
+        self.assertIn("retired issue-intake copy", workflow)
         self.assertIn(".historical_replay_series | type == \"array\"", workflow)
         self.assertIn(".historical_replay_unavailability | type == \"array\"", workflow)
         self.assertIn("_site/site-data/public-state.json", workflow)


### PR DESCRIPTION
## Summary
- remove the dated GitHub Issue Form overlap and fallback copy from the submit page
- make the authenticated server the sole documented intake route
- add deployment guards that reject any reintroduced issue-form URL, overlap timestamps, or fallback wording
- remove the stale Issue Form description from the results-store documentation

## Stack and merge blockers

**NO-GO to merge or deploy now.** This PR accompanies leanprover/lean-eval-submissions#1654 and leanprover/lean-eval#624 and must remain draft until all of the following are true:

- the announced cutoff at 2026-09-30T06:57:10Z has passed;
- pre-cutoff issue runs have drained and the final inventory/delta has been reconciled and promoted;
- the submissions cutoff/final-delta/issue-retirement chain has merged in its required order;
- this branch is rebased onto then-current protected main and re-reviewed; and
- all required checks pass on that final exact head.

## Validation
- Python unit suite: 60 passed
- hosted generated-site build, public-catalog checks, lifecycle/submit-page assertions, link checks, and Pages artifact upload: passed in Actions run 33834446771
- git diff --check: clean
